### PR TITLE
chore: use explicit changesets instead of conventional commits

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -5,6 +5,7 @@ repo = 'dotlottie-rs'
 [package]
 versioned_files = ["dotlottie-rs/Cargo.toml"]
 changelog = "CHANGELOG.md"
+ignore_conventional_commits = true
 
 [[package.assets]]
 path = "release/dotlottie-player.darwin.tar.gz"


### PR DESCRIPTION
Changelog entries will now come from explicit changeset files (`knope document-change`) instead of being auto-generated from PR titles/commit messages