### PR TITLE
feat: 🎸 add tvg_canvas_set_viewport integration and bindings

### DIFF
--- a/.changeset/feat_add_tvg_canvas_set_viewport_integration_and_bindings.md
+++ b/.changeset/feat_add_tvg_canvas_set_viewport_integration_and_bindings.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# feat: 🎸 add tvg_canvas_set_viewport integration and bindings

--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -142,5 +142,6 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
         .function("loadThemeData", &DotLottiePlayer::load_theme_data)
         .function("markers", &DotLottiePlayer::markers)
         .function("activeAnimationId", &DotLottiePlayer::active_animation_id)
-        .function("activeThemeId", &DotLottiePlayer::active_theme_id);
+        .function("activeThemeId", &DotLottiePlayer::active_theme_id)
+        .function("setViewport", &DotLottiePlayer::set_viewport);
 }

--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -124,4 +124,5 @@ interface DotLottiePlayer {
     sequence<Marker> markers();
     string active_animation_id();
     string active_theme_id();
+    boolean set_viewport(i32 x, i32 y, i32 w, i32 h);
 };

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -127,4 +127,5 @@ interface DotLottiePlayer {
     sequence<Marker> markers();
     string active_animation_id();
     string active_theme_id();
+    boolean set_viewport(i32 x, i32 y, i32 w, i32 h);
 };

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -468,6 +468,10 @@ impl DotLottieRuntime {
         is_ok
     }
 
+    pub fn set_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) -> bool {
+        self.renderer.set_viewport(x, y, w, h).is_ok()
+    }
+
     pub fn render(&mut self) -> bool {
         let is_ok = self.renderer.render().is_ok();
 
@@ -1067,6 +1071,13 @@ impl DotLottiePlayer {
         }
 
         ok
+    }
+
+    pub fn set_viewport(&self, x: i32, y: i32, w: i32, h: i32) -> bool {
+        match self.runtime.try_write() {
+            Ok(mut runtime) => runtime.set_viewport(x, y, w, h),
+            _ => false,
+        }
     }
 
     pub fn resize(&self, width: u32, height: u32) -> bool {

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -140,6 +140,18 @@ impl LottieRenderer {
         Ok(())
     }
 
+    pub fn set_viewport(
+        &mut self,
+        x: i32,
+        y: i32,
+        w: i32,
+        h: i32,
+    ) -> Result<(), LottieRendererError> {
+        self.thorvg_canvas
+            .set_viewport(x, y, w, h)
+            .map_err(LottieRendererError::ThorvgError)
+    }
+
     pub fn set_frame(&mut self, no: f32) -> Result<(), LottieRendererError> {
         let total_frames = self
             .thorvg_animation

--- a/dotlottie-rs/src/thorvg.rs
+++ b/dotlottie-rs/src/thorvg.rs
@@ -93,6 +93,18 @@ impl Canvas {
         }
     }
 
+    pub fn set_viewport(
+        &mut self,
+        x: i32,
+        y: i32,
+        w: i32,
+        h: i32,
+    ) -> Result<(), TvgError> {
+        let result = unsafe { tvg_canvas_set_viewport(self.raw_canvas, x, y, w, h) };
+
+        convert_tvg_result(result, "tvg_canvas_set_viewport")
+    }
+
     pub fn set_target(
         &mut self,
         buffer: &mut Vec<u32>,
@@ -182,16 +194,15 @@ impl Animation {
         let mimetype = CString::new(mimetype).expect("Failed to create CString");
         let data = CString::new(data).expect("Failed to create CString");
 
-        let result =
-            unsafe {
-                tvg_picture_load_data(
-                    self.raw_paint,
-                    data.as_ptr(),
-                    data.as_bytes().len() as u32,
-                    mimetype.as_ptr(),
-                    copy,
-                )
-            };
+        let result = unsafe {
+            tvg_picture_load_data(
+                self.raw_paint,
+                data.as_ptr(),
+                data.as_bytes().len() as u32,
+                mimetype.as_ptr(),
+                copy,
+            )
+        };
 
         convert_tvg_result(result, "tvg_picture_load_data")?;
 
@@ -202,14 +213,13 @@ impl Animation {
         let mut width = 0.0;
         let mut height = 0.0;
 
-        let result =
-            unsafe {
-                tvg_picture_get_size(
-                    self.raw_paint,
-                    &mut width as *mut f32,
-                    &mut height as *mut f32,
-                )
-            };
+        let result = unsafe {
+            tvg_picture_get_size(
+                self.raw_paint,
+                &mut width as *mut f32,
+                &mut height as *mut f32,
+            )
+        };
 
         convert_tvg_result(result, "tvg_picture_get_size")?;
 

--- a/web-example.html
+++ b/web-example.html
@@ -61,6 +61,12 @@
     <button id="loop">loopToggle</button>
     <button id="next">Next</button>
     <input id="bg-color" type="color" />
+    <div>
+      <label for="width">Rendering Area Width:</label>
+      <input id="width" type="range" min="0" max="1" step="0.01" value="1" />
+      <label for="height">Rendering Area Height:</label>
+      <input id="height" type="range" min="0" max="1" step="0.01" value="1" />
+    </div>
     <script type="module">
       import createDotLottiePlayerModule from "./release/wasm/DotLottiePlayer.mjs";
 
@@ -78,6 +84,8 @@
       const fitSelect = document.querySelector("#fit");
       const alignSelect = document.querySelector("#align");
       const themeSelect = document.querySelector("#theme-select");
+      const renderAreaWidthInput = document.querySelector("#width");
+      const renderAreaHeightInput = document.querySelector("#height");
 
       const Module = await createDotLottiePlayerModule({
         locateFile: (path, prefix) => {
@@ -234,34 +242,9 @@
       }
 
       function setViewport() {
-        const { left, right, top, bottom } = canvas.getBoundingClientRect();
-        const windowWidth = window.innerWidth;
-        const windowHeight = window.innerHeight;
-
-        let x = 0;
-        let y = 0;
-        let width = canvas.width;
-        let height = canvas.height;
-
-        if (left < 0) {
-          x = Math.abs(left);
-          width -= x;
-        }
-
-        if (top < 0) {
-          y = Math.abs(top);
-          height -= y;
-        }
-
-        if (right > windowWidth) {
-          width -= right - windowWidth;
-        }
-
-        if (bottom > windowHeight) {
-          height -= bottom - windowHeight;
-        }
-
-        dotLottiePlayer.setViewport(x, y, width, height);
+        const width = Number(renderAreaWidthInput.value) * canvas.width;
+        const height = Number(renderAreaHeightInput.value) * canvas.height;
+        dotLottiePlayer.setViewport(0, 0, width, height);
       }
 
       function render() {

--- a/web-example.html
+++ b/web-example.html
@@ -233,7 +233,39 @@
         dotLottiePlayer.resize(width, height);
       }
 
+      function setViewport() {
+        const { left, right, top, bottom } = canvas.getBoundingClientRect();
+        const windowWidth = window.innerWidth;
+        const windowHeight = window.innerHeight;
+
+        let x = 0;
+        let y = 0;
+        let width = canvas.width;
+        let height = canvas.height;
+
+        if (left < 0) {
+          x = Math.abs(left);
+          width -= x;
+        }
+
+        if (top < 0) {
+          y = Math.abs(top);
+          height -= y;
+        }
+
+        if (right > windowWidth) {
+          width -= right - windowWidth;
+        }
+
+        if (bottom > windowHeight) {
+          height -= bottom - windowHeight;
+        }
+
+        dotLottiePlayer.setViewport(x, y, width, height);
+      }
+
       function render() {
+        setViewport();
         const rendered = dotLottiePlayer.render();
         if (rendered) {
           const frameBuffer = dotLottiePlayer.buffer();


### PR DESCRIPTION
**Description:**
In ThorVG v0.13.5, the `tvg_canvas_set_viewport` API was introduced to define the rectangular area of the canvas that will be used for drawing operations. The specified viewport clips the rendering output to the boundaries of the rectangle. This change can improve rendering performance by rendering only within the visible canvas boundaries.

**Changes:**
- Added safe Rust bindings to ThorVG's `tvg_canvas_set_viewport`
- Integrated `tvg_canvas_set_viewport` in the DotLottie runtime
- Updated Uniffi bindings
- Updated Emscripten bindings
- Updated the web example