### PR TITLE
chore: improve release & build artifacts workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,15 @@ on:
       commitSHA:
         description: "Commit SHA (leave blank for default branch)"
         required: false
-      machine:
-        description: "Machine to run on, e.g. macos-12, ubuntu-20.04"
-        required: false
-        default: "macos-12"
-      appleXcodeVersion:
-        description: "Apple Xcode version, e.g. Xcode_13.3.1.app"
-        required: false
-        default: "Xcode_13.3.1.app"
-      appleMacosxSdk:
-        description: "Apple MacOSX SDK, e.g. MacOSX12.3"
-        required: false
-        default: "MacOSX12.3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.target }}-${{ github.event.inputs.commitSHA || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ${{ github.event.inputs.machine }}
+  build-apple:
+    runs-on: macos-12
+    if: github.event.inputs.target == 'apple' || github.event.inputs.target == 'all'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -48,42 +41,78 @@ jobs:
 
       - name: Build Setup
         run: make mac-setup
-
-      - name: Build Android
-        if: github.event.inputs.target == 'android' || github.event.inputs.target == 'all'
         env:
-          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
-          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
-        run: make android
-
-      - name: Upload Android Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: android
-          path: ./release/android/*.tar.gz
+          TARGET: apple
 
       - name: Build Apple
-        if: github.event.inputs.target == 'apple' || github.event.inputs.target == 'all'
         env:
-          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
-          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
+          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
+          APPLE_MACOSX_SDK: MacOSX12.3
         run: rm -f /usr/local/lib/libjpeg* ; make apple
 
       - name: Upload Apple Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: apple
-          path: ./release/apple/*.tar.gz
+          name: dotlottie-player.darwin.tar.gz
+          path: release/apple/dotlottie-player.darwin.tar.gz
+          if-no-files-found: error
+
+  build-android:
+    runs-on: macos-latest
+    if: github.event.inputs.target == 'android' || github.event.inputs.target == 'all'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commitSHA || github.ref }}
+
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Install Make
+        run: brew install make
+
+      - name: Build Setup
+        run: make mac-setup
+        env:
+          TARGET: android
+
+      - name: Build Android
+        run: make android
+
+      - name: Upload Android Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotlottie-player.android.tar.gz
+          path: release/android/dotlottie-player.android.tar.gz
+          if-no-files-found: error
+
+  build-wasm:
+    runs-on: macos-latest
+    if: github.event.inputs.target == 'wasm' || github.event.inputs.target == 'all'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commitSHA || github.ref }}
+
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Install Make
+        run: brew install make
+
+      - name: Build Setup
+        run: make mac-setup
+        env:
+          TARGET: wasm
 
       - name: Build WASM
-        if: github.event.inputs.target == 'wasm' || github.event.inputs.target == 'all'
-        env:
-          APPLE_XCODE_APP_NAME: ${{ github.event.inputs.appleXcodeVersion }}
-          APPLE_MACOSX_SDK: ${{ github.event.inputs.appleMacosxSdk }}
         run: make wasm
 
       - name: Upload WASM Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wasm
-          path: ./release/wasm/*.tar.gz
+          name: dotlottie-player.wasm.tar.gz
+          path: release/wasm/dotlottie-player.wasm.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-pr:
     if: github.head_ref != 'release'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,18 @@
 name: Release
+
 on:
   pull_request:
     types: [closed]
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build-artifacts:
-    if: github.head_ref == 'release' && github.event.pull_request.merged == true
+  build-apple:
     runs-on: macos-12
+    if: github.head_ref == 'release' && github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
       - uses: Homebrew/actions/setup-homebrew@master
@@ -14,36 +20,82 @@ jobs:
         with:
           xcode-version: "13.3.1"
       - uses: ningenMe/setup-rustup@v1.1.0
+
       - name: Install Make
         run: brew install make
+
       - name: Build Setup
         run: make mac-setup
-      - name: Build Artifacts
+        env:
+          TARGET: apple
+
+      - name: Build Apple
         env:
           APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
           APPLE_MACOSX_SDK: MacOSX12.3
-        run: make all
-      - name: Upload Artifact
+        run: rm -f /usr/local/lib/libjpeg* ; make apple
+
+      - name: Upload Apple Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotlottie-player.darwin.tar.gz
+          path: release/apple/dotlottie-player.darwin.tar.gz
+          if-no-files-found: error
+
+  build-android:
+    runs-on: macos-latest
+    if: github.head_ref == 'release' && github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Install Make
+        run: brew install make
+
+      - name: Build Setup
+        run: make mac-setup
+        env:
+          TARGET: android
+
+      - name: Build Android
+        run: make android
+
+      - name: Upload Android Artifacts
         uses: actions/upload-artifact@v4.0.0
         with:
           name: dotlottie-player.android.tar.gz
           path: release/android/dotlottie-player.android.tar.gz
           if-no-files-found: error
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: dotlottie-player.darwin.tar.gz
-          path: release/apple/dotlottie-player.darwin.tar.gz
-          if-no-files-found: error
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4.0.0
+
+  build-wasm:
+    runs-on: macos-latest
+    if: github.head_ref == 'release' && github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Install Make
+        run: brew install make
+
+      - name: Build Setup
+        run: make mac-setup
+        env:
+          TARGET: wasm
+
+      - name: Build WASM
+        run: make wasm
+
+      - name: Upload WASM Artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: dotlottie-player.wasm.tar.gz
           path: release/wasm/dotlottie-player.wasm.tar.gz
           if-no-files-found: error
 
   release:
-    needs: [build-artifacts]
+    needs: [build-apple, build-android, build-wasm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Changes:
- updated the `mac-setup.sh` script to configure the necessary toolchain based on the target platform (WASM, Apple, or Android). This optimization reduces CI build time when targeting a specific platform, such as WASM only.  
- upgraded the Meson version in `mac-setup.sh` to v1.6.0.  
- updated the build artifacts to use the latest macOS image for Android and WASM builds, as `macos-12` is now deprecated. 


test build: 
https://github.com/LottieFiles/dotlottie-rs/actions/runs/11926940801
<img width="332" alt="image" src="https://github.com/user-attachments/assets/e3c272cf-507f-4543-bafe-dee76d773487">
