### PR TITLE
fix(build): exclude wasm stubs from generated C header

### DIFF
--- a/dotlottie-rs/src/lib.rs
+++ b/dotlottie-rs/src/lib.rs
@@ -19,10 +19,11 @@ pub mod c_api;
 
 pub mod tools;
 
-// wasm32-unknown-unknown: auto-enabled when targeting wasm32 (excluding emscripten) with ThorVG
+/// cbindgen:ignore
 #[cfg(all(feature = "tvg", target_arch = "wasm32", not(target_os = "emscripten")))]
 mod wasm;
 
+/// cbindgen:ignore
 #[cfg(all(
     feature = "tvg",
     target_arch = "wasm32",

--- a/dotlottie-rs/src/tools/mod.rs
+++ b/dotlottie-rs/src/tools/mod.rs
@@ -3,6 +3,7 @@
 //! Enable the `tracking_allocator` feature to use [`TrackingAllocator`] as a
 //! `#[global_allocator]` in tests or benchmarks.
 
+/// cbindgen:ignore
 #[cfg(all(feature = "tracking_allocator", feature = "tvg"))]
 mod tvg_alloc;
 

--- a/dotlottie-rs/src/wasm/mod.rs
+++ b/dotlottie-rs/src/wasm/mod.rs
@@ -6,6 +6,8 @@
 //! where there is no system C runtime, no native OpenGL loader, and no
 //! wgpu-native library.
 
+/// cbindgen:ignore
+///
 /// Minimal libc/C++ runtime stubs for `wasm32-unknown-unknown`.
 ///
 /// Unlike `wasm32-unknown-emscripten` or `wasm32-wasi`, the `unknown-unknown`
@@ -13,6 +15,8 @@
 /// (`malloc`, `strcmp`, `snprintf`, …) that must be provided by us.
 mod stubs;
 
+/// cbindgen:ignore
+///
 /// WebGL2 FFI stubs that bridge ThorVG's OpenGL calls to `web_sys::WebGl2RenderingContext`.
 ///
 /// ThorVG's GL engine emits standard OpenGL/GLES function calls (`glBindTexture`,
@@ -21,6 +25,8 @@ mod stubs;
 #[cfg(feature = "tvg-gl")]
 mod webgl_stubs;
 
+/// cbindgen:ignore
+///
 /// WebGPU FFI stubs that bridge ThorVG's wgpu-native calls to the browser's WebGPU API.
 ///
 /// ThorVG's WG engine calls wgpu-native C functions (`wgpuDeviceCreateBuffer`,


### PR DESCRIPTION
Add `/// cbindgen:ignore` to the wasm stubs so cbindgen skips the entire module tree during header generation.