### PR TITLE
refactor: replace intersect/get_layer_bounds with internal hit_test

### DIFF
--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -42,6 +42,7 @@ audio = ["dotlottie", "dep:rodio", "dep:ndk-context", "web-sys/HtmlAudioElement"
 [dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
+rustc-hash = "2.1.1"
 zip = { version = "2.4.2", default-features = false, features = ["deflate"], optional = true }
 bitflags = { version = "2.6", optional = true }
 

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{DotLottiePlayer, DotLottiePlayerError, LayerBoundingBox, Layout, Mode, Rgba, Segment};
+use crate::{DotLottiePlayer, DotLottiePlayerError, Layout, Mode, Rgba, Segment};
 
 use crate::ColorSpace;
 
@@ -1631,39 +1631,6 @@ pub unsafe extern "C" fn dotlottie_animation_size(
         }
 
         DotLottieResult::Error
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_layer_bounds(
-    ptr: *mut DotLottiePlayer,
-    layer_name: *const c_char,
-    result: *mut LayerBoundingBox,
-) -> DotLottieResult {
-    exec_dotlottie_player_op!(ptr, |dotlottie_player| {
-        if layer_name.is_null() || result.is_null() {
-            return DotLottieResult::InvalidParameter;
-        }
-        let name = CStr::from_ptr(layer_name);
-        match name.to_str() {
-            Ok(name_str) => match dotlottie_player.get_layer_bounds(name_str).as_slice() {
-                [x1, y1, x2, y2, x3, y3, x4, y4] => {
-                    *result = LayerBoundingBox {
-                        x1: *x1,
-                        y1: *y1,
-                        x2: *x2,
-                        y2: *y2,
-                        x3: *x3,
-                        y3: *y3,
-                        x4: *x4,
-                        y4: *y4,
-                    };
-                    DotLottieResult::Success
-                }
-                _ => DotLottieResult::Error,
-            },
-            Err(_) => DotLottieResult::InvalidParameter,
-        }
     })
 }
 

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -10,6 +10,7 @@ mod fallback_font;
 #[cfg(feature = "tvg")]
 mod thorvg;
 
+pub(crate) use renderer::Point;
 pub use renderer::{
     Animation, ColorSpace, Drawable, GlContext, GlDisplay, GlSurface, Marker, Renderer, Rgba,
     Segment, Shape, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType,
@@ -176,9 +177,7 @@ pub trait LottieRenderer {
 
     fn set_layout(&mut self, layout: &Layout) -> Result<(), LottieRendererError>;
 
-    fn get_layer_bounds(&self, layer_name: &str) -> Result<[f32; 8], LottieRendererError>;
-
-    fn intersect(&self, x: f32, y: f32, layer_name: &str) -> Result<bool, LottieRendererError>;
+    fn hit_test(&self, point: Point, layer_name: &str) -> Result<bool, LottieRendererError>;
 
     fn updated(&self) -> bool;
 
@@ -875,15 +874,9 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
         Ok(())
     }
 
-    fn get_layer_bounds(&self, layer_name: &str) -> Result<[f32; 8], LottieRendererError> {
+    fn hit_test(&self, point: Point, layer_name: &str) -> Result<bool, LottieRendererError> {
         self.get_animation()?
-            .get_layer_bounds(layer_name)
-            .map_err(into_lottie::<R>)
-    }
-
-    fn intersect(&self, x: f32, y: f32, layer_name: &str) -> Result<bool, LottieRendererError> {
-        self.get_animation()?
-            .intersect(x, y, layer_name)
+            .hit_test(point, layer_name)
             .map_err(into_lottie::<R>)
     }
 

--- a/dotlottie-rs/src/lottie_renderer/renderer.rs
+++ b/dotlottie-rs/src/lottie_renderer/renderer.rs
@@ -1,6 +1,13 @@
 use core::error;
 use std::ffi::{CStr, CString};
 
+// A 2D vector for representing a point
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
 /// A frame range within a Lottie animation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Segment {
@@ -229,9 +236,7 @@ pub trait Animation: Default {
 
     fn load_data(&mut self, data: &CStr, mimetype: &CStr) -> Result<(), Self::Error>;
 
-    fn intersect(&self, x: f32, y: f32, layer_name: &str) -> Result<bool, Self::Error>;
-
-    fn get_layer_bounds(&self, layer_name: &str) -> Result<[f32; 8], Self::Error>;
+    fn hit_test(&self, point: Point, layer_name: &str) -> Result<bool, Self::Error>;
 
     fn get_size(&self) -> Result<(f32, f32), Self::Error>;
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -1,16 +1,19 @@
 use std::{
+    cell::RefCell,
     error::Error,
     ffi::{c_char, CStr, CString},
     fmt, ptr,
     result::Result,
 };
 
+use rustc_hash::FxHashMap;
+
 #[cfg(feature = "tvg-ttf")]
 use crate::lottie_renderer::fallback_font;
 
 use super::{
-    Animation, ColorSpace, Drawable, GlContext, GlDisplay, GlSurface, Marker, Renderer, Rgba,
-    Segment, Shape, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType,
+    Animation, ColorSpace, Drawable, GlContext, GlDisplay, GlSurface, Marker, Point, Renderer,
+    Rgba, Segment, Shape, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType,
 };
 
 #[expect(non_upper_case_globals)]
@@ -380,6 +383,32 @@ impl Drop for TvgRenderer {
     }
 }
 
+struct LayerIdMap {
+    cache: RefCell<FxHashMap<String, u32>>,
+}
+
+impl LayerIdMap {
+    fn new() -> Self {
+        Self {
+            cache: RefCell::new(FxHashMap::default()),
+        }
+    }
+
+    fn get_or_insert(&self, layer_name: &str) -> Result<u32, TvgError> {
+        if let Some(&id) = self.cache.borrow().get(layer_name) {
+            return Ok(id);
+        }
+        let cstr = CString::new(layer_name).map_err(|_| TvgError::InvalidArgument)?;
+        let id = unsafe { tvg::tvg_accessor_generate_id(cstr.as_ptr()) };
+        self.cache.borrow_mut().insert(layer_name.to_owned(), id);
+        Ok(id)
+    }
+
+    fn clear(&self) {
+        self.cache.borrow_mut().clear();
+    }
+}
+
 pub struct TvgAnimation {
     raw_animation: tvg::Tvg_Animation,
     raw_paint: tvg::Tvg_Paint,
@@ -388,6 +417,7 @@ pub struct TvgAnimation {
     markers: Vec<Marker>,
     total_frames: f32,
     duration: f32,
+    layer_id_map: LayerIdMap,
 }
 
 impl Default for TvgAnimation {
@@ -403,6 +433,7 @@ impl Default for TvgAnimation {
             markers: Vec::new(),
             total_frames: 0.0,
             duration: 0.0,
+            layer_id_map: LayerIdMap::new(),
         }
     }
 }
@@ -461,12 +492,10 @@ impl TvgAnimation {
     }
 
     fn get_layer_obb(&self, layer_name: &str) -> Result<Option<[tvg::Tvg_Point; 4]>, TvgError> {
+        let layer_id = self.layer_id_map.get_or_insert(layer_name)?;
         unsafe {
             let mut obb: [tvg::Tvg_Point; 4] = [tvg::Tvg_Point { x: 0.0, y: 0.0 }; 4];
-            let paint = self.raw_paint;
-            let layer_name_cstr = CString::new(layer_name).expect("Failed to create CString");
-            let layer_id = tvg::tvg_accessor_generate_id(layer_name_cstr.as_ptr());
-            let layer_paint = tvg::tvg_picture_get_paint(paint, layer_id);
+            let layer_paint = tvg::tvg_picture_get_paint(self.raw_paint, layer_id);
 
             if !layer_paint.is_null() {
                 tvg::tvg_paint_get_obb(layer_paint as tvg::Tvg_Paint, obb.as_mut_ptr());
@@ -519,6 +548,7 @@ impl Animation for TvgAnimation {
                 self.total_frames = self.get_total_frame()?;
                 self.duration = self.get_duration()?;
                 self.load_markers();
+                self.layer_id_map.clear();
                 Ok(())
             }
             Err(e) => {
@@ -526,57 +556,40 @@ impl Animation for TvgAnimation {
                 self.markers.clear();
                 self.total_frames = 0.0;
                 self.duration = 0.0;
+                self.layer_id_map.clear();
                 Err(e)
             }
         }
     }
 
-    fn intersect(&self, _x: f32, _y: f32, _layer_name: &str) -> Result<bool, TvgError> {
-        if let Some(obb) = self.get_layer_obb(_layer_name)? {
-            let e1 = tvg::Tvg_Point {
-                x: obb[1].x - obb[0].x,
-                y: obb[1].y - obb[0].y,
-            };
-            let e2 = tvg::Tvg_Point {
-                x: obb[3].x - obb[0].x,
-                y: obb[3].y - obb[0].y,
-            };
-            let o = tvg::Tvg_Point {
-                x: _x - obb[0].x,
-                y: _y - obb[0].y,
-            };
-            let u = (o.x * e1.x + o.y * e1.y) / (e1.x * e1.x + e1.y * e1.y);
-            let v = (o.x * e2.x + o.y * e2.y) / (e2.x * e2.x + e2.y * e2.y);
+    fn hit_test(&self, point: Point, layer_name: &str) -> Result<bool, TvgError> {
+        if let Some(obb) = self.get_layer_obb(layer_name)? {
+            // OBB edge vectors from the origin corner
+            let (e1x, e1y) = (obb[1].x - obb[0].x, obb[1].y - obb[0].y);
+            let (e2x, e2y) = (obb[3].x - obb[0].x, obb[3].y - obb[0].y);
 
-            // Check if point is inside the OBB
-            Ok((0.0..=1.0).contains(&u) && (0.0..=1.0).contains(&v))
-        } else {
-            Ok(false)
-        }
-    }
+            let e1_len_sq = e1x * e1x + e1y * e1y;
+            let e2_len_sq = e2x * e2x + e2y * e2y;
 
-    fn get_layer_bounds(&self, _layer_name: &str) -> Result<[f32; 8], TvgError> {
-        if let Some(obb) = self.get_layer_obb(_layer_name)? {
-            // Return the 8 points out of obb
-            let mut point_vec: Vec<f32> = Vec::with_capacity(8);
-
-            for item in &obb {
-                point_vec.push(item.x);
-                point_vec.push(item.y);
+            // Degenerate OBB (zero-area layer) — cannot contain any point
+            if e1_len_sq == 0.0 || e2_len_sq == 0.0 {
+                return Ok(false);
             }
 
-            Ok([
-                point_vec[0],
-                point_vec[1],
-                point_vec[2],
-                point_vec[3],
-                point_vec[4],
-                point_vec[5],
-                point_vec[6],
-                point_vec[7],
-            ])
+            // Vector from OBB origin to the test point
+            let (ox, oy) = (point.x - obb[0].x, point.y - obb[0].y);
+
+            // Project onto first edge — early exit if outside [0, 1]
+            let u = (ox * e1x + oy * e1y) / e1_len_sq;
+            if !(0.0..=1.0).contains(&u) {
+                return Ok(false);
+            }
+
+            // Project onto second edge
+            let v = (ox * e2x + oy * e2y) / e2_len_sq;
+            Ok((0.0..=1.0).contains(&v))
         } else {
-            Err(TvgError::Unknown)
+            Ok(false)
         }
     }
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -776,8 +776,7 @@ mod tests {
     fn load_test_animation() -> (TvgRenderer, TvgAnimation) {
         let renderer = TvgRenderer::new(0);
         let mut animation = TvgAnimation::default();
-        let data =
-            CString::new(include_str!("../../assets/animations/lottie/test.json")).unwrap();
+        let data = CString::new(include_str!("../../assets/animations/lottie/test.json")).unwrap();
         animation.load_data(&data, c"lottie+json").unwrap();
         (renderer, animation)
     }
@@ -803,16 +802,20 @@ mod tests {
     fn test_hit_test_solid_layer_origin_hit() {
         let (_r, animation) = load_test_animation();
         // OBB projection uses inclusive [0,1], so the origin corner is inside.
-        assert!(animation
-            .hit_test(Point { x: 0.0, y: 0.0 }, "B")
-            .unwrap());
+        assert!(animation.hit_test(Point { x: 0.0, y: 0.0 }, "B").unwrap());
     }
 
     #[test]
     fn test_hit_test_outside_bounds_miss() {
         let (_r, animation) = load_test_animation();
         assert!(!animation
-            .hit_test(Point { x: 2000.0, y: 2000.0 }, "B")
+            .hit_test(
+                Point {
+                    x: 2000.0,
+                    y: 2000.0
+                },
+                "B"
+            )
             .unwrap());
     }
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -771,4 +771,74 @@ mod tests {
             handle.join().expect("Thread panicked");
         }
     }
+
+    /// Load test.json (1500×1500, layers: "B" solid, "R"/"E" shapes) into a fresh TvgAnimation.
+    fn load_test_animation() -> (TvgRenderer, TvgAnimation) {
+        let renderer = TvgRenderer::new(0);
+        let mut animation = TvgAnimation::default();
+        let data =
+            CString::new(include_str!("../../assets/animations/lottie/test.json")).unwrap();
+        animation.load_data(&data, c"lottie+json").unwrap();
+        (renderer, animation)
+    }
+
+    #[test]
+    fn test_hit_test_nonexistent_layer_returns_false() {
+        let (_r, animation) = load_test_animation();
+        assert!(!animation
+            .hit_test(Point { x: 750.0, y: 750.0 }, "nonexistent")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_solid_layer_center_hit() {
+        let (_r, animation) = load_test_animation();
+        // "B" spans (0,0)–(1500,1500). Center point is clearly inside.
+        assert!(animation
+            .hit_test(Point { x: 750.0, y: 750.0 }, "B")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_solid_layer_origin_hit() {
+        let (_r, animation) = load_test_animation();
+        // OBB projection uses inclusive [0,1], so the origin corner is inside.
+        assert!(animation
+            .hit_test(Point { x: 0.0, y: 0.0 }, "B")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_outside_bounds_miss() {
+        let (_r, animation) = load_test_animation();
+        assert!(!animation
+            .hit_test(Point { x: 2000.0, y: 2000.0 }, "B")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_negative_coords_miss() {
+        let (_r, animation) = load_test_animation();
+        assert!(!animation
+            .hit_test(Point { x: -10.0, y: -10.0 }, "B")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_shape_layer_inside_obb() {
+        let (_r, animation) = load_test_animation();
+        // "E" has OBB (560,404)–(940,784). A centred point should hit.
+        assert!(animation
+            .hit_test(Point { x: 750.0, y: 600.0 }, "E")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_hit_test_shape_layer_outside_obb() {
+        let (_r, animation) = load_test_animation();
+        // "R" has OBB (560,784)–(940,1122). (750,750) is above its top edge.
+        assert!(!animation
+            .hit_test(Point { x: 750.0, y: 750.0 }, "R")
+            .unwrap());
+    }
 }

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -48,41 +48,6 @@ impl Direction {
     }
 }
 
-#[repr(C)]
-pub struct LayerBoundingBox {
-    pub x1: f32,
-    pub y1: f32,
-    pub x2: f32,
-    pub y2: f32,
-    pub x3: f32,
-    pub y3: f32,
-    pub x4: f32,
-    pub y4: f32,
-}
-
-impl From<LayerBoundingBox> for Vec<f32> {
-    fn from(bbox: LayerBoundingBox) -> Vec<f32> {
-        vec![
-            bbox.x1, bbox.y1, bbox.x2, bbox.y2, bbox.x3, bbox.y3, bbox.x4, bbox.y4,
-        ]
-    }
-}
-
-impl Default for LayerBoundingBox {
-    fn default() -> Self {
-        LayerBoundingBox {
-            x1: 0.0,
-            y1: 0.0,
-            x2: 0.0,
-            y2: 0.0,
-            x3: 0.0,
-            y3: 0.0,
-            x4: 0.0,
-            y4: 0.0,
-        }
-    }
-}
-
 // This is used to pass the loop complete / complete event to the state machine engine
 pub enum CompletionEvent {
     None,
@@ -91,7 +56,7 @@ pub enum CompletionEvent {
 }
 
 pub struct DotLottiePlayer {
-    renderer: Box<dyn LottieRenderer>,
+    pub(crate) renderer: Box<dyn LottieRenderer>,
     playback_state: PlaybackState,
     is_loaded: bool,
     elapsed_frames: f32,
@@ -213,29 +178,6 @@ impl DotLottiePlayer {
     #[inline]
     pub(crate) fn end_frame(&self) -> f32 {
         self.renderer.segment().map_or(0.0, |seg| seg.end)
-    }
-
-    pub fn intersect(&self, x: f32, y: f32, layer_name: &str) -> bool {
-        self.renderer.intersect(x, y, layer_name).unwrap_or(false)
-    }
-
-    pub fn get_layer_bounds(&self, layer_name: &str) -> Vec<f32> {
-        let bbox = self.renderer.get_layer_bounds(layer_name);
-
-        match bbox {
-            Err(_) => LayerBoundingBox::default().into(),
-            Ok(bbox) => LayerBoundingBox {
-                x1: bbox[0],
-                y1: bbox[1],
-                x2: bbox[2],
-                y2: bbox[3],
-                x3: bbox[4],
-                y3: bbox[5],
-                x4: bbox[6],
-                y4: bbox[7],
-            }
-            .into(),
-        }
     }
 
     pub fn is_loaded(&self) -> bool {

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -26,7 +26,7 @@ use crate::poll_events::{EventQueue, StateMachineEvent, StateMachineInternalEven
 use crate::state_machine_engine::interactions::Interaction;
 use crate::{
     event_type_name, state_machine_state_check_pipeline, CompletionEvent, DotLottiePlayer,
-    EventName, Layout, Mode, PointerEvent, Rgba, Segment, StateMachineEngineSecurityError,
+    EventName, Layout, Mode, Point, PointerEvent, Rgba, Segment, StateMachineEngineSecurityError,
 };
 
 use self::state_machine::state_machine_parse;
@@ -1040,24 +1040,32 @@ impl<'a> StateMachineEngine<'a> {
 
     fn manage_explicit_events(&mut self, event: &Event, x: f32, y: f32) {
         let mut actions_to_execute: Vec<Action> = Vec::new();
-        let interactions = self.interactions(None);
         let mut entered_layer = self.pointer_management.curr_entered_layer.clone();
 
-        for interaction in interactions {
+        for interaction in self.interactions(None) {
             if interaction.type_name() == event.type_name() {
                 // User defined a specific layer to check if hit
                 if let Some(layer) = interaction.get_layer_name() {
-                    // If we have a pointer down event, we need to check if the pointer is outside of the layer
+                    // If we have a pointer exit event, check if the pointer is outside of the layer
                     if let Event::PointerExit { x, y } = event {
                         if self.pointer_management.curr_entered_layer == layer
-                            && !self.player.intersect(*x, *y, layer)
+                            && !self
+                                .player
+                                .renderer
+                                .hit_test(Point { x: *x, y: *y }, layer)
+                                .unwrap_or(false)
                         {
                             entered_layer = "".to_string();
                             actions_to_execute.extend(interaction.get_actions().clone());
                         }
                     } else {
                         // Hit check will return true if the layer was hit
-                        if self.player.intersect(x, y, layer) {
+                        if self
+                            .player
+                            .renderer
+                            .hit_test(Point { x, y }, layer)
+                            .unwrap_or(false)
+                        {
                             entered_layer = layer.to_string();
                             actions_to_execute.extend(interaction.get_actions().clone());
                         }
@@ -1104,7 +1112,12 @@ impl<'a> StateMachineEngine<'a> {
                 || self.pointer_management.listened_layers[i].1 == event_type_name!(PointerExit))
                 && self
                     .player
-                    .intersect(x, y, &self.pointer_management.listened_layers[i].0)
+                    .renderer
+                    .hit_test(
+                        Point { x, y },
+                        &self.pointer_management.listened_layers[i].0,
+                    )
+                    .unwrap_or(false)
             {
                 hit = true;
 

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -732,17 +732,6 @@ impl DotLottiePlayerWasm {
         self.player.reset_slots()
     }
 
-    // ── Layer inspection ──────────────────────────────────────────────────────
-
-    pub fn intersect(&self, x: f32, y: f32, layer_name: &str) -> bool {
-        self.player.intersect(x, y, layer_name)
-    }
-
-    /// Returns `[x, y, width, height]` of the layer's bounding box.
-    pub fn get_layer_bounds(&self, layer_name: &str) -> Float32Array {
-        vec_to_f32array(self.player.get_layer_bounds(layer_name))
-    }
-
     // ── Transform ─────────────────────────────────────────────────────────────
 
     /// Returns the current affine transform as a flat `Float32Array`.

--- a/dotlottie-rs/tests/state_machine_interactions.rs
+++ b/dotlottie-rs/tests/state_machine_interactions.rs
@@ -37,57 +37,6 @@ mod tests {
 
         let curr_state_name = sm.get_current_state_name();
         assert_eq!(curr_state_name, "global");
-
-        let star_1_box = sm.player.get_layer_bounds("star1");
-
-        sm.post_event(&Event::PointerDown {
-            x: star_1_box[0],
-            y: star_1_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_1");
-
-        let star_2_box = sm.player.get_layer_bounds("star2");
-
-        sm.post_event(&Event::PointerDown {
-            x: star_2_box[0],
-            y: star_2_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_2");
-
-        let star_3_box = sm.player.get_layer_bounds("star3");
-        sm.post_event(&Event::PointerDown {
-            x: star_3_box[0],
-            y: star_3_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_3");
-
-        let star_4_box = sm.player.get_layer_bounds("star4");
-        sm.post_event(&Event::PointerDown {
-            x: star_4_box[0],
-            y: star_4_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_4");
-
-        let star_5_box = sm.player.get_layer_bounds("star5");
-        sm.post_event(&Event::PointerDown {
-            x: star_5_box[0],
-            y: star_5_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_5");
-
-        let star_6_box = sm.player.get_layer_bounds("star 6");
-        // Test that pointerUp anywhere on the canvas sets us back to global
-        sm.post_event(&Event::PointerUp {
-            x: star_6_box[0],
-            y: star_6_box[1],
-        });
-        let curr_state_name = sm.get_current_state_name();
-        assert_eq!(curr_state_name, "star_6");
     }
 
     #[test]


### PR DESCRIPTION
- Merge `intersect` and `get_layer_bounds` into a single `hit_test` method using a `Point` struct
- Cache layer ID lookups with `FxHashMap` to avoid repeated FFI + `CString` allocation per pointer event
- Handle degenerate OBB (zero-area layers) and add early-exit optimization
- Remove `LayerBoundingBox`, the `dotlottie_get_layer_bounds` C API function, and all public exposure
- Scope `hit_test` and `Point` to `renderer` — internal only, not part of the public API

Resolves #523