### PR TITLE
thorvg: disable partial rendering in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,7 @@ define SETUP_MESON
 		-Dengines=sw \
 		-Dbindings=capi \
 		-Dlog=false \
+		-Dpartial=false \
 		-Dthreads=false \
 		-Dstatic=true \
 		-Dextra=$(EXTRA) \


### PR DESCRIPTION
Partial rendering does not provide meaningful benefits for Lottie animations and instead increases the
binary size unnecessarily.

This should be pushed along with throvg v1.0-pre23