### PR TITLE
fix: return unadjusted frame count from total_frames() 

### DIFF
--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -569,10 +569,7 @@ impl DotLottieRuntime {
     }
 
     pub fn total_frames(&self) -> f32 {
-        match self.renderer.total_frames() {
-            Ok(total_frames) => total_frames,
-            Err(_) => 0.0,
-        }
+        self.renderer.total_frames().unwrap_or(0.0)
     }
 
     pub fn duration(&self) -> f32 {

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -205,15 +205,15 @@ impl DotLottieRuntime {
     fn end_frame(&self) -> f32 {
         if !self.config.marker.is_empty() {
             if let Some((time, duration)) = self.markers.get(&self.config.marker) {
-                return (time + duration).min(self.total_frames());
+                return (time + duration).min(self.total_frames() - 1.0);
             }
         }
 
         if self.config.segment.len() == 2 {
-            return self.config.segment[1].min(self.total_frames());
+            return self.config.segment[1].min(self.total_frames() - 1.0);
         }
 
-        self.total_frames()
+        self.total_frames() - 1.0
     }
 
     pub fn intersect(&self, x: f32, y: f32, layer_name: &str) -> bool {
@@ -570,7 +570,7 @@ impl DotLottieRuntime {
 
     pub fn total_frames(&self) -> f32 {
         match self.renderer.total_frames() {
-            Ok(total_frames) => total_frames - 1.0,
+            Ok(total_frames) => total_frames,
             Err(_) => 0.0,
         }
     }

--- a/dotlottie-rs/src/state_machine_engine/actions/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/actions/mod.rs
@@ -372,7 +372,7 @@ impl ActionTrait for Action {
                                 let percentage = engine.get_numeric_input(value);
                                 if let Some(percentage) = percentage {
                                     let new_perc = percentage / 100.0;
-                                    let frame = player.total_frames() * new_perc;
+                                    let frame = (player.total_frames() - 1.0) * new_perc;
                                     player.set_frame(frame);
                                 }
 
@@ -380,7 +380,7 @@ impl ActionTrait for Action {
                             }
                             StringNumber::F32(value) => {
                                 let new_perc = value / 100.0;
-                                let frame = player.total_frames() * new_perc;
+                                let frame = (player.total_frames() - 1.0) * new_perc;
                                 player.set_frame(frame);
                             }
                         }

--- a/dotlottie-rs/tests/frame_interpolation.rs
+++ b/dotlottie-rs/tests/frame_interpolation.rs
@@ -36,7 +36,6 @@ mod tests {
 
         assert!(player.load_dotlottie_data(include_bytes!("fixtures/emoji.lottie"), WIDTH, HEIGHT));
 
-        let total_frames = player.total_frames();
         let mut rendered_frames: Vec<f32> = vec![];
 
         while !player.is_complete() {
@@ -49,9 +48,15 @@ mod tests {
         }
 
         assert!(!rendered_frames.is_empty());
-        assert_eq!({ rendered_frames.len() }, total_frames as usize);
+        assert_eq!(
+            rendered_frames.len(),
+            (player.total_frames() - 1.0) as usize
+        );
 
-        assert_eq!(rendered_frames[rendered_frames.len() - 1], total_frames);
+        assert_eq!(
+            rendered_frames[rendered_frames.len() - 1],
+            player.total_frames() - 1.0
+        );
 
         for (i, frame) in rendered_frames.iter().enumerate() {
             assert!(*frame == frame.floor(), "Frame {} is interpolated.", i);

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -106,7 +106,7 @@ mod tests {
         assert!(!player.is_playing(), "Expected player to not be playing");
 
         assert!(
-            player.current_frame() == player.total_frames(),
+            player.current_frame() == player.total_frames() - 1.0,
             "Expected current frame to be total frames"
         );
 

--- a/dotlottie-rs/tests/play_mode.rs
+++ b/dotlottie-rs/tests/play_mode.rs
@@ -57,8 +57,8 @@ mod play_mode_tests {
                 Mode::Reverse => {
                     assert_eq!(
                         player.current_frame(),
-                        player.total_frames(),
-                        "Expected current frame to be total frames"
+                        player.total_frames() - 1.0,
+                        "Expected current frame to be end frame"
                     );
                 }
                 Mode::Bounce => {
@@ -71,8 +71,8 @@ mod play_mode_tests {
                 Mode::ReverseBounce => {
                     assert_eq!(
                         player.current_frame(),
-                        player.total_frames(),
-                        "Expected current frame to be total frames"
+                        player.total_frames() - 1.0,
+                        "Expected current frame to be end frame"
                     );
                 }
             }
@@ -107,7 +107,7 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames.len() >= player.total_frames() as usize,
+            rendered_frames.len() >= (player.total_frames() - 1.0) as usize,
             "Expected rendered frames to be greater than or equal to total frames"
         );
 
@@ -121,7 +121,7 @@ mod play_mode_tests {
         }
 
         assert_eq!(
-            player.total_frames(),
+            player.total_frames() - 1.0,
             prev_frame,
             "Expected last frame to be total frames"
         );
@@ -156,11 +156,11 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames.len() >= player.total_frames() as usize,
+            rendered_frames.len() >= (player.total_frames() - 1.0) as usize,
             "Expected rendered frames to be greater than or equal to total frames"
         );
 
-        let mut prev_frame = player.total_frames();
+        let mut prev_frame = player.total_frames() - 1.0;
         for frame in rendered_frames {
             assert!(
                 frame <= prev_frame,
@@ -202,14 +202,14 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames.len() >= player.total_frames() as usize,
+            rendered_frames.len() >= (player.total_frames() - 1.0) as usize,
             "Expected rendered frames to be greater than or equal to total frames"
         );
 
         let mut frame_idx = 0;
 
         while frame_idx < rendered_frames.len()
-            && rendered_frames[frame_idx] < player.total_frames()
+            && rendered_frames[frame_idx] < player.total_frames() - 1.0
         {
             assert!(
                 rendered_frames[frame_idx] <= rendered_frames[frame_idx + 1],
@@ -219,7 +219,7 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames[frame_idx] == player.total_frames(),
+            rendered_frames[frame_idx] == player.total_frames() - 1.0,
             "Expected frame to be total frames at index {}",
             frame_idx
         );
@@ -268,7 +268,7 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames.len() >= player.total_frames() as usize,
+            rendered_frames.len() >= (player.total_frames() - 1.0) as usize,
             "Expected rendered frames to be greater than or equal to total frames"
         );
 
@@ -289,7 +289,7 @@ mod play_mode_tests {
         );
 
         while frame_idx < rendered_frames.len()
-            && rendered_frames[frame_idx] < player.total_frames()
+            && rendered_frames[frame_idx] < player.total_frames() - 1.0
         {
             assert!(
                 rendered_frames[frame_idx] <= rendered_frames[frame_idx + 1],
@@ -299,7 +299,7 @@ mod play_mode_tests {
         }
 
         assert!(
-            rendered_frames[frame_idx] == player.total_frames(),
+            rendered_frames[frame_idx] == player.total_frames() - 1.0,
             "Expected frame to be total frames at index {}",
             frame_idx
         );

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -67,7 +67,7 @@ mod tests {
             assert!(player.is_playing(), "Animation should be playing");
 
             let (start_frame, end_frame) = if player.config().segment.is_empty() {
-                (0.0, player.total_frames())
+                (0.0, player.total_frames() - 1.0)
             } else {
                 (player.config().segment[0], player.config().segment[1])
             };


### PR DESCRIPTION
Changes:
- Made total_frames() return the actual total frame count without adjustments
- Consistently applied the -1.0 offset where needed (end frame calculations, bounds checking)
- Updated all tests to properly check frame boundaries and end conditions
- Ensured all animation modes (normal, reverse, bounce) use consistent frame boundaries