### PR TITLE
fix(ci): use stable Rust toolchain for WASM release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,11 +123,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Setup WASM
         run: make wasm-setup


### PR DESCRIPTION
## Summary
- Release WASM job used `nightly` toolchain while the build artifacts workflow uses `stable` — causing release WASM builds to fail
- Switched to `stable` and removed unnecessary `setup-node` step to match the working build artifacts workflow