### PR TITLE
feat(playback): 🎸 segment duration getter

### DIFF
--- a/.changeset/featplayback_segment_duration_getter.md
+++ b/.changeset/featplayback_segment_duration_getter.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# feat(playback): 🎸 segment duration getter

--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -142,5 +142,6 @@ EMSCRIPTEN_BINDINGS(DotLottiePlayer)
         .function("loadThemeData", &DotLottiePlayer::load_theme_data)
         .function("markers", &DotLottiePlayer::markers)
         .function("activeAnimationId", &DotLottiePlayer::active_animation_id)
-        .function("activeThemeId", &DotLottiePlayer::active_theme_id);
+        .function("activeThemeId", &DotLottiePlayer::active_theme_id)
+        .function("segmentDuration", &DotLottiePlayer::segment_duration);
 }

--- a/dotlottie-ffi/src/dotlottie_player.udl
+++ b/dotlottie-ffi/src/dotlottie_player.udl
@@ -124,4 +124,5 @@ interface DotLottiePlayer {
     sequence<Marker> markers();
     string active_animation_id();
     string active_theme_id();
+    f32 segment_duration();
 };

--- a/dotlottie-ffi/src/dotlottie_player_cpp.udl
+++ b/dotlottie-ffi/src/dotlottie_player_cpp.udl
@@ -127,4 +127,5 @@ interface DotLottiePlayer {
     sequence<Marker> markers();
     string active_animation_id();
     string active_theme_id();
+    f32 segment_duration();
 };

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -490,6 +490,19 @@ impl DotLottieRuntime {
         self.renderer.duration().unwrap_or(0.0)
     }
 
+    pub fn segment_duration(&self) -> f32 {
+        if self.config.segment.is_empty() {
+            self.duration()
+        } else {
+            let start_frame = self.start_frame();
+            let end_frame = self.end_frame();
+
+            let frame_rate = self.total_frames() / self.duration();
+
+            (end_frame - start_frame) / frame_rate
+        }
+    }
+
     pub fn current_frame(&self) -> f32 {
         self.renderer.current_frame
     }
@@ -953,6 +966,10 @@ impl DotLottiePlayer {
 
     pub fn duration(&self) -> f32 {
         self.runtime.read().unwrap().duration()
+    }
+
+    pub fn segment_duration(&self) -> f32 {
+        self.runtime.read().unwrap().segment_duration()
     }
 
     pub fn current_frame(&self) -> f32 {

--- a/dotlottie-rs/tests/speed.rs
+++ b/dotlottie-rs/tests/speed.rs
@@ -84,13 +84,7 @@ mod tests {
             );
             assert!(player.is_playing(), "Animation should be playing");
 
-            let expected_duration = if player.config().segment.is_empty() {
-                player.duration()
-            } else {
-                let segment_total_frames = player.config().segment[1] - player.config().segment[0];
-
-                segment_total_frames / player.total_frames() * player.duration()
-            };
+            let expected_duration = player.segment_duration();
 
             let start_time = std::time::Instant::now();
 


### PR DESCRIPTION
**Context:**

The current `duration()` method returns the duration of the entire animation. However, when the player is playing a specific segment or marker, there is no way to get the duration of the currently playing segment. This PR introduces the `segment_duration()` method, which returns the duration of the currently set segment if it exists. Otherwise, it returns the duration of the whole animation as defined in the Lottie JSON.

**Changes:**

- Added a new method called `segment_duration()`.
- Updated Uniffi bindings and UDL files.
- Updated Emscripten bindings.
- Updated tests.

**Related issue:** [LottieFiles/dotlottie-web#194](https://github.com/LottieFiles/dotlottie-web/issues/194)