### PR TITLE
chore: fix maccatalyst build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ APPLE_TVOS_SIMULATOR_SDK ?= AppleTVSimulator
 APPLE_MACCATALYST := maccatalyst
 APPLE_MACCATALYST_PLATFORM := MacOSX
 APPLE_MACCATALYST_SDK := MacOSX
-APPLE_MACCATALYST_VERSION_MIN ?= 13.0
+APPLE_MACCATALYST_VERSION_MIN ?= 13.1
 
 APPLE_IOS_FRAMEWORK_TYPE := $(APPLE_IOS)
 APPLE_IOS_SIMULATOR_FRAMEWORK_TYPE := $(APPLE_IOS_SIMULATOR)
@@ -266,12 +266,12 @@ root = '/Applications/$(APPLE_XCODE_APP_NAME)/Contents/Developer/Platforms/$(SDK
 has_function_printf = true
 
 [built-in options]
-cpp_args = ['-target', '$(ARCH)-apple-ios13.0-macabi']
-cpp_link_args = ['-target', '$(ARCH)-apple-ios13.0-macabi']
+cpp_args = ['-target', '$(ARCH)-apple-ios$(APPLE_MACCATALYST_VERSION_MIN)-macabi']
+cpp_link_args = ['-target', '$(ARCH)-apple-ios$(APPLE_MACCATALYST_VERSION_MIN)-macabi']
 
 [host_machine]
 system = 'darwin'
-subsystem = '$(SUBSYSTEM)'
+subsystem = 'macos'
 kernel = 'xnu'
 cpu_family = '$(CPU_FAMILY)'
 cpu = '$(CPU)'

--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.0"
 lazy_static = "1.4"
 conan2 = "0.1"
 

--- a/dotlottie-rs/build.rs
+++ b/dotlottie-rs/build.rs
@@ -38,47 +38,6 @@ fn platform_libs() -> Vec<String> {
     }
 }
 
-// Convert Rust target to clang target for bindgen
-fn get_clang_target_from_rust_target(target: &str) -> String {
-    match target {
-        // iOS Simulator fix - convert to the format clang expects
-        "aarch64-apple-ios-sim" => "arm64-apple-ios-simulator".to_string(),
-        "x86_64-apple-ios" => "x86_64-apple-ios-simulator".to_string(),
-        
-        // Regular iOS device targets
-        "aarch64-apple-ios" => "arm64-apple-ios".to_string(),
-        
-        // macOS targets
-        "aarch64-apple-darwin" => "arm64-apple-macosx".to_string(),
-        "x86_64-apple-darwin" => "x86_64-apple-macosx".to_string(),
-        
-        // Mac Catalyst targets
-        "aarch64-apple-ios-macabi" => "arm64-apple-ios-macabi".to_string(),
-        "x86_64-apple-ios-macabi" => "x86_64-apple-ios-macabi".to_string(),
-        
-        // tvOS targets
-        "aarch64-apple-tvos" => "arm64-apple-tvos".to_string(),
-        "aarch64-apple-tvos-sim" => "arm64-apple-tvos-simulator".to_string(),
-        
-        // visionOS targets
-        "aarch64-apple-visionos" => "arm64-apple-xros".to_string(),
-        "aarch64-apple-visionos-sim" => "arm64-apple-xros-simulator".to_string(),
-        
-        // Android targets
-        "aarch64-linux-android" => "aarch64-linux-android".to_string(),
-        "armv7-linux-androideabi" => "armv7-linux-androideabi".to_string(),
-        "x86_64-linux-android" => "x86_64-linux-android".to_string(),
-        "i686-linux-android" => "i686-linux-android".to_string(),
-        
-        // WASM
-        "wasm32-unknown-emscripten" => "wasm32-unknown-emscripten".to_string(),
-        
-        // Default: just replace aarch64 with arm64 for Apple targets
-        _ if target.contains("apple") => target.replace("aarch64", "arm64"),
-        _ => target.to_string(),
-    }
-}
-
 lazy_static! {
     // The project root directory
     static ref PROJECT_DIR: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -126,7 +85,6 @@ fn register_dylib(lib: &String) {
 
 fn register_link_arg(arg: &String) {
     println!("cargo:rustc-link-arg={arg}");
-    
 }
 
 fn apply_build_settings(build_settings: &BuildSettings) {
@@ -147,13 +105,7 @@ fn main() {
         panic!("ARTIFACTS_INCLUDE_DIR and ARTIFACTS_LIB_DIR environment variables are required for thorvg-v1");
     }
 
-    // Get the target and convert it to clang format
-    let target = env::var("TARGET").expect("TARGET environment variable not set");
-    let clang_target = get_clang_target_from_rust_target(&target);
-
-    let mut builder = bindgen::Builder::default()
-        .header("wrapper.h")
-        .clang_arg(format!("--target={clang_target}"));
+    let mut builder = bindgen::Builder::default().header("wrapper.h");
 
     if is_artifacts_provided() {
         let include_dir = find_path(ARTIFACTS_INCLUDE_DIR, true);


### PR DESCRIPTION
This PR addresses build issues related to Apple target triples and updates to tooling to ensure compatibility and correctness.

### Fixes

* **Clang Error:**

  * Fixes `clang: error: invalid version number in '--target=arm64-apple-ios13.0-macabi'` by correcting target specification handling.
* **Bindgen Upgrade:**

  * Upgraded `bindgen` to [v0.72.0](https://github.com/rust-lang/rust-bindgen/releases/tag/v0.72.0), which includes:

    * Improved logic for generating correct Clang target triples via `rust_to_clang_target`.
    * Renamed `*-apple-ios-sim` targets to the new `*-apple-ios-simulator` format.
* **Meson Cross File Fix:**

  * Fixed the `subsystem` field for Mac Catalyst in the Meson cross file.

    * Changed from `maccatalyst` to the correct value `macos`.
    * Reference: [Meson Subsystem Names](https://mesonbuild.com/Reference-tables.html#subsystem-names-since-120)
