### PR TITLE
feat: target Android API level 21 for wider device support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,6 @@ jobs:
 
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: ningenMe/setup-rustup@v1.1.0
-
       - name: Install Make
         run: brew install make
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ANDROID := android
 
 ANDROID_BUILD_PLATFORM := $(BUILD_PLATFORM)-x86_64
 ANDROID_NDK_HOME ?= /opt/homebrew/share/android-ndk
-ANDROID_API_VERSION ?= 24
+ANDROID_API_VERSION ?= 21
 
 # Android Tool chain
 AR := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(ANDROID_BUILD_PLATFORM)/bin/llvm-ar
@@ -194,6 +194,11 @@ ZLIB_LDFLAGS := -Wl,--undefined-version
 CORE_SRC := $(shell find $(CORE)/src -name "*.rs")
 RUNTIME_FFI_SRC := $(shell find $(RUNTIME_FFI)/src -name "*.rs") $(shell find $(RUNTIME_FFI)/src -name "*.udl")
 
+AARCH64_LINUX_ANDROID_CPP_ARGS := []
+ARMV7_LINUX_ANDROIDEABI_CPP_ARGS := ['-Dfseeko=fseek', '-Dftello=ftell', '-D_FILE_OFFSET_BITS=32']
+X86_64_LINUX_ANDROID_CPP_ARGS := []
+I686_LINUX_ANDROID_CPP_ARGS := ['-Dfseeko=fseek', '-Dftello=ftell', '-D_FILE_OFFSET_BITS=32']
+
 # Helper functions
 define ANDROID_CROSS_FILE
 [binaries]
@@ -204,6 +209,9 @@ ranlib     = '$(RANLIB)'
 ld         = '$(LD)'
 strip      = '$(STRIP)'
 pkg-config = 'pkg-config'
+
+[built-in options]
+cpp_args = $(CPP_ARGS)
 
 [host_machine]
 system = '$(ANDROID)'
@@ -600,6 +608,7 @@ $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): SYSROOT := $(ANDROID_NDK_HOM
 $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): CPP := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(ANDROID_BUILD_PLATFORM)/bin/$$($1_ARCH)$(ANDROID_API_VERSION)-clang++
 $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): CPU_FAMILY := $$($1_CPU_FAMILY)
 $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): CPU := $$($1_CPU)
+$$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): CPP_ARGS := $$($1_CPP_ARGS)
 $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE): export OUTPUT_FILE := $$(ANDROID_CROSS_FILE)
 $$($1_THORVG_DEP_BUILD_DIR)/../$(MESON_CROSS_FILE):
 	$$(CREATE_OUTPUT_FILE)

--- a/dotlottie-ffi/assets/android/build.gradle.kts
+++ b/dotlottie-ffi/assets/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
related https://github.com/LottieFiles/dotlottie-android/issues/65

> Note: Building for 32-bit ABIs is broken when targeting API level 21. This solution has been applied: https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and


Build artifacts: https://github.com/LottieFiles/dotlottie-rs/actions/runs/15376509098/job/43261874759