### PR TITLE
fix: 🐛 play() after set_frame() resets the animation

### DIFF
--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -186,29 +186,29 @@ impl DotLottieRuntime {
     }
 
     pub fn play(&mut self) -> bool {
-        if self.is_loaded && !self.is_playing() {
-            if self.is_paused() {
-                self.update_start_time_for_frame(self.current_frame());
-            } else {
-                self.start_time = Instant::now();
-                match self.config.mode {
-                    Mode::Forward | Mode::Bounce => {
-                        self.set_frame(self.start_frame());
-                        self.direction = Direction::Forward;
-                    }
-                    Mode::Reverse | Mode::ReverseBounce => {
-                        self.set_frame(self.end_frame());
-                        self.direction = Direction::Reverse;
-                    }
+        if !self.is_loaded || self.is_playing() {
+            return false;
+        }
+
+        if self.is_complete() && self.is_stopped() {
+            self.start_time = Instant::now();
+            match self.config.mode {
+                Mode::Forward | Mode::Bounce => {
+                    self.set_frame(self.start_frame());
+                    self.direction = Direction::Forward;
+                }
+                Mode::Reverse | Mode::ReverseBounce => {
+                    self.set_frame(self.end_frame());
+                    self.direction = Direction::Reverse;
                 }
             }
-
-            self.playback_state = PlaybackState::Playing;
-
-            true
         } else {
-            false
+            self.update_start_time_for_frame(self.current_frame());
         }
+
+        self.playback_state = PlaybackState::Playing;
+
+        true
     }
 
     pub fn pause(&mut self) -> bool {

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -1,0 +1,161 @@
+mod test_utils;
+
+use crate::test_utils::{HEIGHT, WIDTH};
+use dotlottie_player_core::{Config, DotLottiePlayer};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_play_fail_when_animation_is_not_loaded() {
+        let player = DotLottiePlayer::new(Config::default());
+
+        assert!(
+            !player.play(),
+            "Expected play to fail when animation is not loaded"
+        );
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
+
+        assert!(
+            player.play(),
+            "Expected play to succeed when animation is loaded"
+        );
+    }
+
+    #[test]
+    fn test_play_while_playing() {
+        let player = DotLottiePlayer::new(Config::default());
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
+
+        assert!(player.play());
+
+        assert!(player.is_playing(), "Expected player to be playing");
+
+        assert!(!player.play(), "Expected play to fail when already playing");
+    }
+
+    #[test]
+    fn test_play_after_pause() {
+        let player = DotLottiePlayer::new(Config {
+            use_frame_interpolation: false,
+            ..Config::default()
+        });
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
+
+        assert!(player.play());
+
+        let mid_frame = player.total_frames() / 2.0;
+
+        while player.current_frame() < mid_frame {
+            let next_frame = player.request_frame();
+
+            if player.set_frame(next_frame) {
+                player.render();
+            }
+        }
+
+        assert!(player.pause(), "Expected pause to succeed");
+
+        let paused_at = player.current_frame();
+
+        assert!(player.play(), "Expected play to succeed after pause");
+
+        let mut rendered_frames = vec![];
+
+        while !player.is_complete() {
+            let next_frame = player.request_frame();
+
+            if player.set_frame(next_frame) {
+                player.render();
+
+                rendered_frames.push(player.current_frame());
+            }
+        }
+
+        assert!(
+            (rendered_frames[0] - paused_at).abs() <= 1.0,
+            "Expected first rendered frame to be the same as the frame we paused at"
+        );
+    }
+
+    #[test]
+    fn test_play_after_complete() {
+        let player = DotLottiePlayer::new(Config {
+            use_frame_interpolation: false,
+            ..Config::default()
+        });
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
+
+        assert!(player.play());
+
+        while !player.is_complete() {
+            let next_frame = player.request_frame();
+
+            if player.set_frame(next_frame) {
+                player.render();
+            }
+        }
+
+        assert!(player.is_complete(), "Expected player to be complete");
+
+        assert!(!player.is_playing(), "Expected player to not be playing");
+
+        assert!(
+            player.current_frame() == player.total_frames(),
+            "Expected current frame to be total frames"
+        );
+
+        assert!(player.play(), "Expected play to succeed after complete");
+
+        assert_eq!(
+            player.current_frame(),
+            0.0,
+            "Expected current frame to be 0 after play"
+        );
+    }
+
+    #[test]
+    fn test_play_after_setting_frame() {
+        let player = DotLottiePlayer::new(Config {
+            use_frame_interpolation: false,
+            ..Config::default()
+        });
+
+        assert!(player.load_animation_path("tests/assets/test.json", WIDTH, HEIGHT));
+
+        let mid_frame = player.total_frames() / 2.0;
+
+        assert!(player.set_frame(mid_frame));
+
+        assert_eq!(
+            player.current_frame(),
+            mid_frame,
+            "Expected current frame to be mid frame"
+        );
+
+        assert!(player.play());
+
+        assert_eq!(
+            player.current_frame(),
+            mid_frame,
+            "Expected current frame to be mid frame"
+        );
+
+        let mut rendered_frames = vec![];
+
+        while !player.is_complete() {
+            let next_frame = player.request_frame();
+
+            if player.set_frame(next_frame) && player.render() {
+                rendered_frames.push(player.current_frame());
+            }
+        }
+
+        assert_eq!((rendered_frames[0] - mid_frame).abs() <= 1.0, true);
+    }
+}


### PR DESCRIPTION
**Context:**

This PR addresses an issue reported in dotlottie-web where calling `play` after `set_frame` fails to start the animation from the specified frame. Instead, the animation begins from the initial frame, disregarding the frame set by the user.

The underlying problem is within the `play` method, which incorrectly assumes that if the playback state is `Stopped`, it should always start from the initial frame, ignoring the current frame. This behavior is only appropriate if the animation has completed its cycle and then stopped.

**Changes:**

- Updated the `play` method to initiate from the initial frame only if the animation has completed, but not when it is merely stopped.
- Added several regression and integration tests for the `play` method to ensure:
   - The animation resumes correctly after a pause.
   - The animation resumes correctly after stopping.
   - The animation continues from the current frame.

**Related Issue:** [dotlottie-web issue #174](https://github.com/LottieFiles/dotlottie-web/issues/174)