### PR TITLE
fix: iOS build issue caused by meson 1.5.0

### DIFF
--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -46,7 +46,7 @@ echo "Installing brew package(s) ..."
 brew install android-ndk \
   cmake \
   nasm \
-  meson \
+  meson@1.4.1 \
   ninja \
   pkg-config \
   ktlint \

--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -42,11 +42,14 @@ check_for rustup "https://rustup.rs" "\
      1. Choose the ${GREEN}default${NC} installation option
      2. Either logout & login after the installation, or execute: ${YELLOW}source \"\$HOME/.cargo/env\""
 
+echo "Installing v1.4.1 of Meson..."
+curl https://raw.githubusercontent.com/Homebrew/homebrew-core/2f89922685ce82af272fe045178f63bfb3bc7289/Formula/m/meson.rb > meson.rb
+brew install meson.rb
+
 echo "Installing brew package(s) ..."
 brew install android-ndk \
   cmake \
   nasm \
-  meson@1.4.1 \
   ninja \
   pkg-config \
   ktlint \


### PR DESCRIPTION
Meson automatically bumped to the latest version when using brew install, causing iOS to fail its build.

To fix this this PR reverts to the previous meson version the project has been using.