### PR TITLE
fix(playback): 🐛 update speed causes animation frame jump

### DIFF
--- a/.changeset/fixplayback_update_speed_causes_animation_frame_jump.md
+++ b/.changeset/fixplayback_update_speed_causes_animation_frame_jump.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# fix(playback): 🐛 update speed causes animation frame jump

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -565,6 +565,8 @@ impl DotLottieRuntime {
     fn update_speed(&mut self, new_config: &Config) {
         if self.config.speed != new_config.speed && new_config.speed > 0.0 {
             self.config.speed = new_config.speed;
+
+            self.update_start_time_for_frame(self.current_frame());
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/LottieFiles/dotlottie-web/issues/195