### PR TITLE
fix(wasm): use straight alpha for SW renderer

### DIFF
--- a/dotlottie-rs/src/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm_bindgen_api.rs
@@ -314,7 +314,7 @@ impl DotLottiePlayerWasm {
             self.sw_buffer.resize(required, 0);
         }
         self.player
-            .set_sw_target(&mut self.sw_buffer, width, height, ColorSpace::ABGR8888)
+            .set_sw_target(&mut self.sw_buffer, width, height, ColorSpace::ABGR8888S)
             .is_ok()
     }
 
@@ -407,7 +407,7 @@ impl DotLottiePlayerWasm {
             self.sw_buffer.resize(required, 0);
             if self
                 .player
-                .set_sw_target(&mut self.sw_buffer, width, height, ColorSpace::ABGR8888)
+                .set_sw_target(&mut self.sw_buffer, width, height, ColorSpace::ABGR8888S)
                 .is_err()
             {
                 return false;


### PR DESCRIPTION
## Summary
- SW canvas was using `ABGR8888` (premultiplied alpha) but Canvas 2D `putImageData()` expects straight alpha
- Changed to `ABGR8888S` so semi-transparent pixels render at correct brightness

Resolves LottieFiles/dotlottie-web#758