### PR TITLE
fix: 🐛 manifest_string() panics when no manifest available

### DIFF
--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -1753,7 +1753,6 @@ impl DotLottiePlayer {
         true
     }
 
-    #[cfg(target_arch = "wasm32")]
     pub fn manifest_string(&self) -> String {
         self.player.try_read().map_or_else(|_| String::new(), |player| player.manifest_string())
     }

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -1145,8 +1145,10 @@ impl DotLottiePlayerContainer {
     }
 
     pub fn manifest_string(&self) -> String {
-        self.runtime.read().unwrap().manifest().unwrap().to_string()
-    }
+        self.runtime.try_read().ok()
+            .and_then(|runtime| runtime.manifest())
+            .map_or_else(String::new, |manifest| manifest.to_string())
+    }    
 
     pub fn is_complete(&self) -> bool {
         self.runtime.read().unwrap().is_complete()
@@ -1751,8 +1753,9 @@ impl DotLottiePlayer {
         true
     }
 
+    #[cfg(target_arch = "wasm32")]
     pub fn manifest_string(&self) -> String {
-        self.player.read().unwrap().manifest_string()
+        self.player.try_read().map_or_else(|_| String::new(), |player| player.manifest_string())
     }
 
     pub fn is_complete(&self) -> bool {


### PR DESCRIPTION
fixes a regression in the manifest_string method, which should return an empty string if the Option<Manifest> is None