### PR TITLE
feat: upgrade thorvg v1.0-pre10

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Lint
         run: |
-          cargo clippy --manifest-path=./dotlottie-rs/Cargo.toml --all-targets --all-features -- -D clippy::print_stdout
-          cargo clippy --manifest-path=./dotlottie-ffi/Cargo.toml --all-targets --all-features -- -D clippy::print_stdout
+          cargo clippy --manifest-path=./dotlottie-rs/Cargo.toml --all-targets -- -D clippy::print_stdout
+          cargo clippy --manifest-path=./dotlottie-ffi/Cargo.toml --all-targets -- -D clippy::print_stdout
         env:
           RUSTFLAGS: "-Dwarnings"

--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,7 @@ define SETUP_MESON
 		--backend=ninja \
 		-Dloaders="lottie, png, jpg, webp" \
 		-Ddefault_library=static \
+		-Dengines=sw \
 		-Dbindings=capi \
 		-Dlog=false \
 		-Dthreads=false \
@@ -387,6 +388,8 @@ define CARGO_BUILD
 		-Z build-std-features="panic_immediate_abort,optimize_for_size" \
 		--manifest-path $(PROJECT_DIR)/Cargo.toml \
 		--target $(CARGO_TARGET) \
+		--no-default-features \
+		--features thorvg-v1 \
 		--release; \
 	else \
 		IPHONEOS_DEPLOYMENT_TARGET=$(APPLE_IOS_VERSION_MIN) \
@@ -394,6 +397,8 @@ define CARGO_BUILD
 		cargo build \
 		--manifest-path $(PROJECT_DIR)/Cargo.toml \
 		--target $(CARGO_TARGET) \
+		--no-default-features \
+		--features thorvg-v1 \
 		--release; \
 	fi
 endef
@@ -402,7 +407,8 @@ define UNIFFI_BINDINGS_BUILD
 	rm -rf $(RUNTIME_FFI)/$(RUNTIME_FFI_UNIFFI_BINDINGS)/$(BINDINGS_LANGUAGE)
 	cargo run \
 		--manifest-path $(RUNTIME_FFI)/Cargo.toml \
-		--features=uniffi/cli \
+		--no-default-features \
+		--features=uniffi/cli,thorvg-v1 \
 		--bin uniffi-bindgen \
 		generate $(RUNTIME_FFI)/src/dotlottie_player.udl \
 		--language $(BINDINGS_LANGUAGE) \
@@ -1021,8 +1027,8 @@ bench:
 .PHONY: clippy
 clippy:
 	$(info $(YELLOW)Running clippy for workspace$(NC))
-	cargo clippy --manifest-path $(CORE)/Cargo.toml --all-targets --all-features -- -D clippy::print_stdout
-	cargo clippy --manifest-path $(RUNTIME_FFI)/Cargo.toml --all-targets --all-features -- -D clippy::print_stdout
+	cargo clippy --manifest-path $(CORE)/Cargo.toml --all-targets -- -D clippy::print_stdout
+	cargo clippy --manifest-path $(RUNTIME_FFI)/Cargo.toml --all-targets -- -D clippy::print_stdout
 
 .PHONY: help
 help:

--- a/dotlottie-ffi/Cargo.toml
+++ b/dotlottie-ffi/Cargo.toml
@@ -18,9 +18,14 @@ name = "dotlottie_player"
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
+[features]
+default = ["thorvg-v0"]
+thorvg-v0 = ["dotlottie-rs/thorvg-v0"]
+thorvg-v1 = ["dotlottie-rs/thorvg-v1"]
+
 [dependencies]
 uniffi = { version = "0.28", features = ["cli"] }
-dotlottie-rs = { path = "../dotlottie-rs", features = ["thorvg"] }
+dotlottie-rs = { path = "../dotlottie-rs", default-features = false }
 cfg-if = "1.0"
 bitflags = "2.6.0"
 

--- a/dotlottie-ffi/Cargo.wasm.toml
+++ b/dotlottie-ffi/Cargo.wasm.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotlottie-ffi"
-version = "0.1.31"
+version = "0.1.36"
 edition = "2021"
 build = "build.rs"
 
@@ -19,9 +19,14 @@ name = "dotlottie_player"
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
+[features]
+default = ["thorvg-v0"]
+thorvg-v0 = ["dotlottie-rs/thorvg-v0"]
+thorvg-v1 = ["dotlottie-rs/thorvg-v1"]
+
 [dependencies]
 uniffi = { version = "0.25", features = ["cli"] }
-dotlottie-rs = { path = "../dotlottie-rs", features = ["thorvg"] }
+dotlottie-rs = { path = "../dotlottie-rs", default-features = false }
 cfg-if = "1.0"
 bitflags = "2.6.0"
 

--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -8,7 +8,8 @@ links = "thorvg"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
-thorvg = []
+thorvg-v0 = []
+thorvg-v1 = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -30,7 +31,7 @@ conan2 = "0.1"
 [dev-dependencies]
 criterion = "0.5.1"
 # This is a workaround to enable this feature only on dev.
-dotlottie-rs= { path = ".", features = ["thorvg"] }
+dotlottie-rs= { path = ".", features = ["thorvg-v0"] }
 
 [[bench]]
 name = "benchmarks"

--- a/dotlottie-rs/build.rs
+++ b/dotlottie-rs/build.rs
@@ -97,8 +97,12 @@ fn apply_build_settings(build_settings: &BuildSettings) {
 }
 
 fn main() {
-    if !cfg!(feature = "thorvg") {
+    if !cfg!(feature = "thorvg-v0") && !cfg!(feature = "thorvg-v1") {
         return;
+    }
+
+    if !is_artifacts_provided() && cfg!(feature = "thorvg-v1") {
+        panic!("ARTIFACTS_INCLUDE_DIR and ARTIFACTS_LIB_DIR environment variables are required for thorvg-v1");
     }
 
     let mut builder = bindgen::Builder::default().header("wrapper.h");

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -128,7 +128,7 @@ struct DotLottieRuntime {
 }
 
 impl DotLottieRuntime {
-    #[cfg(feature = "thorvg")]
+    #[cfg(any(feature = "thorvg-v0", feature = "thorvg-v1"))]
     pub fn new(config: Config) -> Self {
         Self::with_renderer(
             config,
@@ -886,7 +886,7 @@ pub struct DotLottiePlayerContainer {
 }
 
 impl DotLottiePlayerContainer {
-    #[cfg(feature = "thorvg")]
+    #[cfg(any(feature = "thorvg-v0", feature = "thorvg-v1"))]
     pub fn new(config: Config) -> Self {
         DotLottiePlayerContainer {
             runtime: RwLock::new(DotLottieRuntime::new(config)),
@@ -1274,7 +1274,7 @@ pub struct DotLottiePlayer {
 }
 
 impl DotLottiePlayer {
-    #[cfg(feature = "thorvg")]
+    #[cfg(any(feature = "thorvg-v0", feature = "thorvg-v1"))]
     pub fn new(config: Config) -> Self {
         DotLottiePlayer {
             player: Rc::new(RwLock::new(DotLottiePlayerContainer::new(config))),

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -5,11 +5,11 @@ use thiserror::Error;
 use crate::Layout;
 
 mod renderer;
-#[cfg(feature = "thorvg")]
+#[cfg(any(feature = "thorvg-v0", feature = "thorvg-v1"))]
 mod thorvg;
 
 pub use renderer::{Animation, ColorSpace, Drawable, Renderer, Shape};
-#[cfg(feature = "thorvg")]
+#[cfg(any(feature = "thorvg-v0", feature = "thorvg-v1"))]
 pub use thorvg::{TvgAnimation, TvgEngine, TvgError, TvgRenderer, TvgShape};
 
 #[derive(Error, Debug)]
@@ -87,6 +87,7 @@ impl dyn LottieRenderer {
         let background_shape = R::Shape::default();
 
         renderer.push(Drawable::Shape(&background_shape)).unwrap();
+        renderer.sync().unwrap();
 
         Box::new(LottieRendererImpl {
             animation: R::Animation::default(),
@@ -229,7 +230,7 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
 
     fn render(&mut self) -> Result<(), LottieRendererError> {
         self.renderer.update().map_err(into_lottie::<R>)?;
-        self.renderer.draw().map_err(into_lottie::<R>)?;
+        self.renderer.draw(true).map_err(into_lottie::<R>)?;
         self.renderer.sync().map_err(into_lottie::<R>)?;
 
         Ok(())

--- a/dotlottie-rs/src/lottie_renderer/renderer.rs
+++ b/dotlottie-rs/src/lottie_renderer/renderer.rs
@@ -78,7 +78,7 @@ pub trait Renderer: Sized + 'static {
 
     fn push(&mut self, drawable: Drawable<Self>) -> Result<(), Self::Error>;
 
-    fn draw(&mut self) -> Result<(), Self::Error>;
+    fn draw(&mut self, clear_buffer: bool) -> Result<(), Self::Error>;
 
     fn sync(&mut self) -> Result<(), Self::Error>;
 

--- a/examples/demo-player/Cargo.toml
+++ b/examples/demo-player/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 minifb = "0.27"
-dotlottie-rs = { path = "../../dotlottie-rs", features = ["thorvg"] }
+dotlottie-rs = { path = "../../dotlottie-rs", features = ["thorvg-v0"] }
 sysinfo = "0.30"
 rand = "0.8"

--- a/examples/demo-state-machine/Cargo.toml
+++ b/examples/demo-state-machine/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 minifb = "0.27"
-dotlottie-rs = { path = "../../dotlottie-rs", features = ["thorvg"] }
+dotlottie-rs = { path = "../../dotlottie-rs", features = ["thorvg-v0"] }
 sysinfo = "0.30"
 rand = "0.8"
 

--- a/examples/demo-state-machine/src/bin/play-on-hover/play-on-hover.rs
+++ b/examples/demo-state-machine/src/bin/play-on-hover/play-on-hover.rs
@@ -1,5 +1,5 @@
-use dotlottie_player_core::events::Event;
-use dotlottie_player_core::{Config, DotLottiePlayer};
+use dotlottie_rs::events::Event;
+use dotlottie_rs::{Config, DotLottiePlayer};
 use minifb::{Key, MouseButton, MouseMode, Window, WindowOptions};
 use std::fs::{self, File};
 use std::io::Read;

--- a/examples/demo-state-machine/src/bin/star-rating/star-rating.rs
+++ b/examples/demo-state-machine/src/bin/star-rating/star-rating.rs
@@ -1,5 +1,5 @@
-use dotlottie_player_core::events::Event;
-use dotlottie_player_core::{Config, DotLottiePlayer};
+use dotlottie_rs::events::Event;
+use dotlottie_rs::{Config, DotLottiePlayer};
 use minifb::{Key, MouseButton, MouseMode, Window, WindowOptions};
 use std::fs::{self, File};
 use std::io::Read;


### PR DESCRIPTION
### Changes

1. **Feature Flags for `thorvg` Versions**
   - Added two feature flags: `thorvg-v1` and `thorvg-v0`.
   - These allow us to maintain compatibility with `thorvg` v0.x.x, as binaries for Linux, Windows, and macOS from the Conan registry currently only support v0.
   - `thorvg-v1` is a pre-release version and is not yet stable or available on Conan.

2. **Default Configuration**
   - By default, the `thorvg-v0` flag is enabled for the FFI, unless explicitly specified otherwise.

3. **Build Target Differences**
   - WebAssembly (WASM), Android, and Apple builds use `thorvg-v1`.
   - Native dependencies (Linux/Windows/macOS) use `thorvg-v0
   
   
 
WASM/APPLE/ANDROID artifacts -> https://github.com/LottieFiles/dotlottie-rs/actions/runs/12764709359