### PR TITLE
chore: 🤖 upgrade dependencies [emsdk@v3.1.57 - uniffi-bindgen-cpp@v0.6.0+v0.25.0]

### DIFF
--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -11,7 +11,7 @@ NC=$(tput sgr0)
 
 # Environment
 EMSDK_VERSION=${EMSDK_VERSION:-latest}
-UNIFFI_BINDGEN_CPP_VERSION=${UNIFFI_BINDGEN_CPP_VERSION:-"v0.5.0+v0.25.0"}
+UNIFFI_BINDGEN_CPP_VERSION=${UNIFFI_BINDGEN_CPP_VERSION:-"v0.6.0+v0.25.0"}
 
 die() { printf %s "${@+$@$'\n'}" 1>&2 ; exit 1; }
 

--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -85,6 +85,8 @@ echo "Setting up emsdk"
 cd "${SCRIPT_DIR}/deps/modules/emsdk" || die "Could not find Emscripten SDK under ${RED}deps/modules/emsdk${NC}!"
 ./emsdk install "${EMSDK_VERSION}"
 ./emsdk activate "${EMSDK_VERSION}"
+cd "${SCRIPT_DIR}/deps/modules/emsdk/upstream/emscripten" || die "Could not find Emscripten under ${RED}deps/modules/emsdk/upstream/emscripten${NC}!"
+npm install
 
 echo
 echo "Disabling unneeded webp features"

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ WASM_BUILD := $(BUILD)/$(WASM)
 
 EMSDK := emsdk
 EMSDK_DIR := $(PROJECT_DIR)/$(DEPS_MODULES_DIR)/$(EMSDK)
-EMSDK_VERSION := 3.1.51
+EMSDK_VERSION := 3.1.57
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp
@@ -260,7 +260,7 @@ cpp_link_args = [
 	'-sDYNAMIC_EXECUTION=0',
 	'--no-entry',
 	'--strip-all',
-	'--embind-emit-tsd=${WASM_MODULE}.d.ts',
+	'--emit-tsd=${WASM_MODULE}.d.ts',
 	'--minify=0']
 
 [host_machine]

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ EMSDK_VERSION := 3.1.57
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp
-UNIFFI_BINDGEN_CPP_VERSION := v0.5.0+v0.25.0
+UNIFFI_BINDGEN_CPP_VERSION := v0.6.0+v0.25.0
 
 WASM_MODULE := DotLottiePlayer
 

--- a/dotlottie-ffi/Cargo.toml
+++ b/dotlottie-ffi/Cargo.toml
@@ -20,11 +20,11 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-uniffi = { version = "0.25.3", features = ["cli"] }
+uniffi = { version = "0.27.1", features = ["cli"] }
 dotlottie_player = { path = "../dotlottie-rs" }
 dotlottie_fms = { path = "../dotlottie-fms" }
 cfg-if = "1.0"
 
 [build-dependencies]
-uniffi = { version = "0.25.3", features = ["build"] }
+uniffi = { version = "0.27.1", features = ["build"] }
 lazy_static = "1.4"

--- a/dotlottie-ffi/Cargo.toml
+++ b/dotlottie-ffi/Cargo.toml
@@ -20,15 +20,11 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-# uncomment uniffi v0.25.3 when building with uniffi-cpp-bindgen targetting C++/WASM
-# uniffi = { version = "0.25.3", features = ["cli"] }
-uniffi = { version = "0.27.1", features = ["cli"] }
+uniffi = { version = "0.25.3", features = ["cli"] }
 dotlottie_player = { path = "../dotlottie-rs" }
 dotlottie_fms = { path = "../dotlottie-fms" }
 cfg-if = "1.0"
 
 [build-dependencies]
-# uncomment uniffi v0.25.3 when building with uniffi-cpp-bindgen targetting C++/WASM
-# uniffi = { version = "0.25.3", features = ["build"] }
-uniffi = { version = "0.27.1", features = ["build"] }
+uniffi = { version = "0.25.3", features = ["build"] }
 lazy_static = "1.4"

--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -29,18 +29,18 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
     // register_vector<ManifestAnimation>("VectorManifestAnimation");
 
     enum_<Mode>("Mode")
-        .value("Forward", Mode::FORWARD)
-        .value("Reverse", Mode::REVERSE)
-        .value("Bounce", Mode::BOUNCE)
-        .value("ReverseBounce", Mode::REVERSE_BOUNCE);
+        .value("Forward", Mode::kForward)
+        .value("Reverse", Mode::kReverse)
+        .value("Bounce", Mode::kBounce)
+        .value("ReverseBounce", Mode::kReverseBounce);
 
     enum_<Fit>("Fit")
-        .value("Contain", Fit::CONTAIN)
-        .value("Cover", Fit::COVER)
-        .value("Fill", Fit::FILL)
-        .value("FitWidth", Fit::FIT_WIDTH)
-        .value("FitHeight", Fit::FIT_HEIGHT)
-        .value("None", Fit::NONE);
+        .value("Contain", Fit::kContain)
+        .value("Cover", Fit::kCover)
+        .value("Fill", Fit::kFill)
+        .value("FitWidth", Fit::kFitWidth)
+        .value("FitHeight", Fit::kFitHeight)
+        .value("None", Fit::kNone);
 
     value_object<Layout>("Layout")
         .field("fit", &Layout::fit)


### PR DESCRIPTION
Changes: 
- Upgrade EMSDK to version 3.1.57 & uniffi-bindgen-cpp to version 0.6.0+v0.25.0
- Due to the upgrade, replace the deprecated `--embind-emit-tsd` option with `--emit-tsd`
- Due to the upgrade, an additional step has been added to the `mac-setup` to install npm packages in `EMSDK`. This is necessary for proper TypeScript file generation when targeting WebAssembly.