### PR TITLE
chore: fix undefined symbol _emscripten_get_now for wasm compatibility

### DIFF
--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -11,7 +11,7 @@ NC=$(tput sgr0)
 
 # Environment
 EMSDK_VERSION=${EMSDK_VERSION:-latest}
-UNIFFI_BINDGEN_CPP_VERSION=${UNIFFI_BINDGEN_CPP_VERSION:-"v0.6.0+v0.25.0"}
+UNIFFI_BINDGEN_CPP_VERSION=${UNIFFI_BINDGEN_CPP_VERSION:-"v0.6.3+v0.25.0"}
 
 die() { printf %s "${@+$@$'\n'}" 1>&2 ; exit 1; }
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ EMSDK_VERSION := 3.1.57
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp
-UNIFFI_BINDGEN_CPP_VERSION := v0.6.0+v0.25.0
+UNIFFI_BINDGEN_CPP_VERSION := v0.6.3+v0.25.0
 
 WASM_MODULE := DotLottiePlayer
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ WASM_BUILD := $(BUILD)/$(WASM)
 
 EMSDK := emsdk
 EMSDK_DIR := $(PROJECT_DIR)/$(DEPS_MODULES_DIR)/$(EMSDK)
-EMSDK_VERSION := 3.1.57
+EMSDK_VERSION := 3.1.68
 EMSDK_ENV := emsdk_env.sh
 
 UNIFFI_BINDGEN_CPP := uniffi-bindgen-cpp

--- a/dotlottie-ffi/emscripten_bindings.cpp
+++ b/dotlottie-ffi/emscripten_bindings.cpp
@@ -1,8 +1,21 @@
 #include "dotlottie_player.hpp"
 #include <emscripten/bind.h>
+#include <emscripten/emscripten.h>
 
 using namespace emscripten;
 using namespace dotlottie_player;
+
+extern "C"
+{
+    /*
+        This is a workaround as instant crate expects a _ prefix for the emscripten_get_now function
+        https://github.com/sebcrozet/instant/issues/35
+    */
+    double _emscripten_get_now()
+    {
+        return emscripten_get_now();
+    }
+}
 
 val buffer(DotLottiePlayer &player)
 {

--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 thiserror = "1.0.48"
-# "emscripten-no-leading-underscore" branch fix this issue -> https://github.com/sebcrozet/instant/issues/35
-instant = { git = "https://github.com/hoodmane/instant", branch = "emscripten-no-leading-underscore", features = ["inaccurate"] }
+instant = { version = "0.1.13", features = ["inaccurate"] }
 serde_json = "1.0.107"
 serde = { version = "1.0.188", features = ["derive"] }
 zip = { version = "2.2.0", default-features = false, features = ["deflate"] }


### PR DESCRIPTION
**Changes:**
- Updated the `instant` crate to version `0.1.13`.
- Fixed the `undefined symbol: _emscripten_get_now` issue by adding the necessary underscore prefix as a workaround.
- Upgrade Uniffi-bindgen-cpp to v0.6.0+v0.25.0
- Emscripten upgrade to v3.1.68

> This change allows the package to be publishable to crates.io, as crates with git dependencies cannot be published.