### PR TITLE
fix: 🐛 ensure canvas is cleared before loading a new animation

### DIFF
--- a/demo-player/src/main.rs
+++ b/demo-player/src/main.rs
@@ -1,5 +1,5 @@
 use dotlottie_player_core::{Config, DotLottiePlayer, Mode, Observer};
-use minifb::{Key, Window, WindowOptions};
+use minifb::{Key, KeyRepeat, Window, WindowOptions};
 use std::fs::{self, File};
 use std::io::Read;
 use std::sync::Arc;
@@ -102,15 +102,16 @@ impl Timer {
 }
 
 fn main() {
-    let mut window = Window::new(
-        "dotLottie rust demo - ESC to exit",
-        WIDTH,
-        HEIGHT,
-        WindowOptions::default(),
-    )
-    .unwrap_or_else(|e| {
-        panic!("{}", e);
-    });
+    let mut window =
+        Window::new(
+            "dotLottie rust demo - ESC to exit",
+            WIDTH,
+            HEIGHT,
+            WindowOptions::default(),
+        )
+        .unwrap_or_else(|e| {
+            panic!("{}", e);
+        });
 
     let base_path = env::var("CARGO_MANIFEST_DIR").unwrap();
 
@@ -201,7 +202,7 @@ fn main() {
             lottie_player.set_config(config)
         }
 
-        if window.is_key_down(Key::Right) {
+        if window.is_key_pressed(Key::Right, KeyRepeat::No) {
             if let Some(manifest) = lottie_player.manifest() {
                 println!("{:?}", i);
 

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -2,15 +2,12 @@ use thiserror::Error;
 
 mod tests;
 
-use crate::thorvg;
+use crate::{Animation, Canvas, Shape, TvgColorspace, TvgEngine, TvgError};
 
 #[derive(Error, Debug)]
 pub enum LottieRendererError {
     #[error("Thorvg error: {0}")]
-    ThorvgError(#[from] thorvg::TvgError),
-
-    #[error("Animation not loaded")]
-    AnimationNotLoaded,
+    ThorvgError(#[from] TvgError),
 
     #[error("Invalid color: {0}")]
     InvalidColor(String),
@@ -20,10 +17,9 @@ pub enum LottieRendererError {
 }
 
 pub struct LottieRenderer {
-    thorvg_animation: Option<thorvg::Animation>,
-    thorvg_canvas: Option<thorvg::Canvas>,
-    thorvg_background_shape: Option<thorvg::Shape>,
-    thorvg_picture: Option<thorvg::Picture>,
+    thorvg_animation: Animation,
+    thorvg_canvas: Canvas,
+    thorvg_background_shape: Shape,
     picture_width: f32,
     picture_height: f32,
     pub width: u32,
@@ -34,11 +30,14 @@ pub struct LottieRenderer {
 
 impl LottieRenderer {
     pub fn new() -> Self {
+        let thorvg_canvas = Canvas::new(TvgEngine::TvgEngineSw, 0);
+        let thorvg_animation = Animation::new();
+        let thorvg_background_shape = Shape::new();
+
         Self {
-            thorvg_animation: None,
-            thorvg_canvas: None,
-            thorvg_background_shape: None,
-            thorvg_picture: None,
+            thorvg_animation,
+            thorvg_canvas,
+            thorvg_background_shape,
             buffer: vec![],
             width: 0,
             height: 0,
@@ -54,56 +53,51 @@ impl LottieRenderer {
         width: u32,
         height: u32,
     ) -> Result<(), LottieRendererError> {
-        let thorvg_animation = thorvg::Animation::new();
-        self.thorvg_picture = thorvg_animation.new_picture();
-        self.thorvg_animation = Some(thorvg_animation);
-        self.thorvg_background_shape = Some(thorvg::Shape::new());
-        self.thorvg_canvas = Some(thorvg::Canvas::new(thorvg::TvgEngine::TvgEngineSw, 0));
+        self.thorvg_canvas.clear(true)?;
 
         self.width = width;
         self.height = height;
+
         self.buffer
             .resize((self.width * self.height * 4) as usize, 0);
-
-        let thorvg_canvas = self
-            .thorvg_canvas
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        let thorvg_background_shape = self
-            .thorvg_background_shape
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_canvas
+        self.thorvg_canvas
             .set_target(
                 &mut self.buffer,
-                width,
-                width,
-                height,
-                thorvg::TvgColorspace::ABGR8888,
+                self.width,
+                self.width,
+                self.height,
+                TvgColorspace::ABGR8888,
             )
             .map_err(LottieRendererError::ThorvgError)?;
 
-        if let Some(picture) = &mut self.thorvg_picture {
-            picture.load(path)?;
+        self.thorvg_animation = Animation::new();
+        self.thorvg_background_shape = Shape::new();
 
-            let (pw, ph) = picture.get_size()?;
-            let (scale, shift_x, shift_y) = calculate_scale_and_shift(pw, ph, width, height);
+        self.thorvg_animation.load(path)?;
 
-            picture.scale(scale)?;
-            picture.translate(shift_x, shift_y)?;
+        let (pw, ph) = self.thorvg_animation.get_size()?;
+        self.picture_width = pw;
+        self.picture_height = ph;
 
-            self.picture_width = pw;
-            self.picture_height = ph;
+        let (scale, shift_x, shift_y) = calculate_scale_and_shift(pw, ph, width, height);
 
-            thorvg_background_shape.append_rect(0.0, 0.0, pw, ph, 0.0, 0.0)?;
-            let (red, green, blue, alpha) = hex_to_rgba(self.background_color);
-            thorvg_background_shape.fill((red, green, blue, alpha))?;
+        self.thorvg_animation.scale(scale)?;
+        self.thorvg_animation.translate(shift_x, shift_y)?;
 
-            thorvg_canvas.push(thorvg_background_shape)?;
-            thorvg_canvas.push(picture)?;
-        }
+        self.thorvg_background_shape.append_rect(
+            0.0,
+            0.0,
+            self.width as f32,
+            self.height as f32,
+            0.0,
+            0.0,
+        )?;
+        let (red, green, blue, alpha) = hex_to_rgba(self.background_color);
+        self.thorvg_background_shape
+            .fill((red, green, blue, alpha))?;
+
+        self.thorvg_canvas.push(&self.thorvg_background_shape)?;
+        self.thorvg_canvas.push(&self.thorvg_animation)?;
 
         Ok(())
     }
@@ -115,89 +109,69 @@ impl LottieRenderer {
         height: u32,
         copy: bool,
     ) -> Result<(), LottieRendererError> {
-        let thorvg_animation = thorvg::Animation::new();
-        self.thorvg_picture = thorvg_animation.new_picture();
-        self.thorvg_animation = Some(thorvg_animation);
-        self.thorvg_background_shape = Some(thorvg::Shape::new());
-        self.thorvg_canvas = Some(thorvg::Canvas::new(thorvg::TvgEngine::TvgEngineSw, 0));
+        self.thorvg_canvas.clear(true)?;
 
         self.width = width;
         self.height = height;
+
         self.buffer
             .resize((self.width * self.height * 4) as usize, 0);
-
-        let thorvg_canvas = self
-            .thorvg_canvas
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        let thorvg_background_shape = self
-            .thorvg_background_shape
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_canvas
+        self.thorvg_canvas
             .set_target(
                 &mut self.buffer,
-                width,
-                width,
-                height,
-                thorvg::TvgColorspace::ABGR8888,
+                self.width,
+                self.width,
+                self.height,
+                TvgColorspace::ABGR8888,
             )
             .map_err(LottieRendererError::ThorvgError)?;
 
-        if let Some(picture) = &mut self.thorvg_picture {
-            picture.load_data(data, "lottie", copy)?;
+        self.thorvg_animation = Animation::new();
+        self.thorvg_background_shape = Shape::new();
 
-            let (pw, ph) = picture.get_size()?;
-            let (scale, shift_x, shift_y) = calculate_scale_and_shift(pw, ph, width, height);
+        self.thorvg_animation.load_data(data, "lottie", copy)?;
 
-            picture.scale(scale)?;
-            picture.translate(shift_x, shift_y)?;
+        let (pw, ph) = self.thorvg_animation.get_size()?;
+        self.picture_width = pw;
+        self.picture_height = ph;
 
-            self.picture_width = pw;
-            self.picture_height = ph;
+        let (scale, shift_x, shift_y) = calculate_scale_and_shift(pw, ph, width, height);
 
-            thorvg_background_shape.append_rect(0.0, 0.0, pw, ph, 0.0, 0.0)?;
-            let (red, green, blue, alpha) = hex_to_rgba(self.background_color);
-            thorvg_background_shape.fill((red, green, blue, alpha))?;
+        self.thorvg_animation.scale(scale)?;
+        self.thorvg_animation.translate(shift_x, shift_y)?;
 
-            thorvg_canvas.push(thorvg_background_shape)?;
-            thorvg_canvas.push(picture)?;
-        }
+        self.thorvg_background_shape.append_rect(
+            0.0,
+            0.0,
+            self.width as f32,
+            self.height as f32,
+            0.0,
+            0.0,
+        )?;
+        let (red, green, blue, alpha) = hex_to_rgba(self.background_color);
+        self.thorvg_background_shape
+            .fill((red, green, blue, alpha))?;
+
+        self.thorvg_canvas.push(&self.thorvg_background_shape)?;
+        self.thorvg_canvas.push(&self.thorvg_animation)?;
 
         Ok(())
     }
 
     pub fn total_frames(&self) -> Result<f32, LottieRendererError> {
-        let thorvg_animation = self
-            .thorvg_animation
-            .as_ref()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_animation
+        self.thorvg_animation
             .get_total_frame()
             .map_err(|e| LottieRendererError::ThorvgError(e))
     }
 
     pub fn duration(&self) -> Result<f32, LottieRendererError> {
-        let thorvg_animation = self
-            .thorvg_animation
-            .as_ref()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_animation
+        self.thorvg_animation
             .get_duration()
             .map_err(|e| LottieRendererError::ThorvgError(e))
     }
 
     pub fn current_frame(&self) -> Result<f32, LottieRendererError> {
-        let thorvg_animation = self
-            .thorvg_animation
-            .as_ref()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_animation
+        self.thorvg_animation
             .get_frame()
             .map_err(|e| LottieRendererError::ThorvgError(e))
     }
@@ -207,25 +181,16 @@ impl LottieRenderer {
     }
 
     pub fn render(&mut self) -> Result<(), LottieRendererError> {
-        let thorvg_canvas = self
-            .thorvg_canvas
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        thorvg_canvas.update()?;
-        thorvg_canvas.draw()?;
-        thorvg_canvas.sync()?;
+        self.thorvg_canvas.update()?;
+        self.thorvg_canvas.draw()?;
+        self.thorvg_canvas.sync()?;
 
         Ok(())
     }
 
     pub fn set_frame(&mut self, no: f32) -> Result<(), LottieRendererError> {
-        let thorvg_animation = self
+        let total_frames = self
             .thorvg_animation
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
-        let total_frames = thorvg_animation
             .get_total_frame()
             .map_err(|e| LottieRendererError::ThorvgError(e))?;
 
@@ -236,17 +201,12 @@ impl LottieRenderer {
             )));
         }
 
-        thorvg_animation
+        self.thorvg_animation
             .set_frame(no)
             .map_err(|e| LottieRendererError::ThorvgError(e))
     }
 
     pub fn resize(&mut self, width: u32, height: u32) -> Result<(), LottieRendererError> {
-        let thorvg_canvas = self
-            .thorvg_canvas
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
         if (width, height) == (self.width, self.height) {
             return Ok(());
         }
@@ -263,23 +223,30 @@ impl LottieRenderer {
         self.buffer
             .resize((self.width * self.height * 4) as usize, 0);
 
-        thorvg_canvas
+        self.thorvg_canvas
             .set_target(
                 &mut self.buffer,
                 self.width,
                 self.width,
                 self.height,
-                thorvg::TvgColorspace::ABGR8888,
+                TvgColorspace::ABGR8888,
             )
             .map_err(LottieRendererError::ThorvgError)?;
 
-        if let Some(picture) = &mut self.thorvg_picture {
-            let (pw, ph) = picture.get_size()?;
-            let (scale, shift_x, shift_y) = calculate_scale_and_shift(pw, ph, width, height);
+        let (scale, shift_x, shift_y) =
+            calculate_scale_and_shift(self.picture_width, self.picture_height, width, height);
 
-            picture.scale(scale)?;
-            picture.translate(shift_x, shift_y)?;
-        }
+        self.thorvg_animation.scale(scale)?;
+        self.thorvg_animation.translate(shift_x, shift_y)?;
+
+        self.thorvg_background_shape.append_rect(
+            0.0,
+            0.0,
+            self.width as f32,
+            self.height as f32,
+            0.0,
+            0.0,
+        )?;
 
         Ok(())
     }
@@ -295,14 +262,9 @@ impl LottieRenderer {
     pub fn set_background_color(&mut self, hex_color: u32) -> Result<(), LottieRendererError> {
         self.background_color = hex_color;
 
-        let thorvg_background_shape = self
-            .thorvg_background_shape
-            .as_mut()
-            .ok_or(LottieRendererError::AnimationNotLoaded)?;
-
         let (red, green, blue, alpha) = hex_to_rgba(self.background_color);
 
-        thorvg_background_shape
+        self.thorvg_background_shape
             .fill((red, green, blue, alpha))
             .map_err(|e| LottieRendererError::ThorvgError(e))
     }

--- a/dotlottie-rs/src/lottie_renderer/tests.rs
+++ b/dotlottie-rs/src/lottie_renderer/tests.rs
@@ -164,16 +164,4 @@ mod tests {
 
         assert!(result.is_ok());
     }
-
-    #[test]
-    fn test_error_on_animation_not_loaded() {
-        let renderer = LottieRenderer::new();
-
-        let result = renderer.total_frames();
-
-        assert!(matches!(
-            result,
-            Err(LottieRendererError::AnimationNotLoaded)
-        ));
-    }
 }

--- a/web-example.html
+++ b/web-example.html
@@ -6,8 +6,10 @@
     <title>WASM test</title>
   </head>
   <body>
-    <div style="max-width: 500px">
-      <canvas style="width: 100%; border: 1px solid black"></canvas>
+    <div style="width: 500px">
+      <canvas
+        style="width: 100%; height: 100%; border: 1px solid black"
+      ></canvas>
       <button id="play">play</button>
       <button id="pause">pause</button>
       <button id="resize">resize</button>
@@ -31,6 +33,7 @@
     <button id="speed-down">speed -</button>
     <button id="loop">loopToggle</button>
     <button id="next">Next</button>
+    <input id="bg-color" type="color" />
     <script type="module">
       import createDotLottiePlayerModule from "./release/wasm/DotLottiePlayer.mjs";
 
@@ -44,6 +47,7 @@
       const speedDownBtn = document.querySelector("#speed-down");
       const loopToggle = document.querySelector("#loop");
       const nextBtn = document.querySelector("#next");
+      const bgColorInput = document.querySelector("#bg-color");
 
       const Module = await createDotLottiePlayerModule({
         locateFile: (path, prefix) => {
@@ -72,7 +76,7 @@
         speed: 1,
         useFrameInterpolation: true,
         segments: createSegments(0, 40),
-        backgroundColor: 0x000000,
+        backgroundColor: 0xff0000ff,
       });
 
       // const data = await fetch(
@@ -97,7 +101,9 @@
         canvas.height
       );
 
-      resize();
+      if (loaded) {
+        resize();
+      }
 
       dotLottiePlayer.setConfig({
         ...dotLottiePlayer.config(),
@@ -246,6 +252,16 @@
             i = 0;
           }
         }
+      });
+
+      bgColorInput.addEventListener("input", (event) => {
+        const color = parseInt(event.target.value.slice(1) + "ff", 16);
+
+        dotLottiePlayer.setConfig({
+          ...dotLottiePlayer.config(),
+          // the expected color is in the format of 0xRRGGBBAA and the alpha component is not provided by the input element
+          backgroundColor: (color << 8) | 0xff,
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
Fixes:
- Ensure `tvg_canvas_clear(true)` is called before loading a new animation to free the pushed paints from memory. This prevents memory leaks when loading multiple animations.
- Modify the `thorvg::Animation` struct to own the raw pointer to the picture, resulting in all related picture methods being moved to the Animation struct. This also simplifies the API.
- The width and height of the background_color shape should match the canvas's width and height, not the picture's width and height.
- Resize the background_color shape on canvas resize.