### PR TITLE
feat: Add `active_theme_id` function

### DIFF
--- a/demo-player/src/main.rs
+++ b/demo-player/src/main.rs
@@ -143,9 +143,9 @@ fn main() {
 
     let mut markers = File::open("src/markers.json").expect("no file found");
     let metadatamarkers = fs::metadata("src/markers.json").expect("unable to read metadata");
-    let mut markersBuffer = vec![0; metadatamarkers.len() as usize];
-    markers.read(&mut markersBuffer).expect("buffer overflow");
-    let string = String::from_utf8(markersBuffer.clone()).unwrap();
+    let mut markers_buffer = vec![0; metadatamarkers.len() as usize];
+    markers.read(&mut markers_buffer).expect("buffer overflow");
+    let string = String::from_utf8(markers_buffer.clone()).unwrap();
     // lottie_player.load_animation_data(string.as_str(), WIDTH as u32, HEIGHT as u32);
     // println!("{:?}", Some(lottie_player.manifest()));
 

--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -141,5 +141,6 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
         .function("loadTheme", &DotLottiePlayer::load_theme)
         .function("loadThemeData", &DotLottiePlayer::load_theme_data)
         .function("markers", &DotLottiePlayer::markers)
-        .function("activeAnimationId", &DotLottiePlayer::active_animation_id);
+        .function("activeAnimationId", &DotLottiePlayer::active_animation_id)
+        .function("activeThemeId", &DotLottiePlayer::active_theme_id);
 }

--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -123,4 +123,5 @@ interface DotLottiePlayer {
     boolean load_theme_data([ByRef] string theme_data);
     sequence<Marker> markers();
     string active_animation_id();
+    string active_theme_id();
 };

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -126,4 +126,5 @@ interface DotLottiePlayer {
     boolean load_theme_data([ByRef] string theme_data);
     sequence<Marker> markers();
     string active_animation_id();
+    string active_theme_id();
 };

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -611,6 +611,8 @@ impl DotLottieRuntime {
 
     pub fn load_animation_data(&mut self, animation_data: &str, width: u32, height: u32) -> bool {
         self.active_animation_id.clear();
+        self.active_theme_id.clear();
+
         self.dotlottie_manager = DotLottieManager::new(None).unwrap();
 
         self.markers = extract_markers(animation_data);
@@ -624,6 +626,8 @@ impl DotLottieRuntime {
 
     pub fn load_animation_path(&mut self, file_path: &str, width: u32, height: u32) -> bool {
         self.active_animation_id.clear();
+        self.active_theme_id.clear();
+
         match fs::read_to_string(file_path) {
             Ok(data) => self.load_animation_data(&data, width, height),
             Err(_) => false,
@@ -632,6 +636,8 @@ impl DotLottieRuntime {
 
     pub fn load_dotlottie_data(&mut self, file_data: &[u8], width: u32, height: u32) -> bool {
         self.active_animation_id.clear();
+        self.active_theme_id.clear();
+
         if self.dotlottie_manager.init(file_data).is_err() {
             return false;
         }

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -94,6 +94,7 @@ struct DotLottieRuntime {
     direction: Direction,
     markers: MarkersMap,
     active_animation_id: String,
+    active_theme_id: String,
 }
 
 impl DotLottieRuntime {
@@ -116,6 +117,7 @@ impl DotLottieRuntime {
             direction,
             markers: MarkersMap::new(),
             active_animation_id: String::new(),
+            active_theme_id: String::new(),
         }
     }
 
@@ -746,11 +748,14 @@ impl DotLottieRuntime {
     }
 
     pub fn load_theme(&mut self, theme_id: &str) -> bool {
+        self.active_theme_id.clear();
+
         if theme_id.is_empty() {
             return self.renderer.load_theme_data("").is_ok();
         }
 
-        self.manifest()
+        let ok = self
+            .manifest()
             .and_then(|manifest| manifest.themes)
             .map_or(false, |themes| {
                 themes
@@ -774,7 +779,13 @@ impl DotLottieRuntime {
                                 })
                                 .is_some()
                     })
-            })
+            });
+
+        if ok {
+            self.active_theme_id = theme_id.to_string();
+        }
+
+        ok
     }
 
     pub fn load_theme_data(&mut self, theme_data: &str) -> bool {
@@ -783,6 +794,10 @@ impl DotLottieRuntime {
 
     pub fn active_animation_id(&self) -> &str {
         &self.active_animation_id
+    }
+
+    pub fn active_theme_id(&self) -> &str {
+        &self.active_theme_id
     }
 }
 
@@ -1093,6 +1108,10 @@ impl DotLottiePlayer {
             .unwrap()
             .active_animation_id()
             .to_string()
+    }
+
+    pub fn active_theme_id(&self) -> String {
+        self.runtime.read().unwrap().active_theme_id().to_string()
     }
 }
 

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -8,6 +8,7 @@ mod tests {
     use std::{
         fs::{self, File},
         io::Read,
+        path::Path,
     };
 
     use super::*;
@@ -113,6 +114,31 @@ mod tests {
         let string = String::from_utf8(buffer.clone()).unwrap();
 
         assert!(player.load_animation_data(&string, WIDTH, HEIGHT));
+        assert!(player.active_theme_id().is_empty());
+
+        assert!(player.is_playing());
+    }
+
+    #[test]
+    fn test_clear_active_theme_id_after_new_animation_path_is_loaded() {
+        let player = DotLottiePlayer::new(Config {
+            autoplay: true,
+            ..Config::default()
+        });
+
+        let valid_theme_id = "test_theme";
+
+        assert!(
+            !player.load_theme(valid_theme_id),
+            "Expected theme to not load"
+        );
+
+        assert!(player.load_dotlottie_data(include_bytes!("assets/test.lottie"), WIDTH, HEIGHT));
+
+        assert!(player.load_theme(valid_theme_id), "Expected theme to load");
+        assert_eq!(player.active_theme_id(), valid_theme_id);
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
         assert!(player.active_theme_id().is_empty());
 
         assert!(player.is_playing());

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -88,8 +88,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "invalid memory reference"]
-    fn test_clear_active_theme_id_after_new_animation_data_loaded() {
+    fn test_clear_active_theme_id_after_new_animation_data_is_loaded() {
         let player = DotLottiePlayer::new(Config {
             autoplay: true,
             ..Config::default()
@@ -107,8 +106,8 @@ mod tests {
         assert!(player.load_theme(valid_theme_id), "Expected theme to load");
         assert_eq!(player.active_theme_id(), valid_theme_id);
 
-        let mut test_json_file = File::open("assets/test.json").expect("no file found");
-        let metadata = fs::metadata("assets/test.json").expect("unable to read metadata");
+        let mut test_json_file = File::open("tests/assets/test.json").expect("no file found");
+        let metadata = fs::metadata("tests/assets/test.json").expect("unable to read metadata");
         let mut buffer = vec![0; metadata.len() as usize];
         test_json_file.read(&mut buffer).expect("buffer overflow");
         let string = String::from_utf8(buffer.clone()).unwrap();
@@ -120,7 +119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_active_theme_id_after_new_dotlottie_loaded() {
+    fn test_clear_active_theme_id_after_new_dotlottie_is_loaded() {
         let player = DotLottiePlayer::new(Config {
             autoplay: true,
             ..Config::default()

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -107,13 +107,8 @@ mod tests {
         assert!(player.load_theme(valid_theme_id), "Expected theme to load");
         assert_eq!(player.active_theme_id(), valid_theme_id);
 
-        let mut test_json_file = File::open("tests/assets/test.json").expect("no file found");
-        let metadata = fs::metadata("tests/assets/test.json").expect("unable to read metadata");
-        let mut buffer = vec![0; metadata.len() as usize];
-        test_json_file.read(&mut buffer).expect("buffer overflow");
-        let string = String::from_utf8(buffer.clone()).unwrap();
-
-        assert!(player.load_animation_data(&string, WIDTH, HEIGHT));
+        let data = std::str::from_utf8(include_bytes!("assets/test.json")).expect("Invalid data.");
+        assert!(player.load_animation_data(data, WIDTH, HEIGHT));
         assert!(player.active_theme_id().is_empty());
 
         assert!(player.is_playing());

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -24,6 +24,7 @@ mod tests {
         assert!(player.load_dotlottie_data(include_bytes!("assets/test.lottie"), WIDTH, HEIGHT));
 
         assert!(player.load_theme(valid_theme_id), "Expected theme to load");
+        assert_eq!(player.active_theme_id(), valid_theme_id);
 
         assert!(player.is_playing());
     }


### PR DESCRIPTION
## Changes
- [x] added `active_theme_id` method to the `DotLottiePlayer`, to return the loaded theme id
- [x] updated multi animations integration tests to ensure the `active_theme_id` is updated correctly
- [x] updated uniffi .udl to expose the `active_theme_id` function to CPP/Kotlin/Swift
- [x] updated emscripten bindings for WASM

Close #119 

I refer @theashraf implementation in #125.