### PR TITLE
Feat/state machine–observer

### DIFF
--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -106,8 +106,14 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
     //     .function("onComplete", &Observer::on_complete)
     //     .function("onStop", &Observer::on_stop);
 
+    // class_<StateMachineObserver>("StateMachineObserver")
+    //     .smart_ptr<std::shared_ptr<StateMachineObserver>>("StateMachineObserver")
+    //     .function("OnTransition", &StateMachineObserver::on_transition);
+    //     .function("onStateEntered", &StateMachineObserver::on_state_entered);
+    //     .function("onStateExit", &StateMachineObserver::on_state_exit);
+
     class_<DotLottiePlayer>("DotLottiePlayer")
-        .smart_ptr<std::shared_ptr<DotLottiePlayer> >("DotLottiePlayer")
+        .smart_ptr<std::shared_ptr<DotLottiePlayer>>("DotLottiePlayer")
         .constructor(&DotLottiePlayer::init, allow_raw_pointers())
         .function("buffer", &buffer)
         .function("clear", &DotLottiePlayer::clear)

--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -16,6 +16,13 @@ interface Observer {
     void on_complete();
 };
 
+[Trait, WithForeign]
+interface StateMachineObserver {
+    void on_transition(string previous_state, string new_state);
+    void on_state_entered(string entering_state);
+    void on_state_exit(string leaving_state);
+};
+
 enum Mode {
     "Forward",
     "Reverse",
@@ -141,4 +148,6 @@ interface DotLottiePlayer {
     boolean start_state_machine();
     boolean end_state_machine();
     boolean post_event([ByRef] Event event);
+    boolean state_machine_subscribe(StateMachineObserver observer);
+    boolean state_machine_unsubscribe(StateMachineObserver observer);
 };

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -15,6 +15,13 @@ namespace dotlottie_player {
 ///    void on_complete();
 /// };
 
+/// [Trait]
+/// interface StateMachineObserver {
+///    void on_transition(string previous_state, string new_state);
+///    void on_state_entered(string entering_state);
+///    void on_state_exit(string leaving_state);
+/// };
+
 enum Mode {
     "Forward",
     "Reverse",
@@ -121,6 +128,8 @@ interface DotLottiePlayer {
     void clear();
 /// void subscribe(Observer observer);
 /// void unsubscribe([ByRef] Observer observer);
+/// void state_machine_subscribe(StateMachineObserver observer);
+/// void state_machine_unsubscribe([ByRef] StateMachineObserver observer);
     boolean is_complete();
     boolean load_theme([ByRef] string theme_id);
     boolean load_theme_data([ByRef] string theme_data);

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::errors::StateMachineError::ParsingError;
 use crate::state_machine::events::Event;
+use crate::StateMachineObserver;
 use crate::{
     extract_markers,
     layout::Layout,
@@ -1424,6 +1425,31 @@ impl DotLottiePlayer {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn subscribe(&self, observer: Arc<dyn Observer>) {
         self.player.write().unwrap().subscribe(observer);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn state_machine_subscribe(&self, observer: Arc<dyn StateMachineObserver>) -> bool {
+        let mut sm = self.state_machine.write().unwrap();
+
+        if sm.is_none() {
+            return false;
+        }
+        sm.as_mut().unwrap().subscribe(observer);
+
+        true
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn state_machine_unsubscribe(&self, observer: Arc<dyn StateMachineObserver>) -> bool {
+        let mut sm = self.state_machine.write().unwrap();
+
+        if sm.is_none() {
+            return false;
+        }
+
+        sm.as_mut().unwrap().unsubscribe(&observer);
+
+        true
     }
 
     pub fn manifest_string(&self) -> String {

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -1189,11 +1189,11 @@ impl DotLottiePlayer {
                 .write()
                 .unwrap()
                 .replace(state_machine.unwrap());
-            return false;
         } else {
             match state_machine {
                 Err(ParsingError { reason }) => {
                     println!("State Machine Is Not Ok -> {}", reason);
+                    return false;
                 }
                 Ok(_) => {}
             }
@@ -1211,12 +1211,16 @@ impl DotLottiePlayer {
             return false;
         }
 
-        self.state_machine
-            .write()
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .start();
+        let ret = self.state_machine.try_write();
+
+        match ret {
+            Ok(mut state_machine) => {
+                state_machine.as_mut().unwrap().start();
+            }
+            Err(_) => {
+                return false;
+            }
+        }
 
         true
     }

--- a/dotlottie-rs/src/state_machine/mod.rs
+++ b/dotlottie-rs/src/state_machine/mod.rs
@@ -287,6 +287,30 @@ impl StateMachine {
                     }
                 }
 
+                // Since value can either be a string, int or bool, we need to check the type and set the context accordingly
+                for variable in parsed_state_machine.context_variables {
+                    match variable.r#type {
+                        ContextJsonType::Numeric => match variable.value {
+                            StringNumberBool::F32(value) => {
+                                new_state_machine.set_numeric_context(&variable.key, value);
+                            }
+                            _ => {}
+                        },
+                        ContextJsonType::String => match variable.value {
+                            StringNumberBool::String(value) => {
+                                new_state_machine.set_string_context(&variable.key, value.as_str());
+                            }
+                            _ => {}
+                        },
+                        ContextJsonType::Boolean => match variable.value {
+                            StringNumberBool::Bool(value) => {
+                                new_state_machine.set_bool_context(&variable.key, value);
+                            }
+                            _ => {}
+                        },
+                    }
+                }
+
                 let mut initial_state = None;
 
                 // All states and transitions have been created, we can set the state machine's initial state

--- a/dotlottie-rs/src/state_machine/mod.rs
+++ b/dotlottie-rs/src/state_machine/mod.rs
@@ -303,30 +303,6 @@ impl StateMachine {
                     }
                 }
 
-                // Since value can either be a string, int or bool, we need to check the type and set the context accordingly
-                for variable in parsed_state_machine.context_variables {
-                    match variable.r#type {
-                        ContextJsonType::Numeric => match variable.value {
-                            StringNumberBool::F32(value) => {
-                                new_state_machine.set_numeric_context(&variable.key, value);
-                            }
-                            _ => {}
-                        },
-                        ContextJsonType::String => match variable.value {
-                            StringNumberBool::String(value) => {
-                                new_state_machine.set_string_context(&variable.key, value.as_str());
-                            }
-                            _ => {}
-                        },
-                        ContextJsonType::Boolean => match variable.value {
-                            StringNumberBool::Bool(value) => {
-                                new_state_machine.set_bool_context(&variable.key, value);
-                            }
-                            _ => {}
-                        },
-                    }
-                }
-
                 let mut initial_state = None;
 
                 // All states and transitions have been created, we can set the state machine's initial state

--- a/dotlottie-rs/src/state_machine/mod.rs
+++ b/dotlottie-rs/src/state_machine/mod.rs
@@ -17,10 +17,10 @@ use crate::{Config, DotLottiePlayerContainer, Layout, Mode};
 use self::parser::{state_machine_parse, ContextJsonType};
 use self::{errors::StateMachineError, events::Event, states::State, transitions::Transition};
 
-pub trait StateMachineObserver {
-    fn load_animation(&mut self, animation_id: &str);
-    fn set_config(&mut self, config: Config);
-    fn set_frame(&mut self, frame: f32);
+pub trait StateMachineObserver: Send + Sync {
+    fn transition_occured(&self, previous_state: &State, new_state: &State);
+    fn on_state_entered(&self, entering_state: &State);
+    fn on_state_exit(&self, leaving_state: &State);
 }
 
 #[derive(PartialEq)]
@@ -39,6 +39,8 @@ pub struct StateMachine {
     numeric_context: HashMap<String, f32>,
     string_context: HashMap<String, String>,
     bool_context: HashMap<String, bool>,
+
+    observers: RwLock<Vec<Arc<dyn StateMachineObserver>>>,
 }
 
 impl StateMachine {
@@ -51,6 +53,7 @@ impl StateMachine {
             string_context: HashMap::new(),
             bool_context: HashMap::new(),
             status: StateMachineStatus::Stopped,
+            observers: RwLock::new(Vec::new()),
         }
     }
 
@@ -66,6 +69,7 @@ impl StateMachine {
             string_context: HashMap::new(),
             bool_context: HashMap::new(),
             status: StateMachineStatus::Stopped,
+            observers: RwLock::new(Vec::new()),
         };
 
         let sm = state_machine.create_state_machine(state_machine_definition, &player);
@@ -78,6 +82,18 @@ impl StateMachine {
                 return Err(err);
             }
         };
+    }
+
+    pub fn subscribe(&self, observer: Arc<dyn StateMachineObserver>) {
+        let mut observers = self.observers.write().unwrap();
+        observers.push(observer);
+    }
+
+    pub fn unsubscribe(&self, observer: &Arc<dyn StateMachineObserver>) {
+        self.observers
+            .write()
+            .unwrap()
+            .retain(|o| !Arc::ptr_eq(o, observer));
     }
 
     pub fn get_numeric_context(&self, key: &str) -> Option<f32> {
@@ -113,7 +129,7 @@ impl StateMachine {
     ) -> Result<StateMachine, StateMachineError> {
         let parsed_state_machine = state_machine_parse(sm_definition);
 
-        // todo somehow getthe context json without having to parse it again
+        // todo somehow get the context json without having to parse it again
         // self.json_context = Some(
         //     state_machine_parse(sm_definition)
         //         .unwrap()
@@ -328,6 +344,7 @@ impl StateMachine {
                     string_context: new_state_machine.string_context,
                     bool_context: new_state_machine.bool_context,
                     status: StateMachineStatus::Stopped,
+                    observers: RwLock::new(Vec::new()),
                 };
 
                 return Ok(new_state_machine);
@@ -562,7 +579,29 @@ impl StateMachine {
 
             if tmp_state > -1 {
                 let next_state = self.states.get(tmp_state as usize).unwrap();
+
+                // Emit transtion occured event
+                self.observers.read().unwrap().iter().for_each(|observer| {
+                    observer.transition_occured(
+                        &*self.current_state.as_ref().unwrap().read().unwrap(),
+                        &*next_state.read().unwrap(),
+                    )
+                });
+
+                // Emit leaving current state event
+                if self.current_state.is_some() {
+                    self.observers.read().unwrap().iter().for_each(|observer| {
+                        observer
+                            .on_state_exit(&*self.current_state.as_ref().unwrap().read().unwrap());
+                    });
+                }
+
                 self.current_state = Some(next_state.clone());
+
+                // Emit entering a new state
+                self.observers.read().unwrap().iter().for_each(|observer| {
+                    observer.on_state_entered(&*next_state.read().unwrap());
+                });
 
                 self.execute_current_state();
             }

--- a/dotlottie-rs/src/state_machine/parser/mod.rs
+++ b/dotlottie-rs/src/state_machine/parser/mod.rs
@@ -82,6 +82,7 @@ pub struct StateActionJson {
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct StateJson {
+    pub name: String,
     pub r#type: StateType,
     pub animation_id: Option<String>,
     pub r#loop: Option<bool>,

--- a/dotlottie-rs/src/state_machine/states/mod.rs
+++ b/dotlottie-rs/src/state_machine/states/mod.rs
@@ -15,6 +15,7 @@ pub trait StateTrait {
     fn add_transition(&mut self, transition: Transition);
     fn remove_transition(&mut self, index: u32);
     fn get_config(&self) -> Option<&Config>;
+    fn get_name(&self) -> String;
     // fn set_reset_context(&mut self, reset_context: bool);
 
     // fn add_entry_action(&mut self, action: String);
@@ -28,6 +29,7 @@ pub trait StateTrait {
 #[derive(Clone, Debug)]
 pub enum State {
     Playback {
+        name: String,
         config: Config,
         reset_context: String,
         animation_id: String,
@@ -36,6 +38,7 @@ pub enum State {
         transitions: Vec<Arc<RwLock<Transition>>>,
     },
     Sync {
+        name: String,
         frame_context_key: String,
         reset_context: String,
         animation_id: String,
@@ -49,6 +52,7 @@ impl std::fmt::Display for State {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context,
                 animation_id,
@@ -66,6 +70,7 @@ impl std::fmt::Display for State {
                 .finish(),
 
             State::Sync {
+                name: _,
                 frame_context_key,
                 reset_context,
                 animation_id,
@@ -89,6 +94,7 @@ impl State {
     pub fn as_str(&self) -> &str {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context: _,
                 animation_id: _,
@@ -97,6 +103,7 @@ impl State {
                 transitions: _,
             } => "Playback",
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id: _,
@@ -112,6 +119,7 @@ impl StateTrait for State {
     fn execute(&mut self, player: &Rc<RwLock<DotLottiePlayerContainer>>) {
         match self {
             State::Playback {
+                name: _,
                 config,
                 reset_context: _,
                 animation_id,
@@ -120,6 +128,7 @@ impl StateTrait for State {
                 transitions: _,
             } => {
                 let config = config.clone();
+                let autoplay = config.autoplay;
 
                 // Tell player to load new animation
                 if !animation_id.is_empty() {
@@ -133,9 +142,13 @@ impl StateTrait for State {
 
                 // Set the config
                 player.write().unwrap().set_config(config);
-                player.write().unwrap().play();
+
+                if autoplay {
+                    player.write().unwrap().play();
+                }
             }
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id: _,
@@ -151,6 +164,7 @@ impl StateTrait for State {
     fn get_reset_context_key(&self) -> &String {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context,
                 animation_id: _,
@@ -159,6 +173,7 @@ impl StateTrait for State {
                 transitions: _,
             } => reset_context,
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context,
                 animation_id: _,
@@ -172,6 +187,7 @@ impl StateTrait for State {
     fn get_animation_id(&self) -> &String {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context: _,
                 animation_id,
@@ -180,6 +196,7 @@ impl StateTrait for State {
                 transitions: _,
             } => animation_id,
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id,
@@ -193,6 +210,7 @@ impl StateTrait for State {
     fn get_transitions(&self) -> &Vec<Arc<RwLock<Transition>>> {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context: _,
                 animation_id: _,
@@ -201,6 +219,7 @@ impl StateTrait for State {
                 transitions,
             } => transitions,
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id: _,
@@ -214,6 +233,7 @@ impl StateTrait for State {
     fn add_transition(&mut self, transition: Transition) {
         match self {
             State::Playback {
+                name: _,
                 config: _,
                 reset_context: _,
                 animation_id: _,
@@ -224,6 +244,7 @@ impl StateTrait for State {
                 transitions.push(Arc::new(RwLock::new(transition)));
             }
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id: _,
@@ -243,6 +264,7 @@ impl StateTrait for State {
     fn get_config(&self) -> Option<&Config> {
         match self {
             State::Playback {
+                name: _,
                 config,
                 reset_context: _,
                 animation_id: _,
@@ -251,6 +273,7 @@ impl StateTrait for State {
                 transitions: _,
             } => return Some(config),
             State::Sync {
+                name: _,
                 frame_context_key: _,
                 reset_context: _,
                 animation_id: _,
@@ -258,6 +281,29 @@ impl StateTrait for State {
                 height: _,
                 transitions: _,
             } => return None,
+        }
+    }
+
+    fn get_name(&self) -> String {
+        match self {
+            State::Playback {
+                name,
+                config: _,
+                reset_context: _,
+                animation_id: _,
+                width: _,
+                height: _,
+                transitions: _,
+            } => name.to_string(),
+            State::Sync {
+                name,
+                frame_context_key: _,
+                reset_context: _,
+                animation_id: _,
+                width: _,
+                height: _,
+                transitions: _,
+            } => name.to_string(),
         }
     }
 

--- a/dotlottie-rs/tests/assets/pigeon_fsm.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -22,6 +23,7 @@
             "exit_actions": []
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -34,6 +36,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/assets/pigeon_fsm_bool_eq_guard.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm_bool_eq_guard.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -17,6 +18,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -29,6 +31,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/assets/pigeon_fsm_eq_guard.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm_eq_guard.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -17,6 +18,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -29,6 +31,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/assets/pigeon_fsm_gt_gte_guard.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm_gt_gte_guard.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -17,6 +18,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -29,6 +31,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/assets/pigeon_fsm_lt_lte_guard.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm_lt_lte_guard.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -17,6 +18,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -29,6 +31,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/assets/pigeon_fsm_ne_guard.json
+++ b/dotlottie-rs/tests/assets/pigeon_fsm_ne_guard.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -17,6 +18,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -29,6 +31,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -305,13 +305,17 @@ mod tests {
 
         // First test that the event doesn't fire if the guard is not met
         player.tmp_set_state_machine_context("counter_0", 5.0);
-        player.post_event(&Event::String("explosion".to_string()));
+        player.post_event(&Event::String {
+            value: "explosion".to_string(),
+        });
 
         // Should stay the same value we initialized it at
         assert_eq!(*observer.custom_data.read().unwrap(), "No event so far");
 
         player.tmp_set_state_machine_context("counter_0", 18.0);
-        player.post_event(&Event::String("explosion".to_string()));
+        player.post_event(&Event::String {
+            value: "explosion".to_string(),
+        });
 
         // Should go to stage 2
         assert_eq!(
@@ -326,7 +330,9 @@ mod tests {
         assert_eq!(*observer2.custom_data.read().unwrap(), "No event so far");
 
         player.tmp_set_state_machine_string_context("counter_1", "not_the_same");
-        player.post_event(&Event::String("complete".to_string()));
+        player.post_event(&Event::String {
+            value: "complete".to_string(),
+        });
 
         // Should go to stage 3
         assert_eq!(*observer2.custom_data.read().unwrap(), "\"done\"");
@@ -338,7 +344,9 @@ mod tests {
         assert_eq!(*observer3.custom_data.read().unwrap(), "No event so far");
 
         player.tmp_set_state_machine_bool_context("counter_2", false);
-        player.post_event(&Event::String("done".to_string()));
+        player.post_event(&Event::String {
+            value: "done".to_string(),
+        });
 
         // Should go to stage 0 and use previous state so it should be "done"
         assert_eq!(*observer3.custom_data.read().unwrap(), "\"done\"");

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -8,11 +8,14 @@ mod tests {
         sync::{Arc, RwLock},
     };
 
-    use dotlottie_player_core::transitions::{Transition::Transition, TransitionTrait};
-
-    use dotlottie_player_core::{events::Event, states::State, Config, DotLottiePlayer, Mode};
+    use dotlottie_player_core::{
+        states::StateTrait,
+        transitions::{Transition::Transition, TransitionTrait},
+        StateMachineObserver,
+    };
 
     use crate::test_utils::{HEIGHT, WIDTH};
+    use dotlottie_player_core::{events::Event, states::State, Config, DotLottiePlayer, Mode};
 
     #[test]
     pub fn load_multiple_states() {
@@ -174,5 +177,170 @@ mod tests {
         }
 
         assert_eq!(i, 3)
+    }
+
+    #[test]
+    fn state_machine_observer_test() {
+        // We create 3 separate observers to test the different methods
+        // Otherwise if we use the same observer all three events will modify the same data
+        pub struct SMObserver1 {
+            pub custom_data: RwLock<String>,
+        }
+
+        impl StateMachineObserver for SMObserver1 {
+            fn transition_occured(&self, previous_state: &State, new_state: &State) {
+                let transition_event = previous_state
+                    .get_transitions()
+                    .get(0)
+                    .unwrap()
+                    .read()
+                    .unwrap()
+                    .get_event();
+
+                let previous_state_transition_event = &*transition_event.read().unwrap();
+
+                let next_transition_event = new_state
+                    .get_transitions()
+                    .get(0)
+                    .unwrap()
+                    .read()
+                    .unwrap()
+                    .get_event();
+
+                let next_state_transition_event = &*next_transition_event.read().unwrap();
+
+                *self.custom_data.write().unwrap() = format!(
+                    "{:?} -> {:?}",
+                    previous_state_transition_event.as_str(),
+                    next_state_transition_event.as_str()
+                );
+            }
+
+            fn on_state_entered(&self, _entering_state: &State) {}
+
+            fn on_state_exit(&self, _leaving_state: &State) {}
+        }
+
+        pub struct SMObserver2 {
+            pub custom_data: RwLock<String>,
+        }
+
+        impl StateMachineObserver for SMObserver2 {
+            fn transition_occured(&self, previous_state: &State, new_state: &State) {}
+
+            fn on_state_entered(&self, entering_state: &State) {
+                let transition_event = entering_state
+                    .get_transitions()
+                    .get(0)
+                    .unwrap()
+                    .read()
+                    .unwrap()
+                    .get_event();
+
+                let state_transition_event = &*transition_event.read().unwrap();
+
+                *self.custom_data.write().unwrap() =
+                    format!("{:?}", state_transition_event.as_str(),);
+            }
+
+            fn on_state_exit(&self, _leaving_state: &State) {}
+        }
+
+        pub struct SMObserver3 {
+            pub custom_data: RwLock<String>,
+        }
+
+        impl StateMachineObserver for SMObserver3 {
+            fn transition_occured(&self, _previous_state: &State, _new_state: &State) {}
+
+            fn on_state_entered(&self, _entering_state: &State) {}
+
+            fn on_state_exit(&self, leaving_state: &State) {
+                let transition_event = leaving_state
+                    .get_transitions()
+                    .get(0)
+                    .unwrap()
+                    .read()
+                    .unwrap()
+                    .get_event();
+
+                let state_transition_event = &*transition_event.read().unwrap();
+
+                *self.custom_data.write().unwrap() =
+                    format!("{:?}", state_transition_event.as_str(),);
+            }
+        }
+
+        let observer = Arc::new(SMObserver1 {
+            custom_data: RwLock::new("No event so far".to_string()),
+        });
+        let observer2 = Arc::new(SMObserver2 {
+            custom_data: RwLock::new("No event so far".to_string()),
+        });
+        let observer3 = Arc::new(SMObserver3 {
+            custom_data: RwLock::new("No event so far".to_string()),
+        });
+
+        use dotlottie_player_core::{events::Event, Config, DotLottiePlayer};
+
+        let player = DotLottiePlayer::new(Config::default());
+        let file_path = format!(
+            "{}{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/assets/pigeon_fsm_ne_guard.json"
+        );
+
+        let mut sm_definition = File::open(file_path).unwrap();
+        let mut buffer_to_string = String::new();
+
+        sm_definition.read_to_string(&mut buffer_to_string).unwrap();
+
+        player.load_state_machine(&buffer_to_string);
+
+        player.start_state_machine();
+
+        player.state_machine_subscribe(observer.clone());
+
+        assert_eq!(*observer.custom_data.read().unwrap(), "No event so far");
+
+        // First test that the event doesn't fire if the guard is not met
+        player.tmp_set_state_machine_context("counter_0", 5.0);
+        player.post_event(&Event::String("explosion".to_string()));
+
+        // Should stay the same value we initialized it at
+        assert_eq!(*observer.custom_data.read().unwrap(), "No event so far");
+
+        player.tmp_set_state_machine_context("counter_0", 18.0);
+        player.post_event(&Event::String("explosion".to_string()));
+
+        // Should go to stage 2
+        assert_eq!(
+            *observer.custom_data.read().unwrap(),
+            "\"explosion\" -> \"complete\""
+        );
+
+        // Start second observer to test on_state_enter
+        player.state_machine_subscribe(observer2.clone());
+
+        // Should stay the same value we initialized it at
+        assert_eq!(*observer2.custom_data.read().unwrap(), "No event so far");
+
+        player.tmp_set_state_machine_string_context("counter_1", "not_the_same");
+        player.post_event(&Event::String("complete".to_string()));
+
+        // Should go to stage 3
+        assert_eq!(*observer2.custom_data.read().unwrap(), "\"done\"");
+
+        // Start third observer to test on_state_exit
+        player.state_machine_subscribe(observer3.clone());
+
+        // Should stay the same value we initialized it at
+        assert_eq!(*observer3.custom_data.read().unwrap(), "No event so far");
+
+        player.tmp_set_state_machine_bool_context("counter_2", false);
+        player.post_event(&Event::String("done".to_string()));
+
+        // Should go to stage 0 and use previous state so it should be "done"
+        assert_eq!(*observer3.custom_data.read().unwrap(), "\"done\"");
     }
 }

--- a/dotlottie-rs/tests/state_machine_guards.rs
+++ b/dotlottie-rs/tests/state_machine_guards.rs
@@ -173,17 +173,13 @@ mod tests {
 
         // Test != with a numeric value
         player.tmp_set_state_machine_context("counter_0", 5.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Should stay in stage 0 since 5 = 5
         assert_eq!(get_current_transition_event(&player), "explosion");
 
         player.tmp_set_state_machine_context("counter_0", 18.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Should go to stage 2
         assert_eq!(get_current_transition_event(&player), "complete");
@@ -193,35 +189,27 @@ mod tests {
             "counter_1",
             "to_be_the_same".to_string().as_str(),
         );
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should stay in stage 2 since diff_value = diff_value
         assert_eq!(get_current_transition_event(&player), "complete");
 
         player
             .tmp_set_state_machine_string_context("counter_1", "not_the_same".to_string().as_str());
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should go to stage 3
         assert_eq!(get_current_transition_event(&player), "done");
 
         // Test != with a bool value
         player.tmp_set_state_machine_bool_context("counter_2", true);
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        player.post_event(&Event::String("done".to_string()));
 
         // Should stay in stage 3 since diff_value = diff_value
         assert_eq!(get_current_transition_event(&player), "done");
 
         player.tmp_set_state_machine_bool_context("counter_2", false);
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        player.post_event(&Event::String("done".to_string()));
 
         // Should go to stage 0
         assert_eq!(get_current_transition_event(&player), "explosion");
@@ -280,51 +268,39 @@ mod tests {
 
         // Test with a numeric value
         player.tmp_set_state_machine_context("counter_0", 4.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Should stay on stage 0 since 4 != 5
         assert_eq!(get_current_transition_event(&player), "explosion");
 
         player.tmp_set_state_machine_context("counter_0", 5.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Should go to stage 1
         assert_eq!(get_current_transition_event(&player), "complete");
 
         // Test with a string value
         player.tmp_set_state_machine_string_context("counter_1", "diff");
-        player.post_event(&Event::String {
-            value: "compelete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should stay on stage 1 since to_be_the_same != diff
         assert_eq!(get_current_transition_event(&player), "complete");
 
         player.tmp_set_state_machine_string_context("counter_1", "to_be_the_same");
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should go to stage 2
         assert_eq!(get_current_transition_event(&player), "done");
 
         // Test with a bool value
         player.tmp_set_state_machine_bool_context("counter_2", false);
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        player.post_event(&Event::String("done".to_string()));
 
         // Should stay on stage 3 since false != true
         assert_eq!(get_current_transition_event(&player), "done");
 
         player.tmp_set_state_machine_bool_context("counter_2", true);
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        player.post_event(&Event::String("done".to_string()));
 
         // Should go to stage 0
         assert_eq!(get_current_transition_event(&player), "explosion");
@@ -384,9 +360,7 @@ mod tests {
         drop(sm);
 
         player.tmp_set_state_machine_context("counter_0", 5.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Not greater than 5.0, should stay on first stage
         assert_eq!(get_current_transition_event(&player), "explosion");
@@ -394,9 +368,9 @@ mod tests {
         // Greater than, should go to stage 2
         player.tmp_set_state_machine_context("counter_0", 6.0);
 
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        let string_event = Event::String("explosion".to_string());
+
+        player.post_event(&string_event);
 
         // Assert stage 2
         assert_eq!(get_current_transition_event(&player), "complete");
@@ -404,9 +378,9 @@ mod tests {
         // Greater than or equal, since its equal should go to stage 3
         player.tmp_set_state_machine_context("counter_0", 60.0);
 
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        let string_event = Event::String("complete".to_string());
+
+        player.post_event(&string_event);
 
         // Assert stage 3
         assert_eq!(get_current_transition_event(&player), "done");
@@ -414,9 +388,9 @@ mod tests {
         // Greater than or equal, since its not >= should stay on same stage
         player.tmp_set_state_machine_context("counter_0", 64.0);
 
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        let string_event = Event::String("done".to_string());
+
+        player.post_event(&string_event);
 
         // Assert stage 3
         assert_eq!(get_current_transition_event(&player), "done");
@@ -424,9 +398,9 @@ mod tests {
         // Greater than or equal, greater than should go to stage 0
         player.tmp_set_state_machine_context("counter_0", 66.0);
 
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        let string_event = Event::String("done".to_string());
+
+        player.post_event(&string_event);
 
         // Assert stage 0
         assert_eq!(get_current_transition_event(&player), "explosion");
@@ -485,9 +459,7 @@ mod tests {
 
         // Test less than
         player.tmp_set_state_machine_context("counter_0", 5.0);
-        player.post_event(&Event::String {
-            value: "explosion".to_string(),
-        });
+        player.post_event(&Event::String("explosion".to_string()));
 
         // Should stay in first stage since 5 == 5
         assert_eq!(get_current_transition_event(&player), "explosion");
@@ -495,9 +467,7 @@ mod tests {
         // Test less than
         player.tmp_set_state_machine_context("counter_0", 1.0);
 
-        let string_event = Event::String {
-            value: "explosion".to_string(),
-        };
+        let string_event = Event::String("explosion".to_string());
 
         player.post_event(&string_event);
 
@@ -506,27 +476,21 @@ mod tests {
 
         // Start testing less than equal
         player.tmp_set_state_machine_context("counter_0", 11.0);
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should stay in second stage since 11 > 10
         assert_eq!(get_current_transition_event(&player), "complete");
 
         // Test equal
         player.tmp_set_state_machine_context("counter_0", 10.0);
-        player.post_event(&Event::String {
-            value: "complete".to_string(),
-        });
+        player.post_event(&Event::String("complete".to_string()));
 
         // Should go to third stage
         assert_eq!(get_current_transition_event(&player), "done");
 
         // Test less than
         player.tmp_set_state_machine_context("counter_0", 14.0);
-        player.post_event(&Event::String {
-            value: "done".to_string(),
-        });
+        player.post_event(&Event::String("done".to_string()));
 
         // Should go back to first stage
         assert_eq!(get_current_transition_event(&player), "explosion");

--- a/dotlottie-rs/tests/state_machine_guards.rs
+++ b/dotlottie-rs/tests/state_machine_guards.rs
@@ -69,6 +69,7 @@ mod tests {
 
             match unwrapped_state {
                 State::Playback {
+                    name: _,
                     config: _,
                     reset_context: _,
                     animation_id: _,

--- a/dotlottie-rs/tests/state_machine_guards.rs
+++ b/dotlottie-rs/tests/state_machine_guards.rs
@@ -5,12 +5,9 @@ mod tests {
     use std::{fs::File, io::Read};
 
     use dotlottie_player_core::states::StateTrait;
-    use dotlottie_player_core::{
-        parser::TransitionGuardConditionType,
-        transitions::{guard::Guard, TransitionTrait},
-    };
+    use dotlottie_player_core::{parser::TransitionGuardConditionType, transitions::guard::Guard};
 
-    use dotlottie_player_core::DotLottiePlayer;
+    use crate::test_utils::get_current_transition_event;
 
     #[test]
     pub fn guards_loaded_correctly() {
@@ -97,27 +94,6 @@ mod tests {
             }
             i += 1;
         }
-    }
-
-    // Helper function to get the current transition event as a string
-    pub fn get_current_transition_event(player: &DotLottiePlayer) -> String {
-        let players_first_state = player
-            .get_state_machine()
-            .read()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .get_current_state()
-            .unwrap();
-
-        let players_first_transition =
-            &*players_first_state.read().unwrap().get_transitions()[0].clone();
-
-        let complete_event = &*players_first_transition.read().unwrap();
-
-        let complete_event_string = complete_event.get_event().read().unwrap().as_str().clone();
-
-        return complete_event_string.clone();
     }
 
     #[test]

--- a/dotlottie-rs/tests/test_utils.rs
+++ b/dotlottie-rs/tests/test_utils.rs
@@ -1,2 +1,26 @@
+use dotlottie_player_core::states::StateTrait;
+use dotlottie_player_core::transitions::TransitionTrait;
+use dotlottie_player_core::DotLottiePlayer;
 pub const WIDTH: u32 = 100;
 pub const HEIGHT: u32 = 100;
+
+// Helper function to get the current transition event as a string
+pub fn get_current_transition_event(player: &DotLottiePlayer) -> String {
+    let players_first_state = player
+        .get_state_machine()
+        .read()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .get_current_state()
+        .unwrap();
+
+    let players_first_transition =
+        &*players_first_state.read().unwrap().get_transitions()[0].clone();
+
+    let complete_event = &*players_first_transition.read().unwrap();
+
+    let complete_event_string = complete_event.get_event().read().unwrap().as_str().clone();
+
+    return complete_event_string.clone();
+}

--- a/examples/demo-state-machine/src/main.rs
+++ b/examples/demo-state-machine/src/main.rs
@@ -1,5 +1,6 @@
 use dotlottie_player_core::events::Event;
-use dotlottie_player_core::{Config, DotLottiePlayer, Layout, Mode, Observer, PlaybackState};
+use dotlottie_player_core::states::State;
+use dotlottie_player_core::{Config, DotLottiePlayer, Layout, Observer, StateMachineObserver};
 use minifb::{Key, KeyRepeat, Window, WindowOptions};
 use std::fs::{self, File};
 use std::io::Read;
@@ -74,6 +75,25 @@ impl Observer for DummyObserver {
     }
     fn on_complete(&self) {
         // println!("on_complete {} ", self.id);
+    }
+}
+
+struct SMObserver {}
+
+impl StateMachineObserver for SMObserver {
+    fn transition_occured(&self, previous_state: &State, new_state: &State) {
+        println!(
+            "transition_occured: {:?} -> \n {:?}",
+            previous_state, new_state
+        );
+    }
+
+    fn on_state_entered(&self, entering_state: &State) {
+        // println!("entering state: {:?}", entering_state);
+    }
+
+    fn on_state_exit(&self, leaving_state: &State) {
+        // println!("exiting state: {:?}", leaving_state);
     }
 }
 
@@ -155,6 +175,8 @@ fn main() {
     let observer1: Arc<dyn Observer + 'static> = Arc::new(DummyObserver { id: 1 });
     let observer2: Arc<dyn Observer + 'static> = Arc::new(DummyObserver { id: 2 });
 
+    let observer3: Arc<dyn StateMachineObserver + 'static> = Arc::new(SMObserver { id: 3 });
+
     lottie_player.subscribe(observer1.clone());
     lottie_player.subscribe(observer2.clone());
 
@@ -191,6 +213,8 @@ fn main() {
 
     lottie_player.load_state_machine(&contents);
     lottie_player.start_state_machine();
+
+    lottie_player.state_machine_subscribe(observer3.clone());
 
     let locked_player = Arc::new(RwLock::new(lottie_player));
 

--- a/examples/demo-state-machine/src/main.rs
+++ b/examples/demo-state-machine/src/main.rs
@@ -220,6 +220,8 @@ fn main() {
 
             pushed -= 1.0;
 
+            pushed -= 1.0;
+
             let p = &mut *locked_player.write().unwrap();
             p.tmp_set_state_machine_context("counter_0", pushed);
 

--- a/examples/demo-state-machine/src/main.rs
+++ b/examples/demo-state-machine/src/main.rs
@@ -1,5 +1,4 @@
 use dotlottie_player_core::events::Event;
-use dotlottie_player_core::states::State;
 use dotlottie_player_core::{Config, DotLottiePlayer, Layout, Observer, StateMachineObserver};
 use minifb::{Key, KeyRepeat, Window, WindowOptions};
 use std::fs::{self, File};
@@ -81,18 +80,18 @@ impl Observer for DummyObserver {
 struct SMObserver {}
 
 impl StateMachineObserver for SMObserver {
-    fn transition_occured(&self, previous_state: &State, new_state: &State) {
+    fn on_transition(&self, previous_state: String, new_state: String) {
         println!(
             "transition_occured: {:?} -> \n {:?}",
             previous_state, new_state
         );
     }
 
-    fn on_state_entered(&self, entering_state: &State) {
+    fn on_state_entered(&self, entering_state: String) {
         // println!("entering state: {:?}", entering_state);
     }
 
-    fn on_state_exit(&self, leaving_state: &State) {
+    fn on_state_exit(&self, leaving_state: String) {
         // println!("exiting state: {:?}", leaving_state);
     }
 }
@@ -175,7 +174,7 @@ fn main() {
     let observer1: Arc<dyn Observer + 'static> = Arc::new(DummyObserver { id: 1 });
     let observer2: Arc<dyn Observer + 'static> = Arc::new(DummyObserver { id: 2 });
 
-    let observer3: Arc<dyn StateMachineObserver + 'static> = Arc::new(SMObserver { id: 3 });
+    let observer3: Arc<dyn StateMachineObserver + 'static> = Arc::new(SMObserver {});
 
     lottie_player.subscribe(observer1.clone());
     lottie_player.subscribe(observer2.clone());
@@ -212,7 +211,6 @@ fn main() {
         .expect("Unable to read the file");
 
     lottie_player.load_state_machine(&contents);
-    lottie_player.start_state_machine();
 
     lottie_player.state_machine_subscribe(observer3.clone());
 
@@ -225,7 +223,7 @@ fn main() {
 
         if window.is_key_down(Key::S) {
             let p = &mut *locked_player.write().unwrap();
-            p.stop();
+            p.start_state_machine();
         }
 
         if window.is_key_pressed(Key::O, KeyRepeat::No) {

--- a/examples/demo-state-machine/src/pigeon_fsm.json
+++ b/examples/demo-state-machine/src/pigeon_fsm.json
@@ -5,6 +5,7 @@
     },
     "states": [
         {
+            "name": "pigeon",
             "type": "PlaybackState",
             "loop": true,
             "autoplay": true,
@@ -23,6 +24,7 @@
             "reset_context": "*"
         },
         {
+            "name": "explosion",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -35,6 +37,7 @@
             "exit_actions": []
         },
         {
+            "name": "feather",
             "type": "PlaybackState",
             "loop": false,
             "autoplay": true,
@@ -44,7 +47,7 @@
             "segment": [],
             "frame_interpolation": true,
             "entry_actions": [],
-            "exit_actions": []
+            "exit_actions": []  
         }
     ],
     "transitions": [


### PR DESCRIPTION
This PR adds:

- Possibility to add a state machine observer with the 3 event callbacks to listen to:
   - `fn on_transition(&self, previous_state: &State, new_state: &State);`
   - `fn on_state_entered(&self, entering_state: &State);`
   - `fn on_state_exit(&self, leaving_state: &State);`
