### PR TITLE
fix: default crate-type to rlib for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ NATIVE_INCLUDE_DIR = $(NATIVE_RELEASE_DIR)/include
 native-opengl:
 	@echo "→ Building OpenGL-only variant..."
 	@echo "Building native libraries with dotlottie-rs c_api and OpenGL..."
-	cargo build --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --features c_api,tvg,tvg-gl,tvg-webp,tvg-png,tvg-jpg,tvg-ttf,tvg-threads,tvg-lottie-expressions --release
+	cargo rustc --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --crate-type cdylib --features c_api,tvg,tvg-gl,tvg-webp,tvg-png,tvg-jpg,tvg-ttf,tvg-threads,tvg-lottie-expressions --release
 
 	$(NATIVE_RELEASE)
 
@@ -171,7 +171,7 @@ native-opengl:
 native-webgpu:
 	@echo "→ Building WebGPU-only variant..."
 	@echo "Building native libraries with dotlottie-rs c_api and WebGPU..."
-	cargo build --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --features c_api,tvg,tvg-wg,tvg-webp,tvg-png,tvg-jpg,tvg-ttf,tvg-threads,tvg-lottie-expressions --release
+	cargo rustc --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --crate-type cdylib --features c_api,tvg,tvg-wg,tvg-webp,tvg-png,tvg-jpg,tvg-ttf,tvg-threads,tvg-lottie-expressions --release
 
 	$(NATIVE_RELEASE)
 
@@ -185,7 +185,7 @@ native:
 ifeq ($(OS),Windows_NT)
 	$(call WINDOWS_CARGO_BUILD,x64,x86_64-pc-windows-msvc,$(NATIVE_FEATURES),)
 else
-	cargo build --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --features $(NATIVE_FEATURES) --release
+	cargo rustc --manifest-path $(DOTLOTTIE_ROOT)/Cargo.toml --crate-type cdylib --features $(NATIVE_FEATURES) --release
 endif
 
 	$(NATIVE_RELEASE)

--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["graphics", "multimedia", "rendering"]
 links = "thorvg"
 
 [lib]
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 default = ["dotlottie", "state-machines", "theming"]

--- a/make/android.mk
+++ b/make/android.mk
@@ -158,8 +158,9 @@ android-aarch64: android-check-ndk
 	AR="$(ANDROID_AR)" \
 	RANLIB="$(ANDROID_RANLIB)" \
 	BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(ANDROID_TOOLCHAIN)/sysroot" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(RUST_TARGET_aarch64) \
 		--release \
 		--no-default-features \
@@ -187,8 +188,9 @@ android-x86_64: android-check-ndk
 	AR="$(ANDROID_AR)" \
 	RANLIB="$(ANDROID_RANLIB)" \
 	BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(ANDROID_TOOLCHAIN)/sysroot" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(RUST_TARGET_x86_64) \
 		--release \
 		--no-default-features \
@@ -216,8 +218,9 @@ android-x86: android-check-ndk
 	AR="$(ANDROID_AR)" \
 	RANLIB="$(ANDROID_RANLIB)" \
 	BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(ANDROID_TOOLCHAIN)/sysroot" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(RUST_TARGET_x86) \
 		--release \
 		--no-default-features \
@@ -245,8 +248,9 @@ android-armv7: android-check-ndk
 	AR="$(ANDROID_AR)" \
 	RANLIB="$(ANDROID_RANLIB)" \
 	BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(ANDROID_TOOLCHAIN)/sysroot" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(RUST_TARGET_armv7) \
 		--release \
 		--no-default-features \

--- a/make/apple.mk
+++ b/make/apple.mk
@@ -217,8 +217,9 @@ apple-macos-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(MACOS_SDK) -mmacosx-version-min=$(MIN_MACOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(MACOS_SDK) -mmacosx-version-min=$(MIN_MACOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$(shell xcrun -sdk macosx --find clang)" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(APPLE_TARGET_macos_arm64) \
 		--release \
 		--no-default-features \
@@ -237,8 +238,9 @@ apple-macos-x86_64: apple-check-xcode
 	CFLAGS="-arch x86_64 -isysroot $(MACOS_SDK) -mmacosx-version-min=$(MIN_MACOS_VERSION)" \
 	CXXFLAGS="-arch x86_64 -isysroot $(MACOS_SDK) -mmacosx-version-min=$(MIN_MACOS_VERSION)" \
 	CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="$(shell xcrun -sdk macosx --find clang)" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(APPLE_TARGET_macos_x86_64) \
 		--release \
 		--no-default-features \
@@ -257,8 +259,9 @@ apple-ios-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(IOS_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(IOS_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_IOS_LINKER="$(shell xcrun -sdk iphoneos --find clang)" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(APPLE_TARGET_ios_arm64) \
 		--release \
 		--no-default-features \
@@ -277,8 +280,9 @@ apple-ios-x86_64: apple-check-xcode
 	CFLAGS="-arch x86_64 -isysroot $(IOS_SIMULATOR_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CXXFLAGS="-arch x86_64 -isysroot $(IOS_SIMULATOR_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CARGO_TARGET_X86_64_APPLE_IOS_LINKER="$(shell xcrun -sdk iphonesimulator --find clang)" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(APPLE_TARGET_ios_x86_64) \
 		--release \
 		--no-default-features \
@@ -297,8 +301,9 @@ apple-ios-sim-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(IOS_SIMULATOR_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(IOS_SIMULATOR_SDK) -miphoneos-version-min=$(MIN_IOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER="$(shell xcrun -sdk iphonesimulator --find clang)" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		--target $(APPLE_TARGET_ios_sim_arm64) \
 		--release \
 		--no-default-features \
@@ -317,8 +322,9 @@ apple-maccatalyst-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(MACOS_SDK) -target arm64-apple-ios$(MIN_MACCATALYST_VERSION)-macabi" \
 	CXXFLAGS="-arch arm64 -isysroot $(MACOS_SDK) -target arm64-apple-ios$(MIN_MACCATALYST_VERSION)-macabi" \
 	CARGO_TARGET_AARCH64_APPLE_IOS_MACABI_LINKER="$(shell xcrun -sdk macosx --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_maccatalyst_arm64) \
 		--no-default-features \
@@ -338,8 +344,9 @@ apple-maccatalyst-x86_64: apple-check-xcode
 	CFLAGS="-arch x86_64 -isysroot $(MACOS_SDK) -target x86_64-apple-ios$(MIN_MACCATALYST_VERSION)-macabi" \
 	CXXFLAGS="-arch x86_64 -isysroot $(MACOS_SDK) -target x86_64-apple-ios$(MIN_MACCATALYST_VERSION)-macabi" \
 	CARGO_TARGET_X86_64_APPLE_IOS_MACABI_LINKER="$(shell xcrun -sdk macosx --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_maccatalyst_x86_64) \
 		--no-default-features \
@@ -359,8 +366,9 @@ apple-visionos-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(VISIONOS_SDK) -target arm64-apple-xros$(MIN_VISIONOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(VISIONOS_SDK) -target arm64-apple-xros$(MIN_VISIONOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_VISIONOS_LINKER="$(shell xcrun -sdk xros --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_visionos_arm64) \
 		--no-default-features \
@@ -380,8 +388,9 @@ apple-visionos-sim-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(VISIONOS_SIMULATOR_SDK) -target arm64-apple-xros$(MIN_VISIONOS_VERSION)-simulator" \
 	CXXFLAGS="-arch arm64 -isysroot $(VISIONOS_SIMULATOR_SDK) -target arm64-apple-xros$(MIN_VISIONOS_VERSION)-simulator" \
 	CARGO_TARGET_AARCH64_APPLE_VISIONOS_SIM_LINKER="$(shell xcrun -sdk xrsimulator --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_visionos_sim_arm64) \
 		--no-default-features \
@@ -401,8 +410,9 @@ apple-tvos-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(TVOS_SDK) -mtvos-version-min=$(MIN_TVOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(TVOS_SDK) -mtvos-version-min=$(MIN_TVOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_TVOS_LINKER="$(shell xcrun -sdk appletvos --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_tvos_arm64) \
 		--no-default-features \
@@ -422,8 +432,9 @@ apple-tvos-sim-arm64: apple-check-xcode
 	CFLAGS="-arch arm64 -isysroot $(TVOS_SIMULATOR_SDK) -mtvos-version-min=$(MIN_TVOS_VERSION)" \
 	CXXFLAGS="-arch arm64 -isysroot $(TVOS_SIMULATOR_SDK) -mtvos-version-min=$(MIN_TVOS_VERSION)" \
 	CARGO_TARGET_AARCH64_APPLE_TVOS_SIM_LINKER="$(shell xcrun -sdk appletvsimulator --find clang)" \
-	cargo +nightly build \
+	cargo +nightly rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type cdylib \
 		-Z build-std=std,panic_abort \
 		--target $(APPLE_TARGET_tvos_sim_arm64) \
 		--no-default-features \

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -103,8 +103,9 @@ linux-x86_64: linux-check-deps
 	RANLIB="ranlib" \
 	CFLAGS="-fPIC" \
 	CXXFLAGS="-fPIC -std=c++14" \
-	cargo build \
+	cargo rustc \
 		--manifest-path dotlottie-rs/Cargo.toml \
+		--crate-type staticlib --crate-type cdylib \
 		--target $(LINUX_TARGET_x86_64) \
 		--release \
 		--no-default-features \
@@ -127,8 +128,9 @@ linux-arm64: linux-check-deps
 		CFLAGS="-fPIC" \
 		CXXFLAGS="-fPIC -std=c++14" \
 		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="gcc" \
-		cargo build \
+		cargo rustc \
 			--manifest-path dotlottie-rs/Cargo.toml \
+			--crate-type staticlib --crate-type cdylib \
 			--target $(LINUX_TARGET_arm64) \
 			--release \
 			--no-default-features \
@@ -141,8 +143,9 @@ linux-arm64: linux-check-deps
 		CFLAGS="-fPIC" \
 		CXXFLAGS="-fPIC -std=c++14" \
 		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \
-		cargo build \
+		cargo rustc \
 			--manifest-path dotlottie-rs/Cargo.toml \
+			--crate-type staticlib --crate-type cdylib \
 			--target $(LINUX_TARGET_arm64) \
 			--release \
 			--no-default-features \

--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -1,24 +1,8 @@
-# ============================================================================
-# WASM Build System — wasm32-unknown-unknown + wasm-pack
-# ============================================================================
-# Prerequisites:
-#   rustup target add wasm32-unknown-unknown
-#   cargo install wasm-pack  (or: make wasm-setup)
-#
-# Usage:
-#   make wasm-setup     — install Rust target + wasm-pack
-#   make wasm           — software-renderer build  → release/wasm/
-#   make wasm-webgl     — WebGL2 build             → release/wasm-webgl/
-#   make wasm-webgpu    — WebGPU build             → release/wasm-webgpu/
-#   make wasm-all       — all three variants
-#   make wasm-clean     — remove build artefacts
-# ============================================================================
+WASM_TARGET  := wasm32-unknown-unknown
+WASM_FEATURES_COMMON := tvg,tvg-sw,tvg-png,tvg-jpg,tvg-webp,tvg-ttf,tvg-lottie-expressions,dotlottie,theming,state-machines,wasm-bindgen-api
+WASM_MANIFEST := dotlottie-rs/Cargo.toml
+WASM_ARTIFACT := dotlottie-rs/target/$(WASM_TARGET)/release/dotlottie_rs.wasm
 
-WASM_BINDGEN_TARGET := wasm32-unknown-unknown
-WASM_BINDGEN_COMMON := tvg,tvg-sw,tvg-png,tvg-jpg,tvg-webp,tvg-ttf,tvg-lottie-expressions,dotlottie,theming,state-machines,wasm-bindgen-api
-
-# Apple's system clang lacks the WebAssembly backend.  Use Homebrew LLVM if
-# present, otherwise fall back to whatever clang/clang++ is on PATH.
 LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
 ifneq ($(LLVM_PREFIX),)
   WASM_CC  := $(LLVM_PREFIX)/bin/clang
@@ -28,39 +12,46 @@ else
   WASM_CXX := clang++
 endif
 
+WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+
 .PHONY: wasm-setup wasm wasm-webgl wasm-webgpu wasm-all wasm-clean
 
-# Install the wasm32-unknown-unknown Rust target and wasm-pack
 wasm-setup:
-	@rustup target add $(WASM_BINDGEN_TARGET)
-	@command -v wasm-pack >/dev/null 2>&1 || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+	@rustup target add $(WASM_TARGET)
+	@cargo install wasm-bindgen-cli --version $(WASM_BINDGEN_VERSION) --locked
 
-# Software-renderer build — no graphics API required
+define wasm_build
+	@mkdir -p $(3)
+	CC=$(WASM_CC) CXX=$(WASM_CXX) RUSTFLAGS="$(2)" \
+		cargo rustc \
+			--manifest-path $(WASM_MANIFEST) \
+			--crate-type cdylib \
+			--target $(WASM_TARGET) \
+			--release \
+			--no-default-features \
+			--features $(WASM_FEATURES_COMMON)$(if $(1),$(comma)$(1))
+	wasm-bindgen $(WASM_ARTIFACT) \
+		--out-dir $(3) \
+		--target web \
+		--typescript
+	@if command -v wasm-opt >/dev/null 2>&1; then \
+		wasm-opt $(3)/dotlottie_rs_bg.wasm -o $(3)/dotlottie_rs_bg.wasm -O; \
+	fi
+endef
+
+comma := ,
+
 wasm:
-	CC=$(WASM_CC) CXX=$(WASM_CXX) \
-		wasm-pack build dotlottie-rs --target web \
-		--out-dir ../release/wasm \
-		--no-default-features --features $(WASM_BINDGEN_COMMON)
+	$(call wasm_build,,,release/wasm)
 
-# WebGL2 build
 wasm-webgl:
-	CC=$(WASM_CC) CXX=$(WASM_CXX) \
-		wasm-pack build dotlottie-rs --target web \
-		--out-dir ../release/wasm-webgl \
-		--no-default-features --features $(WASM_BINDGEN_COMMON),tvg-gl,webgl
+	$(call wasm_build,tvg-gl$(comma)webgl,,release/wasm-webgl)
 
-# WebGPU build — requires web_sys_unstable_apis cfg for all Gpu* web-sys types
 wasm-webgpu:
-	CC=$(WASM_CC) CXX=$(WASM_CXX) \
-		RUSTFLAGS="--cfg=web_sys_unstable_apis" \
-		wasm-pack build dotlottie-rs --target web \
-		--out-dir ../release/wasm-webgpu \
-		--no-default-features --features $(WASM_BINDGEN_COMMON),tvg-wg,webgpu
+	$(call wasm_build,tvg-wg$(comma)webgpu,--cfg=web_sys_unstable_apis,release/wasm-webgpu)
 
-# Build all three variants
 wasm-all: wasm wasm-webgl wasm-webgpu
 
-# Remove wasm artefacts
 wasm-clean:
-	@cargo clean --manifest-path dotlottie-rs/Cargo.toml --target $(WASM_BINDGEN_TARGET)
+	@cargo clean --manifest-path $(WASM_MANIFEST) --target $(WASM_TARGET)
 	@rm -rf release/wasm release/wasm-webgl release/wasm-webgpu

--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -13,15 +13,15 @@ else
 endif
 
 WASM_LOCKFILE := dotlottie-rs/Cargo.lock
-WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' $(WASM_LOCKFILE) 2>/dev/null | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
 
 .PHONY: wasm-setup wasm wasm-webgl wasm-webgpu wasm-all wasm-clean
 
 wasm-setup:
 	@rustup target add $(WASM_TARGET)
 	@if [ ! -f $(WASM_LOCKFILE) ]; then cargo generate-lockfile --manifest-path $(WASM_MANIFEST); fi
-	$(eval WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' $(WASM_LOCKFILE) | grep version | head -1 | sed 's/.*"\(.*\)"/\1/'))
-	@cargo install wasm-bindgen-cli --version $(WASM_BINDGEN_VERSION) --locked
+	@cargo install wasm-bindgen-cli \
+		--version "$$(grep -A1 'name = "wasm-bindgen"' $(WASM_LOCKFILE) | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')" \
+		--locked
 
 define wasm_build
 	@mkdir -p $(3)

--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -12,12 +12,15 @@ else
   WASM_CXX := clang++
 endif
 
-WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+WASM_LOCKFILE := dotlottie-rs/Cargo.lock
+WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' $(WASM_LOCKFILE) 2>/dev/null | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
 
 .PHONY: wasm-setup wasm wasm-webgl wasm-webgpu wasm-all wasm-clean
 
 wasm-setup:
 	@rustup target add $(WASM_TARGET)
+	@if [ ! -f $(WASM_LOCKFILE) ]; then cargo generate-lockfile --manifest-path $(WASM_MANIFEST); fi
+	$(eval WASM_BINDGEN_VERSION := $(shell grep -A1 'name = "wasm-bindgen"' $(WASM_LOCKFILE) | grep version | head -1 | sed 's/.*"\(.*\)"/\1/'))
 	@cargo install wasm-bindgen-cli --version $(WASM_BINDGEN_VERSION) --locked
 
 define wasm_build

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -73,7 +73,7 @@ define WINDOWS_CARGO_BUILD
 	else \
 		LLVM_LINE='rem no LLVM override'; \
 	fi; \
-	printf '@echo off\ncall "%s" %s\nif errorlevel 1 exit /b 1\n%s\n"%s" build --manifest-path "%s" --target %s --release %s --features %s\n' \
+	printf '@echo off\ncall "%s" %s\nif errorlevel 1 exit /b 1\n%s\n"%s" rustc --manifest-path "%s" --crate-type staticlib --crate-type cdylib --target %s --release %s --features %s\n' \
 		"$$VCVARS_WIN" "$(1)" "$$LLVM_LINE" "$$CARGO_WIN" "$$MANIFEST_WIN" "$(2)" \
 		"$(4)" "$(3)" > "$$TMPBAT"; \
 	echo "-> Building $(2) with cargo..."; \

--- a/web-example.html
+++ b/web-example.html
@@ -353,7 +353,7 @@
               throw new Error("WebGPU not available in this browser");
             const adapter = await navigator.gpu.requestAdapter();
             if (!adapter) throw new Error('No WebGPU adapter found');
-            const device  = await adapter.requestDevice();
+            const gpuDevice = await adapter.requestDevice();
             const gpuCtx  = canvas.getContext('webgpu');
             if (!gpuCtx) throw new Error('Canvas WebGPU context unavailable');
             // 'premultiplied' lets transparent ThorVG pixels show the CSS


### PR DESCRIPTION
## Summary
- Change `crate-type` from `["staticlib", "cdylib", "rlib"]` to `["rlib"]` in Cargo.toml
- Update all Makefiles to use `cargo rustc --crate-type` to explicitly request the artifact types each platform needs
- Migrate `wasm.mk` from `wasm-pack` to `cargo rustc --crate-type cdylib` + `wasm-bindgen-cli` (version auto-resolved from Cargo.lock)
- Fix `WASM_ARTIFACT` path (`dotlottie-rs/target/` — no workspace root)
- Fix undefined `gpuDevice` reference in `web-example.html` WebGPU init

**Why:** On ESP-IDF the final binary is an ELF produced by the linker. `staticlib` and `cdylib` outputs are not needed and cause build issues with the Xtensa toolchain. This is a generic portability improvement — platforms that need FFI artifacts now request them explicitly.

| Platform | Crate types requested |
|----------|----------------------|
| Android | `cdylib` |
| Apple | `cdylib` |
| Linux | `staticlib`, `cdylib` |
| Windows | `staticlib`, `cdylib` |
| WASM | `cdylib` (via cargo rustc + wasm-bindgen) |