### PR TITLE
feat: add support for Apple visionOS & tvOS

### DIFF
--- a/.mac-setup.sh
+++ b/.mac-setup.sh
@@ -63,11 +63,16 @@ if [[ "${TARGET}" == "android" || "${TARGET}" == "all" ]]; then
   brew install android-ndk
 fi
 
-echo "Installing Rust nightly..."
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
+echo "Checking if Rust nightly is already installed..."
+if ! rustup toolchain list | grep -q nightly; then
+  echo "Installing Rust nightly..."
+  rustup toolchain install nightly
+  rustup component add rust-src --toolchain nightly
+else
+  echo "Rust nightly is already installed. Skipping installation."
+fi
 
-rustup component add rust-src
+rustup component add rust-src --toolchain stable
 
 echo
 echo "Installing rust target(s) ..."


### PR DESCRIPTION
Added targets:
* Apple tvOS on ARM64.
* Apple tvOS Simulator on ARM64.
* Apple visionOS on ARM64.
* Apple visionOS Simulator on ARM64.

Build artifacts: https://github.com/LottieFiles/dotlottie-rs/actions/runs/15490859744
