### PR TITLE
feat: 🎸 active_animation_id()

### DIFF
--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -121,4 +121,5 @@ interface DotLottiePlayer {
     boolean load_theme([ByRef] string theme_id);
     boolean load_theme_data([ByRef] string theme_data);
     sequence<Marker> markers();
+    string active_animation_id();
 };

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -124,4 +124,5 @@ interface DotLottiePlayer {
     boolean load_theme([ByRef] string theme_id);
     boolean load_theme_data([ByRef] string theme_data);
     sequence<Marker> markers();
+    string active_animation_id();
 };

--- a/dotlottie-rs/tests/multi_animation.rs
+++ b/dotlottie-rs/tests/multi_animation.rs
@@ -27,13 +27,24 @@ mod tests {
                 animation.id
             );
 
-            /*
-               TODO: assert if the currently loaded animation is the same as the one we loaded
-               require the player to have a method to get the currently loaded animation
+            let active_animation_id = player.active_animation_id();
 
-                let current_animation = player.current_animation();
-                assert_eq!(current_animation.id, animation.id);
-            */
+            assert_eq!(
+                active_animation_id, animation.id,
+                "Active animation id is not equal to the loaded animation id"
+            );
         }
+
+        assert!(
+            !player.load_animation("invalid_id", WIDTH, HEIGHT),
+            "Loaded animation with invalid id"
+        );
+
+        let active_action_id = player.active_animation_id();
+
+        assert!(
+            active_action_id.is_empty(),
+            "Active animation id is not empty"
+        );
     }
 }


### PR DESCRIPTION
Changes: 

- added `active_animation_id()` method to the DotLottiePlayer, to return the loaded animation id as in the manifest.json of .lottie file
- updated multi animations integration tests to ensure the `active_animation_id` is updated correctly
- updated uniffi .udl to expose the `active_animation_id` function to CPP/Kotlin/Swift
- updated emscripten bindings for WASM