### PR TITLE
fix(fms): 🐛 invalid embed of image assets

### DIFF
--- a/dotlottie-fms/src/functions.rs
+++ b/dotlottie-fms/src/functions.rs
@@ -72,6 +72,8 @@ pub fn get_animation(bytes: &Vec<u8>, animation_id: &str) -> Result<String, DotL
                 assets[i]["u"] = "".into();
                 assets[i]["p"] =
                     format!("data:image/{};base64,{}", image_ext, image_data_base64).into();
+                // explicitly indicate that the image asset is inlined
+                assets[i]["e"] = 1.into();
             }
         }
     }


### PR DESCRIPTION
**Context:**
ThorVG requires inlined image assets to have an explicit embed property set to 1; otherwise, image will be ignored, as mentioned [here](https://github.com/thorvg/thorvg/issues/2168#issuecomment-2050068811).

This is related to issue https://github.com/LottieFiles/dotlottie-web/issues/170.

**Changes:**

- The get_animation function has been updated to explicitly set the e (embed) property to 1, in accordance with the [Lottie specifications](https://lottiefiles.github.io/lottie-docs/assets/#image)