### PR TITLE
fix: emit cargo:root= so dependents can locate ThorVG artifacts

### DIFF
--- a/dotlottie-rs/build.rs
+++ b/dotlottie-rs/build.rs
@@ -615,6 +615,8 @@ namespace tvg
 
         cc_build.compile("thorvg");
 
+        println!("cargo:root={}", out_dir.display());
+
         // Generate ThorVG C API bindings
         let bindings = bindgen::Builder::default()
             .header("deps/thorvg/src/bindings/capi/thorvg_capi.h")


### PR DESCRIPTION
## Summary
- Emit `cargo:root=` after compiling ThorVG, exposing `DEP_THORVG_ROOT` to dependent crates via Cargo's `links` metadata system
- Allows downstream build scripts to locate `libthorvg.a` and generated headers without hardcoding paths