### PR TITLE
fix: ignore animation property on GlobalState

### DIFF
--- a/dotlottie-rs/src/state_machine_engine/states/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/states/mod.rs
@@ -131,10 +131,7 @@ impl StateTrait for State {
                     }
                 }
             }
-            State::GlobalState {
-                entry_actions,
-                ..
-            } => {
+            State::GlobalState { entry_actions, .. } => {
                 // Perform entry actions
                 if let Some(actions) = entry_actions {
                     for action in actions {


### PR DESCRIPTION
Remove the animation field from GlobalState so the state machine doesn't load animations when entering global state.