### PR TITLE
fix(wasm): add tvg-webp to WASM build features

### DIFF
--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -15,7 +15,7 @@
 # ============================================================================
 
 WASM_BINDGEN_TARGET := wasm32-unknown-unknown
-WASM_BINDGEN_COMMON := tvg,tvg-sw,tvg-png,tvg-jpg,tvg-ttf,dotlottie,theming,state-machines,wasm,wasm-bindgen-api
+WASM_BINDGEN_COMMON := tvg,tvg-sw,tvg-png,tvg-jpg,tvg-webp,tvg-ttf,dotlottie,theming,state-machines,wasm,wasm-bindgen-api
 
 # sed -i behaves differently on macOS (BSD) vs Linux (GNU)
 ifeq ($(shell uname),Darwin)


### PR DESCRIPTION
WebP image assets are silently skipped when tvg-webp is absent, producing a blank canvas for animations that use WebP layers