### PR TITLE
ci: 🎡 add flexible environment customization for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ on:
         required: false
         default: "macos-12"
       appleXcodeVersion:
-        description: "Apple Xcode version, e.g. 13.3.1"
+        description: "Apple Xcode version, e.g. Xcode_13.3.1.app"
         required: false
-        default: "13.3.1"
+        default: "Xcode_13.3.1.app"
       appleMacosxSdk:
         description: "Apple MacOSX SDK, e.g. MacOSX12.3"
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,22 @@ on:
       commitSHA:
         description: "Commit SHA (leave blank for default branch)"
         required: false
+      machine:
+        description: "Machine to run on, e.g. macos-12, ubuntu-20.04"
+        required: false
+        default: "macos-12"
+      appleXcodeVersion:
+        description: "Apple Xcode version, e.g. 13.3.1"
+        required: false
+        default: "13.3.1"
+      appleMacosxSdk:
+        description: "Apple MacOSX SDK, e.g. MacOSX12.3"
+        required: false
+        default: "MacOSX12.3"
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: ${{ github.event.inputs.machine }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -40,8 +52,8 @@ jobs:
       - name: Build Android
         if: github.event.inputs.target == 'android' || github.event.inputs.target == 'all'
         env:
-          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
-          APPLE_MACOSX_SDK: MacOSX12.3
+          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
+          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
         run: make android
 
       - name: Upload Android Artifacts
@@ -53,8 +65,8 @@ jobs:
       - name: Build Apple
         if: github.event.inputs.target == 'apple' || github.event.inputs.target == 'all'
         env:
-          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
-          APPLE_MACOSX_SDK: MacOSX12.3
+          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
+          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
         run: rm -f /usr/local/lib/libjpeg* ; make apple
 
       - name: Upload Apple Artifacts
@@ -66,8 +78,8 @@ jobs:
       - name: Build WASM
         if: github.event.inputs.target == 'wasm' || github.event.inputs.target == 'all'
         env:
-          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
-          APPLE_MACOSX_SDK: MacOSX12.3
+          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
+          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
         run: make wasm
 
       - name: Upload WASM Artifacts


### PR DESCRIPTION
This pull request adds a new feature to our CI workflow, giving us more flexibility in configuring the build environment. With these changes, you can now specify the machine image version, Xcode version, and macOS SDK to use during the build process.

### Changes
- Machine Selection: You can now choose the machine image version (e.g., macos-11, macos-12) before running the build.
- Xcode Version: Allows specifying which version of Xcode (e.g., Xcode_13.3.1.app) to use.
- macOS SDK: You can define the macOS SDK version (e.g., MacOSX12.3) for the build.