### PR TITLE
chore: suppress unused variable warnings for feature-gated code

### DIFF
--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -87,7 +87,11 @@ pub struct TvgRenderer {
 }
 
 impl TvgRenderer {
-    pub fn new(engine_method: TvgEngine, threads: u32) -> Self {
+    pub fn new(
+        #[cfg_attr(not(feature = "thorvg-v0"), allow(unused_variables))]
+        engine_method: TvgEngine,
+        threads: u32,
+    ) -> Self {
         let mut count = RENDERERS_COUNT.lock().unwrap();
 
         #[cfg(feature = "thorvg-v0")]


### PR DESCRIPTION

<img width="1932" height="302" alt="Warp 2025-07-30 15 12 45" src="https://github.com/user-attachments/assets/d62e79b6-cc82-4d67-b3dd-135eb04017eb" />


Add cfg_attr directives to handle lint warnings for variables that are only used in specific feature configurations (thorvg-v0 vs thorvg-v1).

This prevents `false` positive warnings when building with different feature flags enabled.