### PR TITLE
fix: ensure renderer updates and marks state as updated in set_slots

### DIFF
--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -491,7 +491,13 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
     fn set_slots(&mut self, slots: &str) -> Result<(), LottieRendererError> {
         self.get_animation_mut()?
             .set_slots(slots)
-            .map_err(into_lottie::<R>)
+            .map_err(into_lottie::<R>)?;
+
+        self.renderer.update().map_err(into_lottie::<R>)?;
+
+        self.updated = true;
+
+        Ok(())
     }
 
     fn set_quality(&mut self, quality: u8) -> Result<(), LottieRendererError> {


### PR DESCRIPTION
The set_slots method was not calling renderer.update() or setting the updated flag after applying slots, which could lead to stale renderer state. This change ensures the renderer is properly updated and the state is marked as changed when slots are set.