### PR TITLE
chore(wasm): 🤖 reduce WASM binary size

### DIFF
--- a/.changeset/chorewasm_reduce_wasm_binary_size.md
+++ b/.changeset/chorewasm_reduce_wasm_binary_size.md
@@ -1,0 +1,12 @@
+---
+default: minor
+---
+
+# chore(wasm): 🤖 reduce WASM binary size
+
+- **WASM Binary Optimization:**
+
+  - Reduced binary size by ~38.99 KB using `-Oz` flag.
+
+- **JavaScript Glue Optimization:**
+  - Reduced glue code size by ~36.88 KB with Closure Compiler.

--- a/.changeset/chorewasm_reduce_wasm_binary_size.md
+++ b/.changeset/chorewasm_reduce_wasm_binary_size.md
@@ -6,7 +6,12 @@ default: minor
 
 - **WASM Binary Optimization:**
 
-  - Reduced binary size by ~38.99 KB using `-Oz` flag.
+  - Applied the `-Oz` flag with `emcc` for size optimization.
+  - Used the compact `emmalloc` allocator.
+  - Used the rust nightly toolchain to remove location details and panic string formatting for a smaller binary size.
+  - Reduced binary size by ~142 KB (from 1,245,102 bytes to 1,099,243 bytes).
 
 - **JavaScript Glue Optimization:**
-  - Reduced glue code size by ~36.88 KB with Closure Compiler.
+
+  - Enabled the Closure compiler with the `--closure=1` flag.
+  - Reduced glue code size by ~36.88 KB (from 67,964 bytes to 30,197 bytes).

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -23,15 +23,11 @@ jobs:
         run: brew install make
       - name: Build Setup
         run: make mac-setup
-      - name: Check Rust Versions
-        run: |
-          rustc --version --verbose
-          rustc +nightly --version --verbose
       - name: Build Artifacts
         env:
           APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
           APPLE_MACOSX_SDK: MacOSX12.3
-        run: make wasm
+        run: make demo-player
       - name: Run Tests
         run: make test
       - name: Run Clippy

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -23,11 +23,15 @@ jobs:
         run: brew install make
       - name: Build Setup
         run: make mac-setup
+      - name: Check Rust Versions
+        run: |
+          rustc --version --verbose
+          rustc +nightly --version --verbose
       - name: Build Artifacts
         env:
           APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
           APPLE_MACOSX_SDK: MacOSX12.3
-        run: make demo-player
+        run: make wasm
       - name: Run Tests
         run: make test
       - name: Run Clippy

--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -66,6 +66,12 @@ rustup target add aarch64-linux-android \
   aarch64-apple-ios-sim \
   wasm32-unknown-emscripten
 
+
+echo "Installing nightly toolchain"
+rustup install nightly 
+rustup component add rust-src --toolchain nightly 
+rustup target add wasm32-unknown-emscripten --toolchain nightly
+
 echo
 echo "Install cargo dependencies"
 cargo install uniffi-bindgen-cpp \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ WASM_BUILD := $(BUILD)/$(WASM)
 
 EMSDK := emsdk
 EMSDK_DIR := $(PROJECT_DIR)/$(DEPS_MODULES_DIR)/$(EMSDK)
-EMSDK_VERSION := 3.1.61
+EMSDK_VERSION := 3.1.57
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ cpp_link_args = [
 	'-Wl,-u,ntohs',
 	'-Wl,-u,htonl',
 	'-Wshift-negative-value',
-	'-flto', '-Os', '--bind', '-sWASM=1',
+	'-flto', '-Oz', '--bind', '-sWASM=1',
 	'-sALLOW_MEMORY_GROWTH=1',
 	'-sFORCE_FILESYSTEM=0',
 	'-sMODULARIZE=1',
@@ -263,7 +263,7 @@ cpp_link_args = [
 	'--no-entry',
 	'--strip-all',
 	'--emit-tsd=${WASM_MODULE}.d.ts',
-	'--minify=0']
+	'--closure=1']
 
 [host_machine]
 system = '$(SYSTEM)'

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ exe_suffix = 'js'
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-ffunction-sections', '-fdata-sections']
 cpp_link_args = [
+	'-sMALLOC=emmalloc',
 	'-Wl,-u,htons',
 	'-Wl,-u,ntohs',
 	'-Wl,-u,htonl',

--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ define CARGO_BUILD
 		source $(EMSDK_DIR)/$(EMSDK)_env.sh && \
 		RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build \
 		-Z build-std=std,panic_abort \
-		-Z build-std-features=panic_immediate_abort \
+		-Z build-std-features="panic_immediate_abort,optimize_for_size" \
 		--manifest-path $(PROJECT_DIR)/Cargo.toml \
 		--target $(CARGO_TARGET) \
 		--release; \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ WASM_BUILD := $(BUILD)/$(WASM)
 
 EMSDK := emsdk
 EMSDK_DIR := $(PROJECT_DIR)/$(DEPS_MODULES_DIR)/$(EMSDK)
-EMSDK_VERSION := 3.1.57
+EMSDK_VERSION := 3.1.61
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp
@@ -356,11 +356,20 @@ define CLEAN_LIBGJPEG
 endef
 
 define CARGO_BUILD
-	source $(EMSDK_DIR)/$(EMSDK)_env.sh && \
+	if [ "$(CARGO_TARGET)" = "wasm32-unknown-emscripten" ]; then \
+		source $(EMSDK_DIR)/$(EMSDK)_env.sh && \
+		RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build \
+		-Z build-std=std,panic_abort \
+		-Z build-std-features=panic_immediate_abort \
+		--manifest-path $(PROJECT_DIR)/Cargo.toml \
+		--target $(CARGO_TARGET) \
+		--release; \
+	else \
 		cargo build \
 		--manifest-path $(PROJECT_DIR)/Cargo.toml \
 		--target $(CARGO_TARGET) \
-		--release
+		--release; \
+	fi
 endef
 
 define UNIFFI_BINDINGS_BUILD

--- a/dotlottie-ffi/Cargo.wasm.toml
+++ b/dotlottie-ffi/Cargo.wasm.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.release]
 lto = true
-opt-level = "s"
+opt-level = "z"
 strip = true 
 codegen-units = 1
 panic = "abort" 

--- a/web-example.html
+++ b/web-example.html
@@ -6,6 +6,7 @@
     <title>WASM test</title>
   </head>
   <body>
+    <h1>Test</h1>
     <div style="width: 800px">
       <label for="fit">Fit:</label>
       <select id="fit">
@@ -133,7 +134,7 @@
 
       const data = await fetch(
         // "https://lottie.host/5c89381e-0d1a-4422-8247-f5b7e4b3c4e2/mqs5juC4PW.lottie"
-        "./demo-player/src/theming_example.lottie"
+        "./examples/demo-player/src/theming_example.lottie"
         // "https://lottie.host/294b684d-d6b4-4116-ab35-85ef566d4379/VkGHcqcMUI.lottie",
         // "https://lottie.host/edff17eb-9a84-41f7-810a-22b94fbf9143/uYveqJ1Kqn.lottie"
       ).then((res) => res.arrayBuffer());


### PR DESCRIPTION
### Description:
This PR introduces optimizations to reduce the size of the WASM binary and the accompanying JavaScript glue code.

### Changes:
- **WASM Binary Optimization**:
  - Applied the [`-Oz` flag](https://emscripten.org/docs/tools_reference/emcc.html#emcc-oz) with `emcc` for size optimization.
  - Use the compact [emmalloc](https://emscripten.org/docs/tools_reference/settings_reference.html#malloc) allocator.
  - Use the Rust nightly toolchain to remove location details and panic string formatting for a smaller binary size.
  - **Current Size**: 1,245,102 bytes
  - **New Size**: 1,099,243 bytes
  - **Reduction**: ~142 KB

- **JavaScript Glue Optimization**:
  - Enabled the [Closure Compiler](https://emscripten.org/docs/site/glossary.html#term-closure-compiler) with the `--closure=1` flag.
  - **Current Size**: 67,964 bytes
  - **New Size**: 30,197 bytes
  - **Reduction**: ~36.88 KB
  
 related #107