### PR TITLE
fix: 🐛 .lottie file load failure with float speed property

### DIFF
--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -64,7 +64,7 @@ dictionary ManifestAnimation {
     boolean? loop;
     u32? loop_count;
     string? playMode;
-    u32? speed;
+    f32? speed;
     string? themeColor;
 };
 

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -67,7 +67,7 @@ dictionary Config {
 ///    boolean? loop;
 ///    u32? loop_count;
 ///    string? playMode;
-///    u32? speed;
+///    f32? speed;
 ///    string? themeColor;
 ///};
 

--- a/dotlottie-fms/src/manifest_animation.rs
+++ b/dotlottie-fms/src/manifest_animation.rs
@@ -14,7 +14,7 @@ pub struct ManifestAnimation {
     pub r#loop: Option<bool>,
     pub loop_count: Option<u32>,
     pub playMode: Option<String>,
-    pub speed: Option<u32>,
+    pub speed: Option<f32>,
     pub themeColor: Option<String>,
 }
 
@@ -30,7 +30,7 @@ impl ManifestAnimation {
         r#loop: Option<bool>,
         loop_count: Option<u32>,
         playMode: Option<String>,
-        speed: Option<u32>,
+        speed: Option<f32>,
         themeColor: Option<String>,
     ) -> Self {
         Self {
@@ -71,7 +71,7 @@ impl ManifestAnimation {
             } else {
                 playMode
             },
-            speed: if speed.is_none() { Some(1) } else { speed },
+            speed: if speed.is_none() { Some(1.0) } else { speed },
             themeColor: if themeColor.is_none() {
                 Some("".to_string())
             } else {
@@ -91,7 +91,7 @@ impl ManifestAnimation {
             r#loop: Some(false),
             loop_count: Some(0),
             playMode: Some("normal".to_string()),
-            speed: Some(1),
+            speed: Some(1.0),
             themeColor: Some("".to_string()),
         }
     }

--- a/dotlottie-fms/src/tests/manifest/mod.rs
+++ b/dotlottie-fms/src/tests/manifest/mod.rs
@@ -35,35 +35,33 @@ fn display() {
         None,
     );
 
-    let animation_02 =
-        ManifestAnimation::new(
-            Some(false),
-            Some("red_theme".to_string()),
-            Some(-1),
-            None,
-            "animation_02".to_string(),
-            None,
-            Some(false),
-            Some(12),
-            Some("bounce".to_string()),
-            Some(2),
-            None,
-        );
+    let animation_02 = ManifestAnimation::new(
+        Some(false),
+        Some("red_theme".to_string()),
+        Some(-1),
+        None,
+        "animation_02".to_string(),
+        None,
+        Some(false),
+        Some(12),
+        Some("bounce".to_string()),
+        Some(2.0),
+        None,
+    );
 
-    let animation_03 =
-        ManifestAnimation::new(
-            Some(true),
-            Some("orange_theme".to_string()),
-            Some(1),
-            None,
-            "animation_02".to_string(),
-            None,
-            Some(true),
-            Some(12),
-            None,
-            None,
-            None,
-        );
+    let animation_03 = ManifestAnimation::new(
+        Some(true),
+        Some("orange_theme".to_string()),
+        Some(1),
+        None,
+        "animation_02".to_string(),
+        None,
+        Some(true),
+        Some(12),
+        None,
+        None,
+        None,
+    );
 
     animations.push(animation_01);
 
@@ -95,7 +93,7 @@ fn display() {
               "loop": true,
               "loopCount": 0,
               "playMode": "normal",
-              "speed": 1,
+              "speed": 1.0,
               "themeColor": ""
             }
           ],
@@ -134,44 +132,43 @@ fn display() {
 
     let dis_02 = manifest_with_two_animations.to_json();
 
-    let dis_02_expected =
-        object! {
-          "activeAnimationId": "default_animation_id",
-          "animations": [
-            {
-              "autoplay": false,
-              "defaultTheme": "red_theme",
-              "direction": -1,
-              "hover": false,
-              "id": "animation_02",
-              "intermission": 0,
-              "loop": false,
-              "loopCount": 12,
-              "playMode": "bounce",
-              "speed": 2,
-              "themeColor": ""
-            },
-            {
-              "autoplay": true,
-              "defaultTheme": "orange_theme",
-              "direction": 1,
-              "hover": false,
-              "id": "animation_02",
-              "intermission": 0,
-              "loop": true,
-              "loopCount": 12,
-              "playMode": "Normal",
-              "speed": 1,
-              "themeColor": ""
-            }
-          ],
-          "author": "test_author",
-          "description": "Multi animation",
-          "generator": "dotLottie-fms",
-          "keywords": "dotLottie",
-          "revision": 2,
-          "version": "1.0.0"
-        };
+    let dis_02_expected = object! {
+      "activeAnimationId": "default_animation_id",
+      "animations": [
+        {
+          "autoplay": false,
+          "defaultTheme": "red_theme",
+          "direction": -1,
+          "hover": false,
+          "id": "animation_02",
+          "intermission": 0,
+          "loop": false,
+          "loopCount": 12,
+          "playMode": "bounce",
+          "speed": 2.0,
+          "themeColor": ""
+        },
+        {
+          "autoplay": true,
+          "defaultTheme": "orange_theme",
+          "direction": 1,
+          "hover": false,
+          "id": "animation_02",
+          "intermission": 0,
+          "loop": true,
+          "loopCount": 12,
+          "playMode": "Normal",
+          "speed": 1.0,
+          "themeColor": ""
+        }
+      ],
+      "author": "test_author",
+      "description": "Multi animation",
+      "generator": "dotLottie-fms",
+      "keywords": "dotLottie",
+      "revision": 2,
+      "version": "1.0.0"
+    };
 
     assert_eq!(dis_02.dump(), dis_02_expected.dump());
 }

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -712,7 +712,7 @@ impl DotLottieRuntime {
 
         match playback_settings_result {
             Ok(playback_settings) => {
-                let speed = playback_settings.speed.unwrap_or(1);
+                let speed = playback_settings.speed.unwrap_or(1.0);
                 let loop_animation = playback_settings.r#loop.unwrap_or(false);
                 let direction = playback_settings.direction.unwrap_or(1);
                 let autoplay = playback_settings.autoplay.unwrap_or(false);
@@ -726,7 +726,7 @@ impl DotLottieRuntime {
                     _ => Mode::Forward,
                 };
 
-                self.config.speed = speed as f32;
+                self.config.speed = speed;
                 self.config.autoplay = autoplay;
                 self.config.mode = if play_mode == "normal" {
                     if direction == 1 {


### PR DESCRIPTION

fix #150 

The `manifest.json` in the attached `problematic.zip` contains a speed property defined as a float number. The `dotlottie_fms` assumes the speed is a `u32`, causing a panic when loading this valid .lottie file.

[problematic.zip](https://github.com/LottieFiles/dotlottie-rs/files/15377948/problematic.zip)
