### PR TITLE
fix: 🐛 memory access out of range on resize

### DIFF
--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -72,6 +72,7 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
     //     .field("version", &Manifest::version);
 
     class_<DotLottiePlayer>("DotLottiePlayer")
+        .smart_ptr<std::shared_ptr<DotLottiePlayer>>("DotLottiePlayer")
         .constructor(&DotLottiePlayer::init, allow_raw_pointers())
         .function("buffer", &buffer)
         .function("clear", &DotLottiePlayer::clear)
@@ -98,7 +99,7 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
         .function("setFrame", &DotLottiePlayer::set_frame)
         .function("stop", &DotLottiePlayer::stop)
         .function("totalFrames", &DotLottiePlayer::total_frames)
-        .function("subscribe", &DotLottiePlayer::subscribe)
-        .function("unsubscribe", &DotLottiePlayer::unsubscribe)
+        // .function("subscribe", &DotLottiePlayer::subscribe)
+        // .function("unsubscribe", &DotLottiePlayer::unsubscribe)
         .function("isComplete", &DotLottiePlayer::is_complete);
 }

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -1,18 +1,18 @@
 namespace dotlottie_player {
 };
 
-[Trait]
-interface Observer {
-    void on_load();
-    void on_load_error();
-    void on_play();
-    void on_pause();
-    void on_stop();
-    void on_frame(f32 frame_no);
-    void on_render(f32 frame_no);
-    void on_loop(u32 loop_count);
-    void on_complete();
-};
+///[Trait]
+///interface Observer {
+/// void on_load();
+/// void on_load_error();
+/// void on_play();
+/// void on_pause();
+/// void on_stop();
+/// void on_frame(f32 frame_no);
+/// void on_render(f32 frame_no);
+/// void on_loop(u32 loop_count);
+/// void on_complete();
+///};
 
 enum Mode {
     "Forward",
@@ -31,41 +31,41 @@ dictionary Config {
     u32 background_color;
 };
 
-dictionary ManifestTheme {
-    string id;
-    sequence<string> values;
-};
+///dictionary ManifestTheme {
+///    string id;
+///    sequence<string> values;
+///};
 
-dictionary ManifestThemes {
-    sequence<ManifestTheme>? value;
-};
+///dictionary ManifestThemes {
+///    sequence<ManifestTheme>? value;
+///};
 
-dictionary ManifestAnimation {
-    boolean? autoplay;
-    string? defaultTheme;
-    i8? direction;
-    boolean? hover;
-    string id;
-    u32? intermission;
-    boolean? loop;
-    u32? loop_count;
-    string? playMode;
-    u32? speed;
-    string? themeColor;
-};
+///dictionary ManifestAnimation {
+///    boolean? autoplay;
+///    string? defaultTheme;
+///    i8? direction;
+///    boolean? hover;
+///    string id;
+///    u32? intermission;
+///    boolean? loop;
+///    u32? loop_count;
+///    string? playMode;
+///    u32? speed;
+///    string? themeColor;
+///};
 
-dictionary Manifest {
-    string? active_animation_id;
-    sequence<ManifestAnimation> animations;
-    string? author;
-    string? description;
-    string? generator;
-    string? keywords;
-    u32? revision;
-    ManifestThemes? themes;
-    sequence<string>? states;
-    string? version;
-};
+///dictionary Manifest {
+///    string? active_animation_id;
+///    sequence<ManifestAnimation> animations;
+///    string? author;
+///   string? description;
+///    string? generator;
+///    string? keywords;
+///    u32? revision;
+///    ManifestThemes? themes;
+///    sequence<string>? states;
+///    string? version;
+///};
 
 interface DotLottiePlayer {
     constructor(Config config);
@@ -73,7 +73,7 @@ interface DotLottiePlayer {
     boolean load_animation_path([ByRef] string animation_path, u32 width, u32 height);
     boolean load_dotlottie_data([ByRef] bytes file_data, u32 width, u32 height);
     boolean load_animation([ByRef] string animation_id, u32 width, u32 height);
-    Manifest? manifest();
+///    Manifest? manifest();
     string manifest_string();
     u64 buffer_ptr();
     u64 buffer_len();
@@ -95,7 +95,7 @@ interface DotLottiePlayer {
     boolean render();
     boolean resize(u32 width, u32 height);
     void clear();
-    void subscribe(Observer observer);
-    void unsubscribe([ByRef] Observer observer);
+///    void subscribe(Observer observer);
+///    void unsubscribe([ByRef] Observer observer);
     boolean is_complete();
 };

--- a/dotlottie-rs/src/thorvg.rs
+++ b/dotlottie-rs/src/thorvg.rs
@@ -244,7 +244,7 @@ impl Animation {
         }
     }
 
-    pub fn get_picture(&self) -> Option<Picture> {
+    pub fn new_picture(&self) -> Option<Picture> {
         let raw_picture = unsafe { tvg_animation_get_picture(self.raw_animation) };
 
         if raw_picture.is_null() {


### PR DESCRIPTION
Problem:
The `resize` method in `LottieRenderer` creates a new `Picture` every time called causing memory out of access as it returns a new `Picture` instance, not the same `Picture` instance associated with the current `Animation` created on `load`.

Fix:
* Maintain a `thorvg_picture` property in the LottieRenderer, and use the same thorvg_picture created on `load` when resizing.
* Resize the buffer instead of allocating a new one in memory to maintain it's raw pointer address in memory during the lifetime of the LottieRenderer