### PR TITLE
chore: fix line breaks in README mermaid flow chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ flowchart TD
   B[dotLottie-ios] --> swift+Bindings[Swift Bindings]
   C[dotLottie-android] --> kotlin+Bindings[Kotlin Bindings]
 
-  WASM+Bindings --> dotlottie-ffi[dotlottie-ffi \n 'uniffi bindings']
-  swift+Bindings --> dotlottie-ffi[dotlottie-ffi \n 'uniffi bindings']
-  kotlin+Bindings --> dotlottie-ffi[dotlottie-ffi \n 'uniffi bindings']
+  WASM+Bindings --> dotlottie-ffi[dotlottie-ffi <br> 'uniffi bindings']
+  swift+Bindings --> dotlottie-ffi[dotlottie-ffi <br> 'uniffi bindings']
+  kotlin+Bindings --> dotlottie-ffi[dotlottie-ffi <br> 'uniffi bindings']
 
-  dotlottie-ffi --> dotlottiers[dotLottie-rs \n 'Core player']
+  dotlottie-ffi --> dotlottiers[dotLottie-rs <br> 'Core player']
 
-  dotlottiers --> Thorvg[Thorvg \n 'Lottie renderer']
+  dotlottiers --> Thorvg[Thorvg <br> 'Lottie renderer']
 ```
 
 ## What is dotLottie?


### PR DESCRIPTION
Updated README to replace newline characters with HTML line breaks in mermaid flow chart

**Before:**
<img width="358" height="331" alt="image" src="https://github.com/user-attachments/assets/e5bf9156-ff14-4a47-93cc-10eec96b7e2b" />


**After:**
<img width="312" height="388" alt="image" src="https://github.com/user-attachments/assets/52c86665-51ea-4d79-837a-ada68e54ea3f" />
