### PR TITLE
fix(build): add platform guards to cbindgen-generated C header

### DIFF
--- a/dotlottie-rs/cbindgen.toml
+++ b/dotlottie-rs/cbindgen.toml
@@ -29,8 +29,6 @@ exclude = [
 [defines]
 "target_os = macos" = "__APPLE__"
 "target_os = android" = "__ANDROID__"
-"feature = tvg-wg" = "DOTLOTTIE_TVG_WG"
-"feature = audio" = "DOTLOTTIE_AUDIO"
 
 [parse]
 parse_deps = false

--- a/dotlottie-rs/cbindgen.toml
+++ b/dotlottie-rs/cbindgen.toml
@@ -29,6 +29,8 @@ exclude = [
 [defines]
 "target_os = macos" = "__APPLE__"
 "target_os = android" = "__ANDROID__"
+"feature = tvg-wg" = "DOTLOTTIE_TVG_WG"
+"feature = audio" = "DOTLOTTIE_AUDIO"
 
 [parse]
 parse_deps = false

--- a/dotlottie-rs/cbindgen.toml
+++ b/dotlottie-rs/cbindgen.toml
@@ -26,6 +26,10 @@ exclude = [
     "DeviceCallbackResult",
 ]
 
+[defines]
+"target_os = macos" = "__APPLE__"
+"target_os = android" = "__ANDROID__"
+
 [parse]
 parse_deps = false
 include = ["dotlottie-rs"]

--- a/dotlottie-rs/src/c_api/apple.rs
+++ b/dotlottie-rs/src/c_api/apple.rs
@@ -76,7 +76,6 @@ pub unsafe extern "C" fn dotlottie_free_wgpu_context(context: *mut std::ffi::c_v
 ///
 /// # Safety
 /// context must be a valid pointer from dotlottie_create_wgpu_context_from_metal_layer
-#[cfg(all(feature = "tvg-wg", target_os = "macos"))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_wgpu_context_present(context: *const std::ffi::c_void) {
     if context.is_null() {


### PR DESCRIPTION
## Summary

- Add `[defines]` section to `cbindgen.toml` mapping `target_os` cfg predicates to compiler-predefined C macros (`__APPLE__`, `__ANDROID__`)
- Remove redundant per-function `#[cfg(all(feature = "tvg-wg", target_os = "macos"))]` on `dotlottie_wgpu_context_present` — already covered by the file-level `#![cfg]`

## Problem

cbindgen is a source parser, not a compiler — it doesn't evaluate Rust `#[cfg]` attributes. Platform-gated functions (macOS WebGPU/Metal helpers, Android JVM init) were included unconditionally in the generated `dotlottie_player.h`, causing issues when the header was consumed on non-matching platforms (e.g. Android builds seeing Metal declarations that don't exist in the compiled library).

## Generated header (after)

```c
#if defined(__ANDROID__)
void dotlottie_init_android(void *vm, void *ctx);
#endif

#if defined(__APPLE__)
void *dotlottie_create_wgpu_context_from_metal_layer(void *metal_layer);
#endif
// ... other Apple-gated functions
```
