### PR TITLE
fix: 🐛 segmentation fault when LottieRender is dropped

### DIFF
--- a/demo-player/src/main.rs
+++ b/demo-player/src/main.rs
@@ -219,7 +219,17 @@ fn main() {
         }
 
         if window.is_key_down(Key::L) {
-            lottie_player.load_animation_data(string.as_str(), WIDTH as u32, HEIGHT as u32);
+            lottie_player = DotLottiePlayer::new(Config {
+                mode: Mode::ReverseBounce,
+                loop_animation: true,
+                speed: 1.0,
+                use_frame_interpolation: true,
+                autoplay: true,
+                segments: vec![10.0, 45.0],
+                background_color: 0xffffffff,
+            });
+
+            lottie_player.load_animation_data(&string, WIDTH as u32, HEIGHT as u32);
         }
 
         if window.is_key_down(Key::R) {

--- a/demo-player/src/main.rs
+++ b/demo-player/src/main.rs
@@ -218,7 +218,7 @@ fn main() {
             }
         }
 
-        if window.is_key_down(Key::L) {
+        if window.is_key_pressed(Key::L, KeyRepeat::No) {
             lottie_player = DotLottiePlayer::new(Config {
                 mode: Mode::ReverseBounce,
                 loop_animation: true,
@@ -232,7 +232,7 @@ fn main() {
             lottie_player.load_animation_data(&string, WIDTH as u32, HEIGHT as u32);
         }
 
-        if window.is_key_down(Key::R) {
+        if window.is_key_pressed(Key::R, KeyRepeat::No) {
             lottie_player.load_dotlottie_data(&buffer, WIDTH as u32, HEIGHT as u32);
         }
 

--- a/dotlottie-rs/src/thorvg.rs
+++ b/dotlottie-rs/src/thorvg.rs
@@ -149,7 +149,10 @@ impl Canvas {
 
 impl Drop for Canvas {
     fn drop(&mut self) {
-        unsafe { tvg_canvas_destroy(self.raw_canvas) };
+        unsafe {
+            tvg_canvas_clear(self.raw_canvas, true);
+            tvg_canvas_destroy(self.raw_canvas);
+        };
     }
 }
 
@@ -281,7 +284,7 @@ impl Drawable for Animation {
 impl Drop for Animation {
     fn drop(&mut self) {
         unsafe {
-            tvg_paint_del(self.raw_paint);
+            tvg_animation_del(self.raw_animation);
         };
     }
 }


### PR DESCRIPTION
*issue*
When the `DotLottiePlayer` instance is dropped from memory and a new instance is created, there is a rapid increase in memory usage, resulting in a memory leak. 


*Solution*
Calling `tvg_canvas_clear(true)` should remove the paints instances from memory. Therefore, all that needs to be done is to invoke `tvg_animation_del` when the Animation instance is released.
Also ensure that `tvg_canvas_clear(true)` followed by `tvg_canvas_destroy` is called to drop the canvas properly. This will ensure that the `Animation`, `Canvas`, and any paints pushed to the canvas, such as `Picture` and `Background` shape, are completely freed from memory, and we don't have to drop them individually.