### PR TITLE
fix(wasm): add missing isdigit/tolower stubs, remove JS post-processing

### DIFF
--- a/dotlottie-rs/src/stubs.rs
+++ b/dotlottie-rs/src/stubs.rs
@@ -295,6 +295,20 @@ unsafe extern "C" fn isspace(c: i32) -> i32 {
     matches!(c as u8, b' ' | b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r') as i32
 }
 
+#[cfg_attr(feature = "wasm", no_mangle)]
+unsafe extern "C" fn isdigit(c: i32) -> i32 {
+    matches!(c as u8, b'0'..=b'9') as i32
+}
+
+#[cfg_attr(feature = "wasm", no_mangle)]
+unsafe extern "C" fn tolower(c: i32) -> i32 {
+    if (c as u8).is_ascii_uppercase() {
+        c + 32
+    } else {
+        c
+    }
+}
+
 static RAND_STATE: AtomicU32 = AtomicU32::new(12345);
 
 #[cfg_attr(feature = "wasm", no_mangle)]

--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -17,13 +17,6 @@
 WASM_BINDGEN_TARGET := wasm32-unknown-unknown
 WASM_BINDGEN_COMMON := tvg,tvg-sw,tvg-png,tvg-jpg,tvg-webp,tvg-ttf,tvg-lottie-expressions,dotlottie,theming,state-machines,wasm,wasm-bindgen-api
 
-# sed -i behaves differently on macOS (BSD) vs Linux (GNU)
-ifeq ($(shell uname),Darwin)
-  SED_I := sed -i ''
-else
-  SED_I := sed -i
-endif
-
 # Apple's system clang lacks the WebAssembly backend.  Use Homebrew LLVM if
 # present, otherwise fall back to whatever clang/clang++ is on PATH.
 LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
@@ -42,28 +35,12 @@ wasm-setup:
 	@rustup target add $(WASM_BINDGEN_TARGET)
 	@command -v wasm-pack >/dev/null 2>&1 || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-# Post-process wasm-bindgen output to fix two issues:
-# 1. wasm-bindgen >=0.2 generates `import * as __wbg_star0 from 'env'` unconditionally
-#    even when the wasm binary has no env imports.  Browsers reject the bare 'env'
-#    specifier, so strip the two dead lines.
-# 2. The default module path fallback `new URL('...wasm', import.meta.url)` causes
-#    Webpack/Next.js to try resolving the .wasm file at build time, breaking bundled
-#    consumers. Replace with a throw since DotLottieWasmLoader always provides a URL.
-define strip_env_import
-	$(SED_I) \
-		-e '/^import \* as __wbg_star0 from .env.;/d' \
-		-e '/imports\[.env.\] = __wbg_star0;/d' \
-		-e "s|module_or_path = new URL('dotlottie_rs_bg.wasm', import.meta.url);|throw new Error('WASM module URL must be provided via DotLottieWasmLoader or setWasmUrl().');|" \
-		$(1)/dotlottie_rs.js
-endef
-
 # Software-renderer build — no graphics API required
 wasm:
 	CC=$(WASM_CC) CXX=$(WASM_CXX) \
 		wasm-pack build dotlottie-rs --target web \
 		--out-dir ../release/wasm \
 		--no-default-features --features $(WASM_BINDGEN_COMMON)
-	$(call strip_env_import,release/wasm)
 
 # WebGL2 build
 wasm-webgl:
@@ -71,7 +48,6 @@ wasm-webgl:
 		wasm-pack build dotlottie-rs --target web \
 		--out-dir ../release/wasm-webgl \
 		--no-default-features --features $(WASM_BINDGEN_COMMON),tvg-gl,webgl
-	$(call strip_env_import,release/wasm-webgl)
 
 # WebGPU build — requires web_sys_unstable_apis cfg for all Gpu* web-sys types
 wasm-webgpu:
@@ -80,7 +56,6 @@ wasm-webgpu:
 		wasm-pack build dotlottie-rs --target web \
 		--out-dir ../release/wasm-webgpu \
 		--no-default-features --features $(WASM_BINDGEN_COMMON),tvg-wg,webgpu
-	$(call strip_env_import,release/wasm-webgpu)
 
 # Build all three variants
 wasm-all: wasm wasm-webgl wasm-webgpu

--- a/web-example.html
+++ b/web-example.html
@@ -290,7 +290,7 @@
 
           if (rendererType === 'sw') {
             const mod = await import('./release/wasm/dotlottie_rs.js');
-            await mod.default("./release/wasm/dotlottie_rs_bg.wasm");
+            await mod.default({ module_or_path: "./release/wasm/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
             // Grab the 2D context after the canvas is fresh.
             ctx2d = canvas.getContext('2d');
@@ -299,7 +299,7 @@
             const gl = canvas.getContext('webgl2');
             if (!gl) throw new Error('WebGL2 not available in this browser');
             const mod = await import('./release/wasm-webgl/dotlottie_rs.js');
-            await mod.default("./release/wasm-webgl/dotlottie_rs_bg.wasm");
+            await mod.default({ module_or_path: "./release/wasm-webgl/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
             // Pass the WebGL2 context into the WASM layer before loading.
             newPlayer.set_webgl_context(gl);
@@ -320,7 +320,7 @@
               alphaMode: 'premultiplied',
             });
             const mod = await import('./release/wasm-webgpu/dotlottie_rs.js');
-            await mod.default("./release/wasm-webgpu/dotlottie_rs_bg.wasm");
+            await mod.default({ module_or_path: "./release/wasm-webgpu/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
             newPlayer.set_webgpu_device(device);
             newPlayer.set_webgpu_surface(gpuCtx);


### PR DESCRIPTION
- Add `isdigit()` and `tolower()` libc stubs for wasm32 — resolves `env` module imports at link time
- Remove `strip_env_import` sed post-processing from `wasm.mk` (no longer needed)
- Fix deprecated wasm-bindgen init parameter style in `web-example.html`