### PR TITLE
ci: 🎡 use uniffi@0.25.3 for wasm target only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -887,8 +887,21 @@ $(ANDROID): $(ANDROID_BUILD_TARGETS)
 .PHONY: $(APPLE)
 $(APPLE): $(APPLE_BUILD_TARGETS)
 
+.PHONY: pre-make-wasm
+pre-make-wasm:
+	@echo "Copy Cargo.wasm.toml to Cargo.toml..."
+	@cp $(RUNTIME_FFI)/Cargo.wasm.toml $(RUNTIME_FFI)/Cargo.toml
+
+.PHONY: post-make-wasm
+post-make-wasm:
+	@echo "Reset Cargo.toml..."
+	@git -C $(RUNTIME_FFI) checkout -- Cargo.toml
+
 .PHONY: $(WASM)
-$(WASM): $(WASM_BUILD_TARGETS)
+$(WASM):
+	@$(MAKE) pre-make-wasm
+	@$(MAKE) $(WASM_BUILD_TARGETS)
+	@$(MAKE) post-make-wasm
 
 .PHONY: all
 all: $(APPLE) $(ANDROID) $(WASM)

--- a/dotlottie-ffi/Cargo.wasm.toml
+++ b/dotlottie-ffi/Cargo.wasm.toml
@@ -1,0 +1,30 @@
+[package]
+name = "dotlottie-ffi"
+version = "0.1.16"
+edition = "2021"
+build = "build.rs"
+
+[profile.release]
+lto = true
+opt-level = "s"
+strip = true 
+codegen-units = 1
+panic = "abort" 
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+name = "dotlottie_player"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"
+
+[dependencies]
+uniffi = { version = "0.25.3", features = ["cli"] }
+dotlottie_player = { path = "../dotlottie-rs" }
+dotlottie_fms = { path = "../dotlottie-fms" }
+cfg-if = "1.0"
+
+[build-dependencies]
+uniffi = { version = "0.25.3", features = ["build"] }
+lazy_static = "1.4"


### PR DESCRIPTION
**Context:**
- WASM bindings are generated from the C++ bindings created by `uniffi-bindgen-cpp`.
- `uniffi-bindgen-cpp` supports only `uniffi@v0.25.x`. Therefore, we need to dynamically downgrade the uniffi version from `v0.27` to `v0.25` when building for WASM.

**Changes:**
- Created `Cargo.wasm.toml`, which is a modified copy of the default `Cargo.toml`, but with `uniffi@v0.25` instead of `uniffi@v0.27`.
- Updated the Makefile to include two steps: `pre-make-wasm` and `post-make-wasm`. The `pre-make wasm` step copies the contents of `Cargo.wasm.toml` to the default `Cargo.toml`, and the `post-make-wasm` step cleans it up, restoring the original `Cargo.toml`.

> These changes will ensure that the WASM release assets function properly, eliminating the need to build WASM locally for release