### PR TITLE
fix: 🐛 memory leak when LottieRenderer is created

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug demo-player",
+      "program": "${workspaceFolder}/examples/demo-player/target/debug/demo-player",
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -815,15 +815,13 @@ impl DotLottieRuntime {
         let theme_exists = self
             .manifest()
             .and_then(|manifest| manifest.themes.as_ref())
-            .map_or(false, |themes| {
-                themes.iter().any(|theme| theme.id == theme_id)
-            });
+            .is_some_and(|themes| themes.iter().any(|theme| theme.id == theme_id));
 
         if !theme_exists {
             return false;
         }
 
-        let can_set_theme = self.manifest().map_or(false, |manifest| {
+        let can_set_theme = self.manifest().is_some_and(|manifest| {
             manifest.animations.iter().any(|animation| {
                 animation.themes.is_none()
                     || animation
@@ -1584,11 +1582,11 @@ impl DotLottiePlayer {
     }
 
     pub fn clear(&self) {
-        self.player.write().unwrap().clear();
+        self.player.write().unwrap().clear()
     }
 
     pub fn set_config(&self, config: Config) {
-        self.player.write().unwrap().set_config(config);
+        self.player.write().unwrap().set_config(config)
     }
 
     pub fn speed(&self) -> f32 {
@@ -1672,7 +1670,7 @@ impl DotLottiePlayer {
     }
 
     pub fn subscribe(&self, observer: Arc<dyn Observer>) {
-        self.player.write().unwrap().subscribe(observer);
+        self.player.write().unwrap().subscribe(observer)
     }
 
     pub fn state_machine_subscribe(&self, observer: Arc<dyn StateMachineObserver>) -> bool {
@@ -1709,7 +1707,7 @@ impl DotLottiePlayer {
     }
 
     pub fn unsubscribe(&self, observer: &Arc<dyn Observer>) {
-        self.player.write().unwrap().unsubscribe(observer);
+        self.player.write().unwrap().unsubscribe(observer)
     }
 
     pub fn set_theme(&self, theme_id: &str) -> bool {

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -83,9 +83,14 @@ pub trait LottieRenderer {
 
 impl dyn LottieRenderer {
     pub fn new<R: Renderer>(renderer: R) -> Box<Self> {
+        let mut renderer = renderer;
+        let background_shape = R::Shape::default();
+
+        renderer.push(Drawable::Shape(&background_shape)).unwrap();
+
         Box::new(LottieRendererImpl {
             animation: R::Animation::default(),
-            background_shape: R::Shape::default(),
+            background_shape,
             renderer,
             buffer: vec![],
             width: 0,


### PR DESCRIPTION
Context:
The background shape is destroyed only when it is owned by the canvas and the canvas is cleared or destroyed

Leaks report: 
```
Process:         demo-player [20165]
Path:            /Users/USER/*/demo-player
Load Address:    0x1029d8000
Identifier:      demo-player
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [20164]

Date/Time:       2025-01-11 22:59:19.593 +0700
Launch Time:     2025-01-11 22:59:06.200 +0700
OS Version:      macOS 14.5 (23F79)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.2 (16C5032a)

Physical footprint:         19.4M
Physical footprint (peak):  36.2M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 20165: 196 nodes malloced for 15 KB
Process 20165: 3 leaks for 288 total leaked bytes.

STACK OF 1 INSTANCE OF 'ROOT CYCLE: <tvg::Shape>':
17  dyld                                  0x1925220e0 start + 2360
16  demo-player                           0x1029daaa4 main + 36
15  demo-player                           0x1029daca0 std::rt::lang_start::h75a238737c88dd58 + 84  rt.rs:194
14  demo-player                           0x102ae1770 std::rt::lang_start_internal::hacda2dedffd2edb4 + 1092
13  demo-player                           0x1029dacd4 std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::hc2f6f33d619d76e3 + 28  rt.rs:195
12  demo-player                           0x1029db1c0 std::sys::backtrace::__rust_begin_short_backtrace::h8cba6c8ea14dda1e + 24  backtrace.rs:160
11  demo-player                           0x1029daae8 core::ops::function::FnOnce::call_once::h1d8b2a493de320fa + 20  function.rs:250
10  demo-player                           0x1029da374 demo_player::main::h313c68b1f303524b + 40  main.rs:8
9   demo-player                           0x102a1cb44 dotlottie_rs::dotlottie_player::DotLottiePlayer::new::hde37addf97951b61 + 32
8   demo-player                           0x102a1a844 dotlottie_rs::dotlottie_player::DotLottiePlayerContainer::new::h9d6de976900f60e3 + 36
7   demo-player                           0x102a18514 dotlottie_rs::dotlottie_player::DotLottieRuntime::new::h5352e0300c55ee1a + 132
6   demo-player                           0x1029db2c4 dotlottie_rs::dotlottie_player::DotLottieRuntime::with_renderer::h7791b0e8b5bf6c54 + 180
5   demo-player                           0x102a50e8c _$LT$dyn$u20$dotlottie_rs..lottie_renderer..LottieRenderer$GT$::new::h150b8af904f5c722 + 128
4   demo-player                           0x1029f9a30 _$LT$dotlottie_rs..lottie_renderer..thorvg..TvgShape$u20$as$u20$core..default..Default$GT$::default::hfca35332b0732286 + 12
3   demo-player                           0x102ba0774 tvg_shape_new + 20  tvgCapi.cpp:273
2   demo-player                           0x102b096fc tvg::Shape::gen() + 24  tvgShape.cpp:48
1   libc++abi.dylib                       0x192863bd4 operator new(unsigned long) + 32
0   libsystem_malloc.dylib                0x1926e4a68 _malloc_zone_malloc_instrumented_or_legacy + 148 
====
    3 (288 bytes) ROOT CYCLE: <tvg::Shape 0x14b8042d0> [48]
       1 (144 bytes) ROOT CYCLE: <malloc in tvg::Paint::Paint() 0x14b804300> [144]
          CYCLE BACK TO <tvg::Shape 0x14b8042d0> [48]
       1 (96 bytes) ROOT CYCLE: <malloc in tvg::Shape::gen() 0x14b804390> [96]
          CYCLE BACK TO <tvg::Shape 0x14b8042d0> [48]

```