### PR TITLE
fix: 🐛 prevent inlining of already embedded image assets in .lottie

### DIFF
--- a/dotlottie-fms/src/functions.rs
+++ b/dotlottie-fms/src/functions.rs
@@ -42,6 +42,11 @@ pub fn get_animation(bytes: &Vec<u8>, animation_id: &str) -> Result<String, DotL
     // Loop through the parsed lottie animation and check for image assets
     if let Some(assets) = lottie_animation["assets"].as_array_mut() {
         for i in 0..assets.len() {
+            // Skip if the asset is already inlined
+            if assets[i]["e"].as_i64() == Some(1) {
+                continue;
+            }
+
             if !assets[i]["p"].is_null() {
                 let image_asset_filename =
                     format!("images/{}", assets[i]["p"].to_string().replace("\"", ""));


### PR DESCRIPTION
Context:
dotlottie player attempts to inline external assets if they exist by assuming that any asset with a "p" property (path property) requires inlining. However, there are instances where the Lottie JSON contains already embedded image assets within the .lottie file. Attempting to inline these already inlined assets corrupts the Lottie JSON, causing the player to fail to load the animation data properly.

Changes: 
- Added a check to skip the inlining process if the image asset is already inlined.


test .lottie
[3230094.zip](https://github.com/user-attachments/files/15782726/3230094.zip)
