### PR TITLE
fix: minimum deployment version of the iOS and MacOSX targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build-apple:
-    runs-on: macos-12
+    runs-on: macos-latest-large
     if: github.event.inputs.target == 'apple' || github.event.inputs.target == 'all'
     steps:
       - name: Checkout Repository
@@ -31,9 +31,6 @@ jobs:
           ref: ${{ github.event.inputs.commitSHA || github.ref }}
 
       - uses: Homebrew/actions/setup-homebrew@master
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "13.3.1"
       - uses: ningenMe/setup-rustup@v1.1.0
 
       - name: Install Make
@@ -45,10 +42,9 @@ jobs:
           TARGET: apple
 
       - name: Build Apple
-        env:
-          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
-          APPLE_MACOSX_SDK: MacOSX12.3
-        run: rm -f /usr/local/lib/libjpeg* ; make apple
+        run: |
+          rm -f /usr/local/lib/libjpeg*
+          make apple
 
       - name: Upload Apple Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -11,35 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO:For Testing, Remove Before Merge
-  build-apple:
-    runs-on: macos-latest-large
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - uses: Homebrew/actions/setup-homebrew@master
-      - uses: ningenMe/setup-rustup@v1.1.0
-
-      - name: Install Make
-        run: brew install make
-
-      - name: Build Setup
-        run: make mac-setup
-        env:
-          TARGET: apple
-
-      - name: Build Apple
-        run: |
-          rm -f /usr/local/lib/libjpeg*
-          make apple
-
-      - name: Upload Apple Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dotlottie-player.darwin.tar.gz
-          path: release/apple/dotlottie-player.darwin.tar.gz
-          if-no-files-found: error
   check-pr:
     if: github.head_ref != 'release'
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -11,6 +11,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TODO:For Testing, Remove Before Merge
+  build-apple:
+    runs-on: macos-latest-large
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Install Make
+        run: brew install make
+
+      - name: Build Setup
+        run: make mac-setup
+        env:
+          TARGET: apple
+
+      - name: Build Apple
+        run: |
+          rm -f /usr/local/lib/libjpeg*
+          make apple
+
+      - name: Upload Apple Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotlottie-player.darwin.tar.gz
+          path: release/apple/dotlottie-player.darwin.tar.gz
+          if-no-files-found: error
   check-pr:
     if: github.head_ref != 'release'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,11 @@ concurrency:
 
 jobs:
   build-apple:
-    runs-on: macos-12
+    runs-on: macos-latest-large
     if: github.head_ref == 'release' && github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
       - uses: Homebrew/actions/setup-homebrew@master
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "13.3.1"
       - uses: ningenMe/setup-rustup@v1.1.0
 
       - name: Install Make
@@ -30,10 +27,9 @@ jobs:
           TARGET: apple
 
       - name: Build Apple
-        env:
-          APPLE_XCODE_APP_NAME: Xcode_13.3.1.app
-          APPLE_MACOSX_SDK: MacOSX12.3
-        run: rm -f /usr/local/lib/libjpeg* ; make apple
+        run: |
+          rm -f /usr/local/lib/libjpeg*
+          make apple
 
       - name: Upload Apple Artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ define CREATE_FRAMEWORK
                      -c "Add :CFBundleShortVersionString string 1.0.0" \
                      -c "Add :CFBundlePackageType string FMWK" \
                      -c "Add :CFBundleExecutable string $(DOTLOTTIE_PLAYER_MODULE)" \
-                     -c "Add :MinimumOSVersion string $(APPLE_IOS_VERSION_MIN)" \
+                     -c "Add :MinimumOSVersion string $(if $(findstring macosx,$(BASE_DIR)),$(APPLE_MACOS_VERSION_MIN),$(APPLE_IOS_VERSION_MIN))" \
                      -c "Add :CFBundleSupportedPlatforms array" \
 										 $(foreach platform,$(PLIST_DISABLE),-c "Add :CFBundleSupportedPlatforms:0 string $(platform)" ) \
 										 $(foreach platform,$(PLIST_ENABLE),-c "Add :CFBundleSupportedPlatforms:1 string $(platform)" ) \

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ APPLE_BUILD := $(BUILD)/$(APPLE)
 APPLE_IOS := ios
 APPLE_IOS_PLATFORM := iPhoneOS
 APPLE_IOS_SDK ?= iPhoneOS
-APPLE_IOS_VERSION_MIN ?= 15.4
-THORVG_APPLE_IOS_VERSION_MIN ?= 11.0 # Minimum iOS version supported by ThorVG, needs to be the same for cpp_args and cpp_link_args
+APPLE_MACOS_VERSION_MIN ?= 11.0
+APPLE_IOS_VERSION_MIN ?= 13.0
 APPLE_XCODE_APP_NAME ?= Xcode.app
 
 APPLE_IOS_SIMULATOR := ios-simulator
@@ -226,8 +226,14 @@ has_function_printf = true
 
 $(if $(filter $(PLATFORM),$(APPLE_IOS_PLATFORM) $(APPLE_IOS_SIMULATOR_PLATFORM)),\
 [built-in options]\n\
-cpp_args = ['-miphoneos-version-min=$(THORVG_APPLE_IOS_VERSION_MIN)']\n\
-cpp_link_args = ['-miphoneos-version-min=$(THORVG_APPLE_IOS_VERSION_MIN)']\n\
+cpp_args = ['-miphoneos-version-min=$(APPLE_IOS_VERSION_MIN)']\n\
+cpp_link_args = ['-miphoneos-version-min=$(APPLE_IOS_VERSION_MIN)']\n\
+,)
+
+$(if $(filter $(PLATFORM),$(APPLE_MACOSX_PLATFORM)),\
+[built-in options]\n\
+cpp_args = ['-mmacosx-version-min=$(APPLE_MACOS_VERSION_MIN)']\n\
+cpp_link_args = ['-mmacosx-version-min=$(APPLE_MACOS_VERSION_MIN)']\n\
 ,)
 
 [host_machine]
@@ -366,6 +372,8 @@ define CLEAN_LIBGJPEG
 endef
 
 define SIMPLE_CARGO_BUILD
+	IPHONEOS_DEPLOYMENT_TARGET=$(APPLE_IOS_VERSION_MIN) \
+	MACOSX_DEPLOYMENT_TARGET=$(APPLE_MACOS_VERSION_MIN) \
 	cargo build \
 	--manifest-path $(PROJECT_DIR)/Cargo.toml \
 	--release;
@@ -381,6 +389,8 @@ define CARGO_BUILD
 		--target $(CARGO_TARGET) \
 		--release; \
 	else \
+		IPHONEOS_DEPLOYMENT_TARGET=$(APPLE_IOS_VERSION_MIN) \
+		MACOSX_DEPLOYMENT_TARGET=$(APPLE_MACOS_VERSION_MIN) \
 		cargo build \
 		--manifest-path $(PROJECT_DIR)/Cargo.toml \
 		--target $(CARGO_TARGET) \
@@ -566,7 +576,7 @@ define NEW_APPLE_CMAKE_BUILD
 $4/$(CMAKE_CACHE): DEP_SOURCE_DIR := $(DEPS_MODULES_DIR)/$3
 $4/$(CMAKE_CACHE): DEP_BUILD_DIR := $4
 $4/$(CMAKE_CACHE): DEP_ARTIFACTS_DIR := $$($1_DEPS_ARTIFACTS_DIR)
-$4/$(CMAKE_CACHE): CMAKE_BUILD_SETTINGS := -GXcode -DCMAKE_MACOSX_BUNDLE=NO
+$4/$(CMAKE_CACHE): CMAKE_BUILD_SETTINGS := -GXcode -DCMAKE_MACOSX_BUNDLE=NO -DDEPLOYMENT_TARGET=$(if $(findstring DARWIN,$1),$(APPLE_MACOS_VERSION_MIN),$(APPLE_IOS_VERSION_MIN))
 $4/$(CMAKE_CACHE): PLATFORM := -DPLATFORM=$$($1_ARCH)
 $4/$(CMAKE_CACHE): TOOLCHAIN_FILE := -DCMAKE_TOOLCHAIN_FILE=$(PWD)/$(DEPS_MODULES_DIR)/ios-cmake/ios.toolchain.cmake
 $4/$(CMAKE_CACHE):

--- a/dotlottie-ffi/Cargo.toml
+++ b/dotlottie-ffi/Cargo.toml
@@ -6,10 +6,6 @@ build = "build.rs"
 
 [profile.release]
 lto = true
-opt-level = "z"
-strip = true 
-codegen-units = 1
-panic = "abort"
 
 [lib]
 crate-type = ["staticlib", "cdylib", "rlib"]


### PR DESCRIPTION
Changes:
- Updated GitHub Actions to use the latest macOS version since macOS-12 has been deprecated.
- Ensured that native dependencies, and dotLottie-rs are built for the same minimum OS version. This is a potential fix for the issue: https://github.com/LottieFiles/dotlottie-ios/issues/9