### PR TITLE
refactor: simplify error handling and remove unnecessary error details

### DIFF
--- a/.changeset/refactor_simplify_error_handling_and_remove_unnecessary_error_details.md
+++ b/.changeset/refactor_simplify_error_handling_and_remove_unnecessary_error_details.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# refactor: simplify error handling and remove unnecessary error details

--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -13,13 +13,11 @@ thorvg-v1 = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-thiserror = "1.0.48"
 instant = { version = "0.1.13", features = ["inaccurate"] }
 serde_json = "1.0.107"
 serde = { version = "1.0.188", features = ["derive"] }
 zip = { version = "2.2.0", default-features = false, features = ["deflate"] }
 base64 = "0.22.1"
-json = "0.12.4"
 jzon = "0.12.5"
 spin = "0.9"
 url = "2.5.4"

--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -2193,10 +2193,10 @@ impl DotLottiePlayer {
                         let tmp_sm = state_machine.as_ref().unwrap();
 
                         match error {
-                            StateMachineEngineError::ParsingError { reason } => tmp_sm.observe_on_error(&reason),
-                            StateMachineEngineError::CreationError { reason } => tmp_sm.observe_on_error(&reason),
-                            StateMachineEngineError::SecurityCheckErrorMultipleGuardlessTransitions { state_name } => tmp_sm.observe_on_error(&state_name),
-                            StateMachineEngineError::SecurityCheckErrorDuplicateStateName { state_name } => tmp_sm.observe_on_error(&state_name),
+                            StateMachineEngineError::ParsingError => tmp_sm.observe_on_error("ParsingError"),
+                            StateMachineEngineError::CreationError => tmp_sm.observe_on_error("CreationError"),
+                            StateMachineEngineError::SecurityCheckErrorMultipleGuardlessTransitions => tmp_sm.observe_on_error("SecurityCheckErrorMultipleGuardlessTransitions"),
+                            StateMachineEngineError::SecurityCheckErrorDuplicateStateName => tmp_sm.observe_on_error("SecurityCheckErrorDuplicateStateName"),
                             _ => {}
                         }
                     }

--- a/dotlottie-rs/src/fms/dolottie_manager.rs
+++ b/dotlottie-rs/src/fms/dolottie_manager.rs
@@ -148,9 +148,7 @@ impl DotLottieManager {
             }
         }
 
-        Err(DotLottieError::AnimationNotFound {
-            animation_id: animation_id.to_string(),
-        })
+        Err(DotLottieError::AnimationNotFound)
     }
 
     pub fn contains_animation(&self, animation_id: &str) -> Result<bool, DotLottieError> {
@@ -197,9 +195,7 @@ impl DotLottieManager {
 
                 Ok(animation)
             } else {
-                Err(DotLottieError::AnimationNotFound {
-                    animation_id: animation_id.to_string(),
-                })
+                Err(DotLottieError::AnimationNotFound)
             }
         }
     }
@@ -213,9 +209,7 @@ impl DotLottieManager {
             }
         }
 
-        Err(DotLottieError::AnimationNotFound {
-            animation_id: animation_id.to_string(),
-        })
+        Err(DotLottieError::AnimationNotFound)
     }
 
     ///

--- a/dotlottie-rs/src/fms/errors.rs
+++ b/dotlottie-rs/src/fms/errors.rs
@@ -1,29 +1,12 @@
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum DotLottieError {
-    #[error("Failed to open archive")]
     ArchiveOpenError,
-
-    #[error("State machine error")]
-    StateMachineError { reason: String },
-
-    #[error("Unable to find the file: {file_name}")]
-    FileFindError { file_name: String },
-
-    #[error("Unable to read the contents")]
+    StateMachineError,
+    FileFindError,
     ReadContentError,
-
-    #[error("Unable to lock the animations mutex")]
     MutexLockError,
-
-    #[error("Animation not found")]
-    AnimationNotFound { animation_id: String },
-
-    #[error("No animations found in dotLottie file")]
+    AnimationNotFound,
     AnimationsNotFound,
-
-    #[error("No manifest found")]
     ManifestNotFound,
-
-    #[error("Invalid UTF-8")]
     InvalidUtf8Error,
 }

--- a/dotlottie-rs/src/fms/functions.rs
+++ b/dotlottie-rs/src/fms/functions.rs
@@ -36,9 +36,7 @@ pub fn get_animation(
     } else if let Ok(data) = read_zip_file(&mut archive, &lot_path) {
         data
     } else {
-        return Err(DotLottieError::FileFindError {
-            file_name: format!("{} or {}", json_path, lot_path),
-        });
+        return Err(DotLottieError::FileFindError);
     };
 
     let animation_data =
@@ -68,11 +66,9 @@ pub fn get_animation(
                         .to_string()
                         .replace('"', "");
 
-                    let mut result = archive.by_name(&image_asset_filename).map_err(|_| {
-                        DotLottieError::FileFindError {
-                            file_name: image_asset_filename,
-                        }
-                    })?;
+                    let mut result = archive
+                        .by_name(&image_asset_filename)
+                        .map_err(|_| DotLottieError::FileFindError)?;
 
                     let mut content = Vec::new();
 
@@ -104,12 +100,9 @@ pub fn get_manifest(bytes: &[u8]) -> Result<Manifest, DotLottieError> {
     let mut archive =
         ZipArchive::new(io::Cursor::new(bytes)).map_err(|_| DotLottieError::ArchiveOpenError)?;
 
-    let mut result =
-        archive
-            .by_name("manifest.json")
-            .map_err(|_| DotLottieError::FileFindError {
-                file_name: String::from("manifest.json"),
-            })?;
+    let mut result = archive
+        .by_name("manifest.json")
+        .map_err(|_| DotLottieError::FileFindError)?;
 
     let mut content = Vec::new();
     result
@@ -140,9 +133,7 @@ pub fn get_theme(bytes: &[u8], theme_id: &str) -> Result<String, DotLottieError>
     let mut content = Vec::new();
     archive
         .by_name(&search_file_name)
-        .map_err(|_| DotLottieError::FileFindError {
-            file_name: search_file_name,
-        })?
+        .map_err(|_| DotLottieError::FileFindError)?
         .read_to_end(&mut content)
         .map_err(|_| DotLottieError::ReadContentError)?;
 
@@ -157,9 +148,7 @@ pub fn get_state_machine(bytes: &[u8], state_machine_id: &str) -> Result<String,
     let mut content = Vec::new();
     archive
         .by_name(&search_file_name)
-        .map_err(|_| DotLottieError::FileFindError {
-            file_name: search_file_name,
-        })?
+        .map_err(|_| DotLottieError::FileFindError)?
         .read_to_end(&mut content)
         .map_err(|_| DotLottieError::ReadContentError)?;
 
@@ -173,9 +162,7 @@ fn read_zip_file(
 ) -> Result<Vec<u8>, DotLottieError> {
     let mut file = archive
         .by_name(path)
-        .map_err(|_| DotLottieError::FileFindError {
-            file_name: path.to_string(),
-        })?;
+        .map_err(|_| DotLottieError::FileFindError)?;
 
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -131,8 +131,7 @@ impl<R: Renderer> LottieRendererImpl<R> {
     fn resize_buffer(&mut self, width: u32, height: u32) -> Result<(), LottieRendererError> {
         let buffer_size = (width as u64)
             .checked_mul(height as u64)
-            .ok_or_else(|| LottieRendererError::InvalidArgument)?
-            as usize;
+            .ok_or(LottieRendererError::InvalidArgument)? as usize;
 
         if self.buffer.capacity() >= buffer_size {
             self.buffer.clear();

--- a/dotlottie-rs/src/lottie_renderer/renderer.rs
+++ b/dotlottie-rs/src/lottie_renderer/renderer.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt};
+use core::fmt;
 
 pub enum ColorSpace {
     ABGR8888,
@@ -13,7 +13,7 @@ pub enum Drawable<'d, R: Renderer> {
 }
 
 pub trait Shape: Default {
-    type Error: Error;
+    type Error: fmt::Debug;
 
     fn fill(&mut self, color: (u8, u8, u8, u8)) -> Result<(), Self::Error>;
 
@@ -31,7 +31,7 @@ pub trait Shape: Default {
 }
 
 pub trait Animation: Default {
-    type Error: Error;
+    type Error: fmt::Debug;
 
     fn load_data(&mut self, data: &str, mimetype: &str, copy: bool) -> Result<(), Self::Error>;
 
@@ -74,7 +74,7 @@ pub trait Animation: Default {
 pub trait Renderer: Sized + 'static {
     type Shape: Shape<Error = Self::Error>;
     type Animation: Animation<Error = Self::Error>;
-    type Error: fmt::Debug + Error + 'static;
+    type Error: fmt::Debug + 'static;
 
     fn set_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) -> Result<(), Self::Error>;
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -9,7 +9,6 @@ use instant::Instant;
 use spin::Mutex;
 
 use std::{ffi::CString, ptr, result::Result};
-use thiserror::Error;
 
 use super::{Animation, ColorSpace, Drawable, Renderer, Shape};
 
@@ -21,19 +20,13 @@ mod tvg {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum TvgError {
-    #[error("Invalid argument")]
     InvalidArgument,
-    #[error("Insufficient condition")]
     InsufficientCondition,
-    #[error("Failed allocation")]
     FailedAllocation,
-    #[error("Memory corruption")]
     MemoryCorruption,
-    #[error("Not supported")]
     NotSupported,
-    #[error("Unknown error")]
     Unknown,
 }
 
@@ -94,12 +87,11 @@ pub struct TvgRenderer {
 
 impl TvgRenderer {
     pub fn new(engine_method: TvgEngine, threads: u32) -> Self {
-        
         let mut count = RENDERERS_COUNT.lock();
-        
+
         #[cfg(feature = "thorvg-v0")]
         let engine = engine_method.into();
-        
+
         if *count == 0 {
             #[cfg(feature = "thorvg-v0")]
             {
@@ -204,10 +196,14 @@ impl Drop for TvgRenderer {
 
         if *count == 0 {
             #[cfg(feature = "thorvg-v0")]
-            unsafe { tvg::tvg_engine_term(self.engine_method) };
+            unsafe {
+                tvg::tvg_engine_term(self.engine_method)
+            };
 
             #[cfg(feature = "thorvg-v1")]
-            unsafe { tvg::tvg_engine_term() };
+            unsafe {
+                tvg::tvg_engine_term()
+            };
         }
     }
 }

--- a/dotlottie-rs/src/state_machine_engine/actions/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/actions/mod.rs
@@ -1,5 +1,4 @@
 use open_url::OpenUrlMode;
-use thiserror::Error;
 
 use serde::Deserialize;
 use utils::NativeOpenUrl;
@@ -15,10 +14,9 @@ pub mod open_url;
 mod utils;
 mod whitelist;
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum StateMachineActionError {
-    #[error("Error executing action: {0}")]
-    ExecuteError(String),
+    ExecuteError,
 }
 
 pub trait ActionTrait {
@@ -235,16 +233,11 @@ impl ActionTrait for Action {
                 match read_lock {
                     Ok(player) => {
                         if !player.set_theme(value) {
-                            return Err(StateMachineActionError::ExecuteError(format!(
-                                "Error loading theme: {}",
-                                value
-                            )));
+                            return Err(StateMachineActionError::ExecuteError);
                         }
                     }
                     Err(_) => {
-                        return Err(StateMachineActionError::ExecuteError(
-                            "Error getting read lock on player".to_string(),
-                        ));
+                        return Err(StateMachineActionError::ExecuteError);
                     }
                 }
                 Ok(())
@@ -261,16 +254,11 @@ impl ActionTrait for Action {
                             .replace("$y", &engine.pointer_management.pointer_y.to_string());
 
                         if !player.set_slots(&value) {
-                            return Err(StateMachineActionError::ExecuteError(format!(
-                                "Error loading theme data: {}",
-                                value
-                            )));
+                            return Err(StateMachineActionError::ExecuteError);
                         }
                     }
                     Err(_) => {
-                        return Err(StateMachineActionError::ExecuteError(
-                            "Error getting read lock on player".to_string(),
-                        ));
+                        return Err(StateMachineActionError::ExecuteError);
                     }
                 }
 
@@ -291,18 +279,13 @@ impl ActionTrait for Action {
                     }
 
                     if let Ok(false) | Err(_) = whitelist.is_allowed(url) {
-                        return Err(StateMachineActionError::ExecuteError(
-                            "URL contained inside the Action has not been whitelisted.".to_string(),
-                        ));
+                        return Err(StateMachineActionError::ExecuteError);
                     }
                 }
 
                 match open_url_config.mode {
                     OpenUrlMode::Deny => {
-                        return Err(StateMachineActionError::ExecuteError(
-                            "Opening URLs has been denied by the player's configuration."
-                                .to_string(),
-                        ));
+                        return Err(StateMachineActionError::ExecuteError);
                     }
                     OpenUrlMode::Interaction => {
                         if let Some(Event::PointerDown { .. }) = interaction {
@@ -336,24 +319,18 @@ impl ActionTrait for Action {
                             if let Some(frame) = frame {
                                 player.set_frame(frame);
                             } else {
-                                return Err(StateMachineActionError::ExecuteError(
-                                    "Error getting value from input.".to_string(),
-                                ));
+                                return Err(StateMachineActionError::ExecuteError);
                             }
                             return Ok(());
                         } else {
-                            return Err(StateMachineActionError::ExecuteError(
-                                "Error getting read lock on player".to_string(),
-                            ));
+                            return Err(StateMachineActionError::ExecuteError);
                         }
                     }
                     StringNumber::F32(value) => {
                         if let Ok(player) = read_lock {
                             player.set_frame(*value);
                         } else {
-                            return Err(StateMachineActionError::ExecuteError(
-                                "Error getting read lock on player".to_string(),
-                            ));
+                            return Err(StateMachineActionError::ExecuteError);
                         }
                     }
                 }
@@ -386,9 +363,7 @@ impl ActionTrait for Action {
                         }
                     }
                     Err(_) => {
-                        return Err(StateMachineActionError::ExecuteError(
-                            "Error getting read lock on player".to_string(),
-                        ));
+                        return Err(StateMachineActionError::ExecuteError);
                     }
                 }
 

--- a/dotlottie-rs/src/state_machine_engine/errors.rs
+++ b/dotlottie-rs/src/state_machine_engine/errors.rs
@@ -1,5 +1,4 @@
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum StateMachineError {
-    #[error("Failed to parse JSON state machine definition")]
-    ParsingError { reason: String },
+    ParsingError,
 }

--- a/dotlottie-rs/src/state_machine_engine/interactions/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/interactions/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use serde::Deserialize;
 
 use super::actions::Action;
@@ -53,73 +51,6 @@ pub enum Interaction {
         state_name: String,
         actions: Vec<Action>,
     },
-}
-
-impl Display for Interaction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PointerUp {
-                layer_name,
-                actions,
-            } => f
-                .debug_struct("PointerUp")
-                .field("layer_name", layer_name)
-                .field("action", actions)
-                .finish(),
-            Self::PointerDown {
-                layer_name,
-                actions,
-            } => f
-                .debug_struct("PointerDown")
-                .field("layer_name", layer_name)
-                .field("action", actions)
-                .finish(),
-            Self::PointerEnter {
-                layer_name,
-                actions,
-            } => f
-                .debug_struct("PointerEnter")
-                .field("layer_name", layer_name)
-                .field("action", actions)
-                .finish(),
-            Self::PointerMove { actions } => f
-                .debug_struct("PointerMove")
-                .field("action", actions)
-                .finish(),
-            Self::PointerExit {
-                layer_name,
-                actions,
-            } => f
-                .debug_struct("PointerExit")
-                .field("layer_name", layer_name)
-                .field("action", actions)
-                .finish(),
-            Self::Click {
-                layer_name,
-                actions,
-            } => f
-                .debug_struct("Click")
-                .field("layer_name", layer_name)
-                .field("action", actions)
-                .finish(),
-            Self::OnComplete {
-                state_name,
-                actions,
-            } => f
-                .debug_struct("OnComplete")
-                .field("state_name", state_name)
-                .field("action", actions)
-                .finish(),
-            Self::OnLoopComplete {
-                state_name,
-                actions,
-            } => f
-                .debug_struct("OnLoopComplete")
-                .field("state_name", state_name)
-                .field("action", actions)
-                .finish(),
-        }
-    }
 }
 
 impl InteractionTrait for Interaction {

--- a/dotlottie-rs/src/state_machine_engine/security/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/security/mod.rs
@@ -1,42 +1,24 @@
 use std::collections::HashSet;
 
 use super::{
+    inputs::Input,
     state_machine::StringBool,
     states::StateTrait,
     transitions::{
         guard::{self, Guard},
         Transition, TransitionTrait,
     },
-    inputs::Input,
     StateMachineEngine,
 };
 
 use crate::state_machine::StringNumberBool;
 use crate::state_machine_engine::State::GlobalState;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum StateMachineEngineSecurityError {
-    #[error(
-        "The state: {} has multiple transitions without guards. This is not allowed.",
-        state_name
-    )]
-    SecurityCheckErrorMultipleGuardlessTransitions { state_name: String },
-
-    #[error(
-        "The state name: {} has been used multiple times. This is not allowed.",
-        state_name
-    )]
-    SecurityCheckErrorDuplicateStateName { state_name: String },
-
-    #[error(
-        "A guard is using a input: {} for its compareTo that does not exist or is of the wrong type. This is not allowed.",
-        input_name
-    )]
-    SecurityCheckErrorInputCompareToIsWrong { input_name: String },
-
-    #[error(
-        "Multiple GlobalState state types have been used. Only a single GlobalState is allowed."
-    )]
+    SecurityCheckErrorMultipleGuardlessTransitions,
+    SecurityCheckErrorDuplicateStateName,
+    SecurityCheckErrorInputCompareToIsWrong,
     MultipleGlobalStates,
 }
 
@@ -64,11 +46,7 @@ pub fn state_machine_state_check_pipeline(
 
         // Check if the state names are unique
         if !name_set.insert(state_name.to_string()) {
-            return Err(
-                StateMachineEngineSecurityError::SecurityCheckErrorDuplicateStateName {
-                    state_name: state_name.to_string(),
-                },
-            );
+            return Err(StateMachineEngineSecurityError::SecurityCheckErrorDuplicateStateName);
         }
 
         let transitions = state.transitions();
@@ -94,9 +72,7 @@ pub fn state_machine_state_check_pipeline(
         // Checks for multiple guardless transitions
         if count > 1 {
             return Err(
-                StateMachineEngineSecurityError::SecurityCheckErrorMultipleGuardlessTransitions {
-                    state_name: state.name(),
-                },
+                StateMachineEngineSecurityError::SecurityCheckErrorMultipleGuardlessTransitions,
             );
         }
     }
@@ -134,9 +110,7 @@ pub fn check_guards_for_existing_inputs(
                         }
 
                         if !found {
-                            return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong {
-                                            input_name: input_name.to_string(),
-                                        });
+                            return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong);
                         }
                     }
                 }
@@ -156,9 +130,7 @@ pub fn check_guards_for_existing_inputs(
                         }
 
                         if !found {
-                            return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong {
-                                            input_name: input_name.to_string(),
-                                        });
+                            return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong);
                         }
                     }
                 }
@@ -179,9 +151,7 @@ pub fn check_guards_for_existing_inputs(
                             }
 
                             if !found {
-                                return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong {
-                                                input_name: input_name.to_string(),
-                                            });
+                                return Err(StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong);
                             }
                         }
                     }
@@ -221,9 +191,7 @@ pub fn check_guards_for_existing_events(
 
                 if !found {
                     return Err(
-                        StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong {
-                            input_name: input_name.to_string(),
-                        },
+                        StateMachineEngineSecurityError::SecurityCheckErrorInputCompareToIsWrong,
                     );
                 }
             }

--- a/dotlottie-rs/src/state_machine_engine/state_machine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/state_machine/mod.rs
@@ -86,8 +86,6 @@ pub fn state_machine_parse(json: &str) -> Result<StateMachine, StateMachineError
 
     match result {
         Ok(k) => Ok(k),
-        Err(err) => Err(StateMachineError::ParsingError {
-            reason: err.to_string(),
-        }),
+        Err(_err) => Err(StateMachineError::ParsingError),
     }
 }

--- a/dotlottie-rs/src/state_machine_engine/states/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/states/mod.rs
@@ -8,10 +8,9 @@ use super::{actions::StateMachineActionError, transitions::Transition, StateMach
 
 use super::actions::{Action, ActionTrait};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum StatesError {
-    #[error("Failed to parse JSON state machine definition")]
-    ParsingError { reason: String },
+    ParsingError,
 }
 
 pub trait StateTrait {


### PR DESCRIPTION
### Description

Refactors error handling by simplifying custom error types and removing unnecessary error detail propagation. This includes:

* Dropping `thiserror` in favor of minimal manual error implementations
* Removing the unused `json` crate


### Related Issue

#107

### WASM Binary Size Impact

* **Before:** 1,861,156 bytes
* **After:** 1,848,771 bytes
* **Reduction:** **12.3 KB**