### PR TITLE
fix: preserve theme_id across state machine transitions

### DIFF
--- a/dotlottie-rs/src/dotlottie_player.rs
+++ b/dotlottie-rs/src/dotlottie_player.rs
@@ -644,7 +644,6 @@ impl DotLottieRuntime {
         self.config.use_frame_interpolation = new_config.use_frame_interpolation;
         self.config.segment = new_config.segment;
         self.config.autoplay = new_config.autoplay;
-        self.config.theme_id = new_config.theme_id;
         self.config.animation_id = new_config.animation_id;
 
         if new_config.autoplay {
@@ -870,6 +869,10 @@ impl DotLottieRuntime {
 
             if ok {
                 self.active_animation_id = animation_id.to_string();
+
+                if !self.config.theme_id.is_empty() {
+                    self.set_theme(&self.config.theme_id.clone());
+                }
             }
 
             ok
@@ -928,6 +931,7 @@ impl DotLottieRuntime {
         }
 
         self.active_theme_id.clear();
+        self.config.theme_id.clear();
 
         if theme_id.is_empty() {
             return self.renderer.set_slots("").is_ok();
@@ -970,6 +974,7 @@ impl DotLottieRuntime {
 
         if ok {
             self.active_theme_id = theme_id.to_string();
+            self.config.theme_id = theme_id.to_string();
         }
 
         ok
@@ -977,6 +982,7 @@ impl DotLottieRuntime {
 
     pub fn reset_theme(&mut self) -> bool {
         self.active_theme_id.clear();
+        self.config.theme_id.clear();
         self.renderer.set_slots("").is_ok()
     }
 

--- a/dotlottie-rs/src/state_machine_engine/states/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/states/mod.rs
@@ -117,7 +117,7 @@ impl StateTrait for State {
                             .unwrap_or(default_config.background_color),
                         layout: current_layout,
                         segment: [].to_vec(),
-                        theme_id: "".to_string(),
+                        theme_id: current_config.theme_id,
                         state_machine_id: "".to_string(),
                         animation_id: "".to_string(),
                     };


### PR DESCRIPTION
Fixes bug where theme_id was being reset when entering new states in the state machine.

Root cause: config.theme_id and active_theme_id were not kept in sync. When set_theme() was called, only active_theme_id was updated. During state transitions, the empty config.theme_id was used to create new configs, causing theme reset.

Changes:
- Sync config.theme_id with active_theme_id in set_theme()
- Clear both in reset_theme() and when clearing themes
- Preserve theme_id in state transition config creation
- Re-apply theme after load_animation() to handle cases where renderer was cleared
- Remove redundant config.theme_id assignment in set_config()