### PR TITLE
chore: remove dead code

### DIFF
--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -20,7 +20,7 @@ pub use slots::{
     TextCaps, TextDocument, TextJustify, TextKeyframe, TextSlot, VectorSlot,
 };
 #[cfg(feature = "tvg")]
-pub use thorvg::{TvgAnimation, TvgEngine, TvgError, TvgRenderer, TvgShape};
+pub use thorvg::{TvgAnimation, TvgError, TvgRenderer, TvgShape};
 
 use std::collections::BTreeMap;
 use std::{error::Error, fmt};

--- a/dotlottie-rs/src/lottie_renderer/renderer.rs
+++ b/dotlottie-rs/src/lottie_renderer/renderer.rs
@@ -237,19 +237,11 @@ pub trait Animation: Default {
 
     fn set_size(&mut self, width: f32, height: f32) -> Result<(), Self::Error>;
 
-    fn scale(&mut self, factor: f32) -> Result<(), Self::Error>;
-
-    fn translate(&mut self, tx: f32, ty: f32) -> Result<(), Self::Error>;
-
     fn get_total_frame(&self) -> Result<f32, Self::Error>;
 
     fn get_duration(&self) -> Result<f32, Self::Error>;
 
     fn set_frame(&mut self, frame_no: f32) -> Result<(), Self::Error>;
-
-    fn get_frame(&self) -> Result<f32, Self::Error>;
-
-    fn set_slots_str(&mut self, slots: &CStr) -> Result<(), Self::Error>;
 
     /// Generate a slot override from JSON and return its code for later use
     fn gen_slot(&mut self, slot_json: &CStr) -> Result<u32, Self::Error>;
@@ -265,8 +257,6 @@ pub trait Animation: Default {
     fn tween(&mut self, from: f32, to: f32, progress: f32) -> Result<(), Self::Error>;
 
     fn set_transform(&mut self, matrix: &[f32; 9]) -> Result<(), Self::Error>;
-
-    fn get_transform(&self) -> Result<[f32; 9], Self::Error>;
 
     // ── Markers & Segments ───────────────────────────────────────────────
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -77,24 +77,14 @@ impl From<WgpuTargetType> for std::ffi::c_int {
     }
 }
 
-pub enum TvgEngine {
-    TvgEngineSw,
-    TvgEngineGl,
-}
-
-#[allow(dead_code)]
 #[non_exhaustive]
 enum TvgEngineOption {
-    None,
     Default,
-    Smart,
 }
 impl From<TvgEngineOption> for tvg::Tvg_Engine_Option {
     fn from(option: TvgEngineOption) -> Self {
         match option {
-            TvgEngineOption::None => tvg::Tvg_Engine_Option_TVG_ENGINE_OPTION_NONE,
             TvgEngineOption::Default => tvg::Tvg_Engine_Option_TVG_ENGINE_OPTION_DEFAULT,
-            TvgEngineOption::Smart => tvg::Tvg_Engine_Option_TVG_ENGINE_OPTION_SMART_RENDER,
         }
     }
 }
@@ -610,14 +600,6 @@ impl Animation for TvgAnimation {
         unsafe { tvg::tvg_picture_set_size(self.raw_paint, width, height).into_result() }
     }
 
-    fn scale(&mut self, factor: f32) -> Result<(), TvgError> {
-        unsafe { tvg::tvg_paint_scale(self.raw_paint, factor).into_result() }
-    }
-
-    fn translate(&mut self, tx: f32, ty: f32) -> Result<(), TvgError> {
-        unsafe { tvg::tvg_paint_translate(self.raw_paint, tx, ty).into_result() }
-    }
-
     fn get_total_frame(&self) -> Result<f32, TvgError> {
         Ok(self.total_frames)
     }
@@ -633,33 +615,6 @@ impl Animation for TvgAnimation {
             }
         }
         unsafe { tvg::tvg_animation_set_frame(self.raw_animation, frame_no).into_result() }
-    }
-
-    fn get_frame(&self) -> Result<f32, TvgError> {
-        let mut curr_frame: f32 = 0.0;
-
-        unsafe {
-            tvg::tvg_animation_get_frame(self.raw_animation, &mut curr_frame as *mut f32)
-                .into_result()
-        }?;
-
-        Ok(curr_frame)
-    }
-
-    fn set_slots_str(&mut self, slots_json: &CStr) -> Result<(), TvgError> {
-        let result = if slots_json.to_bytes().is_empty() {
-            unsafe { tvg::tvg_lottie_animation_apply_slot(self.raw_animation, 0) }
-        } else {
-            let slot_id = unsafe {
-                tvg::tvg_lottie_animation_gen_slot(self.raw_animation, slots_json.as_ptr())
-            };
-            if slot_id == 0 {
-                return Err(TvgError::InvalidArgument);
-            }
-            unsafe { tvg::tvg_lottie_animation_apply_slot(self.raw_animation, slot_id) }
-        };
-
-        result.into_result()
     }
 
     fn gen_slot(&mut self, slot_json: &CStr) -> Result<u32, TvgError> {
@@ -704,36 +659,6 @@ impl Animation for TvgAnimation {
         };
 
         unsafe { tvg::tvg_paint_set_transform(self.raw_paint, &tvg_matrix).into_result() }
-    }
-
-    fn get_transform(&self) -> Result<[f32; 9], TvgError> {
-        let mut tvg_matrix = tvg::Tvg_Matrix {
-            e11: 1.0,
-            e12: 0.0,
-            e13: 0.0,
-            e21: 0.0,
-            e22: 1.0,
-            e23: 0.0,
-            e31: 0.0,
-            e32: 0.0,
-            e33: 1.0,
-        };
-
-        unsafe {
-            tvg::tvg_paint_get_transform(self.raw_paint, &mut tvg_matrix).into_result()?;
-        }
-
-        Ok([
-            tvg_matrix.e11,
-            tvg_matrix.e12,
-            tvg_matrix.e13,
-            tvg_matrix.e21,
-            tvg_matrix.e22,
-            tvg_matrix.e23,
-            tvg_matrix.e31,
-            tvg_matrix.e32,
-            tvg_matrix.e33,
-        ])
     }
 
     // ── Markers & Segments ───────────────────────────────────────────────

--- a/dotlottie-rs/src/state_machine_engine/inputs/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/inputs/mod.rs
@@ -139,5 +139,4 @@ impl InputTrait for InputManager {
         self.inputs
             .insert(key.to_string(), InputValue::Event(value.to_string()));
     }
-
 }

--- a/dotlottie-rs/src/state_machine_engine/inputs/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/inputs/mod.rs
@@ -33,8 +33,6 @@ pub trait InputTrait {
     fn get_string(&self, key: &str) -> Option<String>;
     fn get_boolean(&self, key: &str) -> Option<bool>;
     fn get_event(&self, key: &str) -> Option<String>;
-    fn get(&self, key: &str) -> Result<&InputValue, &'static str>;
-    fn reset_all(&mut self);
     fn reset(&mut self, key: &str) -> Option<(InputValue, InputValue)>;
 }
 
@@ -67,10 +65,6 @@ impl InputTrait for InputManager {
         }
 
         None
-    }
-
-    fn reset_all(&mut self) {
-        self.inputs = self.default_values.clone();
     }
 
     fn set_numeric(&mut self, key: &str, value: f32) -> Option<InputValue> {
@@ -146,8 +140,4 @@ impl InputTrait for InputManager {
             .insert(key.to_string(), InputValue::Event(value.to_string()));
     }
 
-    // Generic get method that returns a Result
-    fn get(&self, key: &str) -> Result<&InputValue, &'static str> {
-        self.inputs.get(key).ok_or("Input key not found")
-    }
 }

--- a/dotlottie-rs/src/state_machine_engine/interactions/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/interactions/mod.rs
@@ -9,13 +9,6 @@ pub trait InteractionTrait {
     fn type_name(&self) -> &'static str;
 }
 
-pub enum InteractionAction {
-    Increment,
-    Decrement,
-    Set,
-    None,
-}
-
 #[derive(Deserialize, Debug)]
 #[serde(rename_all_fields = "camelCase")]
 #[serde(tag = "type")]

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -1268,10 +1268,6 @@ impl<'a> StateMachineEngine<'a> {
         Ok(())
     }
 
-    pub fn get_state_machine(&self) -> &StateMachine {
-        &self.state_machine
-    }
-
     pub fn get_current_state_name(&self) -> String {
         if let Some(state) = &self.current_state {
             return state.name();

--- a/dotlottie-rs/src/state_machine_engine/states/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/states/mod.rs
@@ -9,11 +9,6 @@ use super::{actions::StateMachineActionError, transitions::Transition, StateMach
 
 use super::actions::{Action, ActionTrait};
 
-#[derive(Debug)]
-pub enum StatesError {
-    ParsingError,
-}
-
 pub trait StateTrait {
     fn enter(&self, engine: &mut StateMachineEngine) -> Result<(), StateMachineActionError>;
     fn exit(&self, engine: &mut StateMachineEngine) -> Result<(), StateMachineActionError>;


### PR DESCRIPTION
## Summary
- Remove unused trait methods, enum variants, and types across renderer and state machine modules