### PR TITLE
refactor: unify player state into single Status enum

### DIFF
--- a/dotlottie-rs/examples/audio_player.rs
+++ b/dotlottie-rs/examples/audio_player.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::print_stdout)]
 
-use dotlottie_rs::{ColorSpace, DotLottieEvent, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, DotLottieEvent, DotLottiePlayer, Status};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs;
@@ -134,13 +134,13 @@ fn main() {
         let plus_down = window.is_key_down(Key::Equal) || window.is_key_down(Key::NumPadPlus);
         let minus_down = window.is_key_down(Key::Minus) || window.is_key_down(Key::NumPadMinus);
 
-        if p_was_down && !p_down && (player.is_paused() || player.is_stopped()) {
+        if p_was_down && !p_down && player.status() != Status::Playing {
             let _ = player.play();
         }
-        if s_was_down && !s_down && player.is_playing() {
+        if s_was_down && !s_down && player.status() == Status::Playing {
             let _ = player.pause();
         }
-        if x_was_down && !x_down && !player.is_stopped() {
+        if x_was_down && !x_down && player.status() != Status::Stopped {
             let _ = player.stop();
         }
 
@@ -182,12 +182,11 @@ fn main() {
         } else {
             ""
         };
-        let state = if player.is_playing() {
-            "PLAYING"
-        } else if player.is_paused() {
-            "PAUSED "
-        } else {
-            "STOPPED"
+        let state = match player.status() {
+            Status::Idle => "IDLE",
+            Status::Playing => "PLAYING",
+            Status::Paused => "PAUSED",
+            Status::Stopped => "STOPPED",
         };
         let frame = player.current_frame();
         let vol = player.audio_volume();
@@ -202,7 +201,7 @@ fn main() {
         while let Some(event) = player.poll_event() {
             let _ = player.current_frame();
             match event {
-                DotLottieEvent::Load => println!("  -- Load  (is_loaded={})", player.is_loaded()),
+                DotLottieEvent::Load => println!("  -- Load  (status={:?})", player.status()),
                 DotLottieEvent::LoadError => {
                     eprintln!("  !! LoadError — animation failed to load into ThorVG");
                 }

--- a/dotlottie-rs/examples/audio_player.rs
+++ b/dotlottie-rs/examples/audio_player.rs
@@ -20,7 +20,7 @@
 
 #![allow(clippy::print_stdout)]
 
-use dotlottie_rs::{ColorSpace, Player, PlayerEvent};
+use dotlottie_rs::{ColorSpace, Player, PlayerEvent, Status};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs;
@@ -136,13 +136,13 @@ fn main() {
         let plus_down = window.is_key_down(Key::Equal) || window.is_key_down(Key::NumPadPlus);
         let minus_down = window.is_key_down(Key::Minus) || window.is_key_down(Key::NumPadMinus);
 
-        if p_was_down && !p_down && (player.is_paused() || player.is_stopped()) {
+        if p_was_down && !p_down && player.status() != Status::Playing {
             let _ = player.play();
         }
-        if s_was_down && !s_down && player.is_playing() {
+        if s_was_down && !s_down && player.status() == Status::Playing {
             let _ = player.pause();
         }
-        if x_was_down && !x_down && !player.is_stopped() {
+        if x_was_down && !x_down && player.status() != Status::Stopped {
             let _ = player.stop();
         }
 
@@ -191,12 +191,12 @@ fn main() {
         } else {
             ""
         };
-        let state = if player.is_playing() {
-            "PLAYING"
-        } else if player.is_paused() {
-            "PAUSED "
-        } else {
-            "STOPPED"
+        let state = match player.status() {
+            Status::Idle => "IDLE",
+            Status::Playing => "PLAYING",
+            Status::Paused => "PAUSED",
+            Status::Stopped => "STOPPED",
+            Status::Tweening => "TWEENING",
         };
         let frame = player.current_frame();
         let vol = player.audio_volume();
@@ -210,7 +210,7 @@ fn main() {
         // Print audio (and notable playback) events as they arrive.
         while let Some(event) = player.poll_event() {
             match event {
-                PlayerEvent::Load => println!("  -- Load  (is_loaded={})", player.is_loaded()),
+                PlayerEvent::Load => println!("  -- Load  (status={:?})", player.status()),
                 PlayerEvent::LoadError => {
                     eprintln!("  !! LoadError — animation failed to load into ThorVG");
                 }

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{DotLottiePlayer, DotLottiePlayerError, Layout, Mode, Rgba, Segment};
+use crate::{DotLottiePlayer, DotLottiePlayerError, Layout, Mode, Rgba, Segment, Status};
 
 use crate::ColorSpace;
 
@@ -716,38 +716,13 @@ pub unsafe extern "C" fn dotlottie_current_loop_count(
     })
 }
 
-/// Returns whether an animation is loaded.
+/// Returns the current status (Idle, Playing, Paused, or Stopped).
+/// Returns Idle if the pointer is invalid.
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_is_loaded(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_status(ptr: *mut DotLottiePlayer) -> Status {
     match ptr.as_mut() {
-        Some(p) => p.is_loaded(),
-        _ => false,
-    }
-}
-
-/// Returns the current playback status.
-///
-/// Priority order: Playing > Paused > Stopped
-///
-/// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
-///
-/// # Returns
-/// The current PlaybackStatus (Playing, Paused, or Stopped)
-/// Returns Stopped if the pointer is invalid
-#[no_mangle]
-pub unsafe extern "C" fn dotlottie_playback_status(ptr: *mut DotLottiePlayer) -> PlaybackStatus {
-    match ptr.as_mut() {
-        Some(p) => {
-            if p.is_playing() {
-                PlaybackStatus::Playing
-            } else if p.is_paused() {
-                PlaybackStatus::Paused
-            } else {
-                PlaybackStatus::Stopped
-            }
-        }
-        _ => PlaybackStatus::Stopped,
+        Some(p) => p.status(),
+        _ => Status::Idle,
     }
 }
 

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{Layout, Mode, Player, PlayerError, Rgba, Segment};
+use crate::{Layout, Mode, Player, PlayerError, Rgba, Segment, Status};
 
 use crate::ColorSpace;
 
@@ -710,38 +710,13 @@ pub unsafe extern "C" fn dotlottie_get_current_loop_count(
     })
 }
 
-/// Returns whether an animation is loaded.
+/// Returns the current status (Idle, Playing, Paused, Stopped, or Tweening).
+/// Returns Idle if the pointer is invalid.
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_is_loaded(ptr: *mut Player) -> bool {
+pub unsafe extern "C" fn dotlottie_status(ptr: *mut Player) -> Status {
     match ptr.as_mut() {
-        Some(p) => p.is_loaded(),
-        _ => false,
-    }
-}
-
-/// Returns the current playback status.
-///
-/// Priority order: Playing > Paused > Stopped
-///
-/// # Parameters
-/// - `ptr`: Pointer to the Player instance
-///
-/// # Returns
-/// The current PlaybackStatus (Playing, Paused, or Stopped)
-/// Returns Stopped if the pointer is invalid
-#[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_playback_status(ptr: *mut Player) -> PlaybackStatus {
-    match ptr.as_mut() {
-        Some(p) => {
-            if p.is_playing() {
-                PlaybackStatus::Playing
-            } else if p.is_paused() {
-                PlaybackStatus::Paused
-            } else {
-                PlaybackStatus::Stopped
-            }
-        }
-        _ => PlaybackStatus::Stopped,
+        Some(p) => p.status(),
+        _ => Status::Idle,
     }
 }
 

--- a/dotlottie-rs/src/c_api/types.rs
+++ b/dotlottie-rs/src/c_api/types.rs
@@ -13,14 +13,6 @@ use crate::DotLottiePlayerError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
-pub enum PlaybackStatus {
-    Playing = 0,
-    Paused = 1,
-    Stopped = 2,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(C)]
 pub enum DotLottieResult {
     Success = 0,
     Error = 1,

--- a/dotlottie-rs/src/c_api/types.rs
+++ b/dotlottie-rs/src/c_api/types.rs
@@ -13,14 +13,6 @@ use crate::PlayerError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
-pub enum PlaybackStatus {
-    Playing = 0,
-    Paused = 1,
-    Stopped = 2,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(C)]
 pub enum DotLottieResult {
     Success = 0,
     Error = 1,

--- a/dotlottie-rs/src/lib.rs
+++ b/dotlottie-rs/src/lib.rs
@@ -6,6 +6,7 @@ mod fms;
 mod layout;
 mod lottie_renderer;
 mod player;
+mod player_state;
 mod poll_events;
 mod result;
 #[cfg(feature = "state-machines")]

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -256,6 +256,7 @@ impl DotLottiePlayer {
         }
         if self.status == Status::Tweening {
             self.tween_state = None;
+            self.resume_status = Status::Stopped;
         }
 
         self.status = Status::Stopped;

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -18,10 +18,14 @@ use crate::{DotLottieManager, Manifest};
 #[cfg(feature = "state-machines")]
 use crate::{StateMachineEngine, StateMachineEngineError};
 
-pub enum PlaybackState {
-    Playing,
-    Paused,
-    Stopped,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum Status {
+    Idle = 0,
+    Playing = 1,
+    Paused = 2,
+    Stopped = 3,
+    Tweening = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
@@ -57,8 +61,7 @@ pub enum CompletionEvent {
 
 pub struct DotLottiePlayer {
     pub(crate) renderer: Box<dyn LottieRenderer>,
-    playback_state: PlaybackState,
-    is_loaded: bool,
+    status: Status,
     elapsed_frames: f32,
     current_loop_count: u32,
     #[cfg(feature = "dotlottie")]
@@ -69,7 +72,7 @@ pub struct DotLottiePlayer {
     active_marker: Option<CString>,
     event_queue: EventQueue<DotLottieEvent>,
     completion_event: CompletionEvent,
-    // Playback config properties
+    // Config properties
     mode: Mode,
     loop_animation: bool,
     loop_count: u32,
@@ -78,6 +81,7 @@ pub struct DotLottiePlayer {
     autoplay: bool,
     layout: Layout,
     tween_state: Option<TweenState>,
+    resume_status: Status,
     #[cfg(feature = "theming")]
     theme_id: Option<CString>,
     #[cfg(feature = "dotlottie")]
@@ -119,8 +123,7 @@ impl DotLottiePlayer {
     pub fn with_renderer<R: Renderer>(renderer: R) -> Self {
         DotLottiePlayer {
             renderer: <dyn LottieRenderer>::new(renderer),
-            playback_state: PlaybackState::Stopped,
-            is_loaded: false,
+            status: Status::Idle,
             elapsed_frames: 0.0,
             current_loop_count: 0,
             mode: Mode::Forward,
@@ -131,6 +134,7 @@ impl DotLottiePlayer {
             autoplay: false,
             layout: Layout::default(),
             tween_state: None,
+            resume_status: Status::Stopped,
             #[cfg(feature = "theming")]
             theme_id: None,
             #[cfg(feature = "dotlottie")]
@@ -180,34 +184,20 @@ impl DotLottiePlayer {
         self.renderer.segment().map_or(0.0, |seg| seg.end)
     }
 
-    pub fn is_loaded(&self) -> bool {
-        self.is_loaded
-    }
-
     #[inline]
-    pub fn is_playing(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Playing)
-    }
-
-    #[inline]
-    pub fn is_paused(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Paused)
-    }
-
-    #[inline]
-    pub fn is_stopped(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Stopped)
+    pub fn status(&self) -> Status {
+        self.status
     }
 
     pub fn play(&mut self) -> Result<(), DotLottiePlayerError> {
-        if !self.is_loaded {
+        if self.status == Status::Idle {
             return Err(DotLottiePlayerError::AnimationNotLoaded);
         }
-        if self.is_playing() {
+        if self.status == Status::Playing || self.status == Status::Tweening {
             return Err(DotLottiePlayerError::InsufficientCondition);
         }
 
-        if self.is_complete() && self.is_stopped() {
+        if self.is_complete() && self.status == Status::Stopped {
             self.elapsed_frames = 0.0;
             match self.mode {
                 Mode::Forward | Mode::Bounce => {
@@ -227,7 +217,7 @@ impl DotLottiePlayer {
             };
         }
 
-        self.playback_state = PlaybackState::Playing;
+        self.status = Status::Playing;
 
         #[cfg(feature = "audio")]
         if let Some(am) = &mut self.audio_manager {
@@ -240,13 +230,13 @@ impl DotLottiePlayer {
     }
 
     pub fn pause(&mut self) -> Result<(), DotLottiePlayerError> {
-        if !self.is_loaded {
+        if self.status == Status::Idle {
             return Err(DotLottiePlayerError::AnimationNotLoaded);
         }
-        if !self.is_playing() {
+        if self.status != Status::Playing {
             return Err(DotLottiePlayerError::InsufficientCondition);
         }
-        self.playback_state = PlaybackState::Paused;
+        self.status = Status::Paused;
 
         #[cfg(feature = "audio")]
         if let Some(am) = &mut self.audio_manager {
@@ -258,14 +248,17 @@ impl DotLottiePlayer {
     }
 
     pub fn stop(&mut self) -> Result<(), DotLottiePlayerError> {
-        if !self.is_loaded {
+        if self.status == Status::Idle {
             return Err(DotLottiePlayerError::AnimationNotLoaded);
         }
-        if self.is_stopped() {
+        if self.status == Status::Stopped {
             return Err(DotLottiePlayerError::InsufficientCondition);
         }
+        if self.status == Status::Tweening {
+            self.tween_state = None;
+        }
 
-        self.playback_state = PlaybackState::Stopped;
+        self.status = Status::Stopped;
 
         let start_frame = self.start_frame();
         let end_frame = self.end_frame();
@@ -312,7 +305,7 @@ impl DotLottiePlayer {
     }
 
     fn next_frame(&mut self) -> f32 {
-        if !self.is_loaded || !self.is_playing() {
+        if self.status != Status::Playing {
             return self.current_frame();
         }
 
@@ -455,7 +448,7 @@ impl DotLottiePlayer {
 
     #[inline]
     fn advance_frames(&mut self, dt: f32) {
-        if self.is_playing() {
+        if self.status == Status::Playing {
             let duration = self.duration();
             if duration > 0.0 {
                 let fps = self.total_frames() / duration;
@@ -488,7 +481,7 @@ impl DotLottiePlayer {
             .push(DotLottieEvent::Frame { frame_no: no });
 
         #[cfg(feature = "audio")]
-        if self.is_playing() {
+        if self.status == Status::Playing {
             if let Some(am) = &mut self.audio_manager {
                 am.update(no);
             }
@@ -541,7 +534,7 @@ impl DotLottiePlayer {
 
         // Completion logic only applies during active playback — not when the
         // caller renders manually (e.g. scrubbing while paused/stopped).
-        if self.is_playing() && self.is_complete() {
+        if self.status == Status::Playing && self.is_complete() {
             if self.loop_animation {
                 let count_complete =
                     self.loop_count > 0 && self.current_loop_count() >= self.loop_count;
@@ -565,7 +558,7 @@ impl DotLottiePlayer {
                     self.reset_current_loop_count();
                 }
             } else {
-                self.playback_state = PlaybackState::Stopped;
+                self.status = Status::Stopped;
                 self.emit_on_complete();
             }
         }
@@ -836,7 +829,8 @@ impl DotLottiePlayer {
         F: FnOnce(&mut dyn LottieRenderer) -> Result<(), LottieRendererError>,
     {
         self.clear();
-        self.playback_state = PlaybackState::Stopped;
+        self.tween_state = None;
+        self.status = Status::Idle;
         self.elapsed_frames = 0.0;
         self.current_loop_count = 0;
 
@@ -846,7 +840,11 @@ impl DotLottiePlayer {
             return Err(DotLottiePlayerError::Unknown);
         }
 
-        self.is_loaded = loaded;
+        if !loaded {
+            return Err(DotLottiePlayerError::Unknown);
+        }
+
+        self.status = Status::Stopped;
 
         let start_frame = self.start_frame();
         let end_frame = self.end_frame();
@@ -864,11 +862,7 @@ impl DotLottiePlayer {
 
         let _ = self.renderer.render();
 
-        if loaded {
-            Ok(())
-        } else {
-            Err(DotLottiePlayerError::Unknown)
-        }
+        Ok(())
     }
 
     pub fn load_animation_data(
@@ -1043,7 +1037,7 @@ impl DotLottiePlayer {
     }
 
     pub fn is_complete(&self) -> bool {
-        if !self.is_loaded() {
+        if self.status == Status::Idle || self.status == Status::Tweening {
             return false;
         }
 
@@ -1364,17 +1358,17 @@ impl DotLottiePlayer {
         duration: f32,
         easing: [f32; 4],
     ) -> Result<(), DotLottiePlayerError> {
-        if self.is_tweening() {
+        if self.status == Status::Idle {
+            return Err(DotLottiePlayerError::AnimationNotLoaded);
+        }
+        if self.status == Status::Tweening {
             return Err(DotLottiePlayerError::InsufficientCondition);
         }
         let from = self.current_frame();
         self.tween_state = Some(TweenState::new(from, to, duration, easing)?);
+        self.resume_status = self.status;
+        self.status = Status::Tweening;
         Ok(())
-    }
-
-    #[inline]
-    pub fn is_tweening(&self) -> bool {
-        self.tween_state.is_some()
     }
 
     pub(crate) fn sync_tween_frame(&mut self, frame: f32) {
@@ -1403,6 +1397,7 @@ impl DotLottiePlayer {
                 Direction::Reverse => self.end_frame() - to,
             };
             self.tween_state = None;
+            self.status = self.resume_status;
         }
 
         Ok(status)
@@ -1448,7 +1443,7 @@ impl DotLottiePlayer {
     pub fn tick(&mut self, dt: f32) -> Result<bool, DotLottiePlayerError> {
         let dt = dt.max(0.0);
 
-        if self.is_tweening() {
+        if self.status == Status::Tweening {
             match self.tween_advance(dt) {
                 Ok(_) => {
                     self.render()?;
@@ -1456,6 +1451,7 @@ impl DotLottiePlayer {
                 }
                 Err(e) => {
                     self.tween_state = None;
+                    self.status = self.resume_status;
                     Err(e)
                 }
             }

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -4,6 +4,7 @@ use std::{fs, mem};
 
 #[cfg(feature = "audio")]
 use crate::audio::AudioManager;
+use crate::player_state::{Resume, State, TweenOutcome};
 use crate::poll_events::{EventQueue, PlayerEvent};
 use crate::PlayerError;
 use crate::{
@@ -26,10 +27,14 @@ use std::rc::Rc;
 #[cfg(feature = "audio")]
 use std::sync::Arc;
 
-pub enum PlaybackState {
-    Playing,
-    Paused,
-    Stopped,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum Status {
+    Idle = 0,
+    Playing = 1,
+    Paused = 2,
+    Stopped = 3,
+    Tweening = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
@@ -65,8 +70,8 @@ pub enum CompletionEvent {
 
 pub struct Player {
     pub(crate) renderer: Box<dyn LottieRenderer>,
-    playback_state: PlaybackState,
-    is_loaded: bool,
+    state: State,
+    tween_outcome: Option<TweenOutcome>,
     elapsed_frames: f32,
     current_loop_count: u32,
     #[cfg(feature = "dotlottie")]
@@ -77,7 +82,7 @@ pub struct Player {
     active_marker: Option<CString>,
     event_queue: EventQueue<PlayerEvent, 16>,
     completion_event: CompletionEvent,
-    // Playback config properties
+    // Config properties
     mode: Mode,
     loop_animation: bool,
     loop_count: u32,
@@ -85,7 +90,6 @@ pub struct Player {
     use_frame_interpolation: bool,
     autoplay: bool,
     layout: Layout,
-    tween_state: Option<TweenState>,
     #[cfg(feature = "theming")]
     theme_id: Option<CString>,
     #[cfg(feature = "dotlottie")]
@@ -127,8 +131,8 @@ impl Player {
     pub fn with_renderer<R: Renderer>(renderer: R) -> Self {
         Player {
             renderer: <dyn LottieRenderer>::new(renderer),
-            playback_state: PlaybackState::Stopped,
-            is_loaded: false,
+            state: State::Idle,
+            tween_outcome: None,
             elapsed_frames: 0.0,
             current_loop_count: 0,
             mode: Mode::Forward,
@@ -138,7 +142,6 @@ impl Player {
             use_frame_interpolation: true,
             autoplay: false,
             layout: Layout::default(),
-            tween_state: None,
             #[cfg(feature = "theming")]
             theme_id: None,
             #[cfg(feature = "dotlottie")]
@@ -216,34 +219,50 @@ impl Player {
         self.renderer.segment().map_or(0.0, |seg| seg.end)
     }
 
-    pub fn is_loaded(&self) -> bool {
-        self.is_loaded
+    #[inline]
+    pub fn status(&self) -> Status {
+        match self.state {
+            State::Idle => Status::Idle,
+            State::Stopped => Status::Stopped,
+            State::Paused => Status::Paused,
+            State::Playing => Status::Playing,
+            State::Tweening { .. } => Status::Tweening,
+        }
     }
 
-    #[inline]
-    pub fn is_playing(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Playing)
+    fn end_tween(&mut self, outcome: TweenOutcome) {
+        if let State::Tweening { resume, .. } = self.state {
+            self.state = resume.into();
+            self.tween_outcome = Some(outcome);
+        }
     }
 
-    #[inline]
-    pub fn is_paused(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Paused)
-    }
-
-    #[inline]
-    pub fn is_stopped(&self) -> bool {
-        matches!(self.playback_state, PlaybackState::Stopped)
+    pub(crate) fn take_tween_outcome(&mut self) -> Option<TweenOutcome> {
+        self.tween_outcome.take()
     }
 
     pub fn play(&mut self) -> Result<(), PlayerError> {
-        if !self.is_loaded {
-            return Err(PlayerError::AnimationNotLoaded);
-        }
-        if self.is_playing() {
-            return Err(PlayerError::InsufficientCondition);
+        match &mut self.state {
+            State::Idle => return Err(PlayerError::AnimationNotLoaded),
+            State::Playing => return Err(PlayerError::InsufficientCondition),
+            State::Tweening { resume, .. } => {
+                if *resume == Resume::Playing {
+                    return Err(PlayerError::InsufficientCondition);
+                }
+                *resume = Resume::Playing;
+
+                #[cfg(feature = "audio")]
+                if let Some(am) = &self.audio {
+                    am.borrow_mut().set_playing(true);
+                }
+
+                self.event_queue.push(PlayerEvent::Play);
+                return Ok(());
+            }
+            State::Stopped | State::Paused => {}
         }
 
-        if self.is_complete() && self.is_stopped() {
+        if self.is_complete() && matches!(self.state, State::Stopped) {
             self.elapsed_frames = 0.0;
             match self.mode {
                 Mode::Forward | Mode::Bounce => {
@@ -263,7 +282,7 @@ impl Player {
             };
         }
 
-        self.playback_state = PlaybackState::Playing;
+        self.state = State::Playing;
 
         #[cfg(feature = "audio")]
         if let Some(am) = &self.audio {
@@ -276,13 +295,23 @@ impl Player {
     }
 
     pub fn pause(&mut self) -> Result<(), PlayerError> {
-        if !self.is_loaded {
-            return Err(PlayerError::AnimationNotLoaded);
+        match &mut self.state {
+            State::Idle => return Err(PlayerError::AnimationNotLoaded),
+            State::Playing => {}
+            State::Tweening { resume, .. } if *resume == Resume::Playing => {
+                *resume = Resume::Paused;
+
+                #[cfg(feature = "audio")]
+                if let Some(am) = &self.audio {
+                    am.borrow_mut().set_playing(false);
+                }
+
+                self.event_queue.push(PlayerEvent::Pause);
+                return Ok(());
+            }
+            _ => return Err(PlayerError::InsufficientCondition),
         }
-        if !self.is_playing() {
-            return Err(PlayerError::InsufficientCondition);
-        }
-        self.playback_state = PlaybackState::Paused;
+        self.state = State::Paused;
 
         #[cfg(feature = "audio")]
         if let Some(am) = &self.audio {
@@ -294,14 +323,14 @@ impl Player {
     }
 
     pub fn stop(&mut self) -> Result<(), PlayerError> {
-        if !self.is_loaded {
-            return Err(PlayerError::AnimationNotLoaded);
-        }
-        if self.is_stopped() {
-            return Err(PlayerError::InsufficientCondition);
+        match self.state {
+            State::Idle => return Err(PlayerError::AnimationNotLoaded),
+            State::Stopped => return Err(PlayerError::InsufficientCondition),
+            State::Tweening { .. } => self.end_tween(TweenOutcome::Cancelled),
+            State::Playing | State::Paused => {}
         }
 
-        self.playback_state = PlaybackState::Stopped;
+        self.state = State::Stopped;
 
         let start_frame = self.start_frame();
         let end_frame = self.end_frame();
@@ -348,7 +377,7 @@ impl Player {
     }
 
     fn next_frame(&mut self) -> f32 {
-        if !self.is_loaded || !self.is_playing() {
+        if !matches!(self.state, State::Playing) {
             return self.current_frame();
         }
 
@@ -491,7 +520,7 @@ impl Player {
 
     #[inline]
     fn advance_frames(&mut self, dt: f32) {
-        if self.is_playing() {
+        if matches!(self.state, State::Playing) {
             let duration = self.duration();
             if duration > 0.0 {
                 let fps = self.total_frames() / duration;
@@ -563,7 +592,7 @@ impl Player {
 
         // Completion logic only applies during active playback — not when the
         // caller renders manually (e.g. scrubbing while paused/stopped).
-        if self.is_playing() && self.is_complete() {
+        if matches!(self.state, State::Playing) && self.is_complete() {
             if self.loop_animation {
                 let count_complete =
                     self.loop_count > 0 && self.current_loop_count() >= self.loop_count;
@@ -590,7 +619,7 @@ impl Player {
                     self.reset_current_loop_count();
                 }
             } else {
-                self.playback_state = PlaybackState::Stopped;
+                self.state = State::Stopped;
                 self.emit_on_complete();
             }
         }
@@ -851,17 +880,18 @@ impl Player {
     where
         F: FnOnce(&mut dyn LottieRenderer) -> Result<(), LottieRendererError>,
     {
-        self.playback_state = PlaybackState::Stopped;
+        self.end_tween(TweenOutcome::Cancelled);
+        self.state = State::Idle;
         self.elapsed_frames = 0.0;
         self.current_loop_count = 0;
 
         let loaded = loader(&mut *self.renderer).is_ok();
 
-        if self.renderer.set_layout(&self.layout).is_err() {
+        if self.renderer.set_layout(&self.layout).is_err() || !loaded {
             return Err(PlayerError::Unknown);
         }
 
-        self.is_loaded = loaded;
+        self.state = State::Stopped;
 
         let start_frame = self.start_frame();
         let end_frame = self.end_frame();
@@ -879,11 +909,7 @@ impl Player {
 
         let _ = self.renderer.render();
 
-        if loaded {
-            Ok(())
-        } else {
-            Err(PlayerError::Unknown)
-        }
+        Ok(())
     }
 
     pub fn load_animation_data(&mut self, animation_data: &CStr) -> Result<(), PlayerError> {
@@ -1056,7 +1082,7 @@ impl Player {
     }
 
     pub fn is_complete(&self) -> bool {
-        if !self.is_loaded() {
+        if matches!(self.state, State::Idle | State::Tweening { .. }) {
             return false;
         }
 
@@ -1452,17 +1478,18 @@ impl Player {
     }
 
     pub fn tween(&mut self, to: f32, duration: f32, easing: [f32; 4]) -> Result<(), PlayerError> {
-        if self.is_tweening() {
-            return Err(PlayerError::InsufficientCondition);
-        }
+        let resume = match self.state {
+            State::Idle => return Err(PlayerError::AnimationNotLoaded),
+            State::Tweening { .. } => return Err(PlayerError::InsufficientCondition),
+            State::Stopped => Resume::Stopped,
+            State::Paused => Resume::Paused,
+            State::Playing => Resume::Playing,
+        };
         let from = self.current_frame();
-        self.tween_state = Some(TweenState::new(from, to, duration, easing)?);
+        let tween = TweenState::new(from, to, duration, easing)?;
+        self.tween_outcome = None;
+        self.state = State::Tweening { tween, resume };
         Ok(())
-    }
-
-    #[inline]
-    pub fn is_tweening(&self) -> bool {
-        self.tween_state.is_some()
     }
 
     pub(crate) fn sync_tween_frame(&mut self, frame: f32) {
@@ -1474,23 +1501,25 @@ impl Player {
     }
 
     pub fn tween_advance(&mut self, dt: f32) -> Result<TweenStatus, PlayerError> {
-        let tween = self
-            .tween_state
-            .as_mut()
-            .ok_or(PlayerError::InsufficientCondition)?;
+        let (status, progress, from, to) = match &mut self.state {
+            State::Tweening { tween, .. } => {
+                let (status, progress) = tween.update(dt);
+                (status, progress, tween.from, tween.to)
+            }
+            _ => return Err(PlayerError::InsufficientCondition),
+        };
 
-        let (status, progress) = tween.update(dt);
-        let from = tween.from;
-        let to = tween.to;
-
-        self.renderer.tween(from, to, progress)?;
+        if let Err(e) = self.renderer.tween(from, to, progress) {
+            self.end_tween(TweenOutcome::Cancelled);
+            return Err(e.into());
+        }
 
         if status == TweenStatus::Completed {
             self.elapsed_frames = match self.direction {
                 Direction::Forward => to - self.start_frame(),
                 Direction::Reverse => self.end_frame() - to,
             };
-            self.tween_state = None;
+            self.end_tween(TweenOutcome::Completed);
         }
 
         Ok(status)
@@ -1536,16 +1565,13 @@ impl Player {
     pub fn tick(&mut self, dt: f32) -> Result<bool, PlayerError> {
         let dt = dt.max(0.0);
 
-        if self.is_tweening() {
+        if matches!(self.state, State::Tweening { .. }) {
             match self.tween_advance(dt) {
                 Ok(_) => {
                     self.render()?;
                     Ok(true)
                 }
-                Err(e) => {
-                    self.tween_state = None;
-                    Err(e)
-                }
+                Err(e) => Err(e),
             }
         } else {
             self.advance_frames(dt);

--- a/dotlottie-rs/src/player_state.rs
+++ b/dotlottie-rs/src/player_state.rs
@@ -1,0 +1,44 @@
+use crate::tween::TweenState;
+
+pub(crate) enum State {
+    Idle,
+    Stopped,
+    Paused,
+    Playing,
+    Tweening { tween: TweenState, resume: Resume },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Resume {
+    Stopped,
+    Paused,
+    Playing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TweenOutcome {
+    Completed,
+    Cancelled,
+}
+
+impl From<Resume> for State {
+    fn from(resume: Resume) -> Self {
+        match resume {
+            Resume::Stopped => State::Stopped,
+            Resume::Paused => State::Paused,
+            Resume::Playing => State::Playing,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_maps_to_matching_state() {
+        assert!(matches!(State::from(Resume::Stopped), State::Stopped));
+        assert!(matches!(State::from(Resume::Paused), State::Paused));
+        assert!(matches!(State::from(Resume::Playing), State::Playing));
+    }
+}

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -1408,8 +1408,8 @@ impl<'a> StateMachineEngine<'a> {
 
         self.check_completion();
 
-        let needs_resume =
-            self.status == StateMachineEngineStatus::Tweening && !self.player.is_tweening();
+        let needs_resume = self.status == StateMachineEngineStatus::Tweening
+            && self.player.status() != crate::Status::Tweening;
 
         if needs_resume {
             self.resume_from_tweening();

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -33,6 +33,7 @@ use crate::state_machine::StringNumberBool;
 
 use crate::actions::whitelist::Whitelist;
 use crate::event_queue::EventQueue;
+use crate::player_state::TweenOutcome;
 use crate::state_machine_engine::events::{StateMachineEvent, StateMachineInternalEvent};
 use crate::state_machine_engine::interactions::Interaction;
 use crate::{
@@ -708,6 +709,15 @@ impl<'a> StateMachineEngine<'a> {
                 self.current_state = Some(state);
             }
         }
+    }
+
+    fn abort_tweening(&mut self) {
+        if self.status != StateMachineEngineStatus::Tweening {
+            return;
+        }
+        self.status = StateMachineEngineStatus::Running;
+        self.tween_transition_target_state = None;
+        self.tween_target_frame = None;
     }
 
     // Set the current state to the target state
@@ -1448,11 +1458,17 @@ impl<'a> StateMachineEngine<'a> {
 
         self.check_completion();
 
-        let needs_resume =
-            self.status == StateMachineEngineStatus::Tweening && !self.player.is_tweening();
-
-        if needs_resume {
-            self.resume_from_tweening();
+        if self.status == StateMachineEngineStatus::Tweening
+            && self.player.status() != crate::Status::Tweening
+        {
+            match self.player.take_tween_outcome() {
+                Some(TweenOutcome::Completed) => self.resume_from_tweening(),
+                Some(TweenOutcome::Cancelled) => self.abort_tweening(),
+                None => {
+                    debug_assert!(false, "tween ended without recording an outcome");
+                    self.abort_tweening();
+                }
+            }
         }
 
         if self.status != StateMachineEngineStatus::Stopped {

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -138,6 +138,29 @@ impl From<PlayerMode> for Mode {
     }
 }
 
+/// Current status of the animation player.
+#[wasm_bindgen]
+#[derive(Clone, Copy, PartialEq)]
+pub enum Status {
+    Idle = 0,
+    Playing = 1,
+    Paused = 2,
+    Stopped = 3,
+    Tweening = 4,
+}
+
+impl From<crate::Status> for Status {
+    fn from(s: crate::Status) -> Self {
+        match s {
+            crate::Status::Idle => Status::Idle,
+            crate::Status::Playing => Status::Playing,
+            crate::Status::Paused => Status::Paused,
+            crate::Status::Stopped => Status::Stopped,
+            crate::Status::Tweening => Status::Tweening,
+        }
+    }
+}
+
 // ─── JS object helpers ────────────────────────────────────────────────────────
 
 fn js_obj_with_type(type_name: &str) -> Object {
@@ -462,23 +485,11 @@ impl DotLottiePlayerWasm {
 
     // ── State queries ─────────────────────────────────────────────────────────
 
-    pub fn is_playing(&self) -> bool {
-        self.player.is_playing()
-    }
-    pub fn is_paused(&self) -> bool {
-        self.player.is_paused()
-    }
-    pub fn is_stopped(&self) -> bool {
-        self.player.is_stopped()
-    }
-    pub fn is_loaded(&self) -> bool {
-        self.player.is_loaded()
+    pub fn status(&self) -> Status {
+        self.player.status().into()
     }
     pub fn is_complete(&self) -> bool {
         self.player.is_complete()
-    }
-    pub fn is_tweening(&self) -> bool {
-        self.player.is_tweening()
     }
 
     // ── Frame queries ─────────────────────────────────────────────────────────

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -138,6 +138,29 @@ impl From<PlayerMode> for Mode {
     }
 }
 
+/// Current status of the animation player.
+#[wasm_bindgen]
+#[derive(Clone, Copy, PartialEq)]
+pub enum Status {
+    Idle = 0,
+    Playing = 1,
+    Paused = 2,
+    Stopped = 3,
+    Tweening = 4,
+}
+
+impl From<crate::Status> for Status {
+    fn from(s: crate::Status) -> Self {
+        match s {
+            crate::Status::Idle => Status::Idle,
+            crate::Status::Playing => Status::Playing,
+            crate::Status::Paused => Status::Paused,
+            crate::Status::Stopped => Status::Stopped,
+            crate::Status::Tweening => Status::Tweening,
+        }
+    }
+}
+
 // ─── JS object helpers ────────────────────────────────────────────────────────
 
 fn js_obj_with_type(type_name: &str) -> Object {
@@ -455,23 +478,11 @@ impl DotLottiePlayerWasm {
 
     // ── State queries ─────────────────────────────────────────────────────────
 
-    pub fn is_playing(&self) -> bool {
-        self.player.is_playing()
-    }
-    pub fn is_paused(&self) -> bool {
-        self.player.is_paused()
-    }
-    pub fn is_stopped(&self) -> bool {
-        self.player.is_stopped()
-    }
-    pub fn is_loaded(&self) -> bool {
-        self.player.is_loaded()
+    pub fn status(&self) -> Status {
+        self.player.status().into()
     }
     pub fn is_complete(&self) -> bool {
         self.player.is_complete()
-    }
-    pub fn is_tweening(&self) -> bool {
-        self.player.is_tweening()
     }
 
     // ── Frame queries ─────────────────────────────────────────────────────────

--- a/dotlottie-rs/tests/autoplay.rs
+++ b/dotlottie-rs/tests/autoplay.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -39,9 +39,7 @@ mod tests {
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
         assert!(player.load_animation_path(&path).is_ok());
-        assert!(player.is_playing());
-        assert!(!player.is_paused());
-        assert!(!player.is_stopped());
+        assert_eq!(player.status(), Status::Playing);
         assert!(!player.is_complete());
         assert_eq!(player.current_frame(), 0.0);
 
@@ -73,9 +71,7 @@ mod tests {
 
         assert!(loaded.is_ok());
 
-        assert!(!player.is_playing());
-        assert!(!player.is_paused());
-        assert!(player.is_stopped());
+        assert_eq!(player.status(), Status::Stopped);
         assert!(!player.is_complete());
         assert!(player.current_frame() == 0.0);
 

--- a/dotlottie-rs/tests/autoplay.rs
+++ b/dotlottie-rs/tests/autoplay.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player};
+use dotlottie_rs::{ColorSpace, Player, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -39,9 +39,7 @@ mod tests {
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
         assert!(player.load_animation_path(&path).is_ok());
-        assert!(player.is_playing());
-        assert!(!player.is_paused());
-        assert!(!player.is_stopped());
+        assert_eq!(player.status(), Status::Playing);
         assert!(!player.is_complete());
         assert_eq!(player.current_frame(), 0.0);
 
@@ -73,9 +71,7 @@ mod tests {
 
         assert!(loaded.is_ok());
 
-        assert!(!player.is_playing());
-        assert!(!player.is_paused());
-        assert!(player.is_stopped());
+        assert_eq!(player.status(), Status::Stopped);
         assert!(!player.is_complete());
         assert!(player.current_frame() == 0.0);
 

--- a/dotlottie-rs/tests/markers.rs
+++ b/dotlottie-rs/tests/markers.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -86,7 +86,11 @@ mod tests {
 
         assert_eq!(player.active_marker(), Some(marker_name.as_c_str()));
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         // assert current frame is the marker start
         assert_eq!(player.current_frame(), 20.0);

--- a/dotlottie-rs/tests/markers.rs
+++ b/dotlottie-rs/tests/markers.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player, Segment};
+use dotlottie_rs::{ColorSpace, Player, Segment, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -86,7 +86,11 @@ mod tests {
 
         assert_eq!(player.active_marker(), Some(marker_name.as_c_str()));
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         // assert current frame is the marker start
         assert_eq!(player.current_frame(), 20.0);

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use std::ffi::CString;
 
 use crate::test_utils::{HEIGHT, WIDTH};
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError, Status};
 
 #[cfg(test)]
 mod tests {
@@ -50,7 +50,11 @@ mod tests {
 
         assert_eq!(player.play(), Ok(()));
 
-        assert!(player.is_playing(), "Expected player to be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Expected player to be playing"
+        );
 
         assert_eq!(
             player.play(),
@@ -127,7 +131,11 @@ mod tests {
 
         assert!(player.is_complete(), "Expected player to be complete");
 
-        assert!(!player.is_playing(), "Expected player to not be playing");
+        assert_ne!(
+            player.status(),
+            Status::Playing,
+            "Expected player to not be playing"
+        );
 
         assert!(
             player.current_frame() == player.total_frames() - 1.0,

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use std::ffi::CString;
 
 use crate::test_utils::{HEIGHT, WIDTH};
-use dotlottie_rs::{ColorSpace, Player, PlayerError};
+use dotlottie_rs::{ColorSpace, Player, PlayerError, Status};
 
 #[cfg(test)]
 mod tests {
@@ -50,7 +50,11 @@ mod tests {
 
         assert_eq!(player.play(), Ok(()));
 
-        assert!(player.is_playing(), "Expected player to be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Expected player to be playing"
+        );
 
         assert_eq!(
             player.play(),
@@ -127,7 +131,11 @@ mod tests {
 
         assert!(player.is_complete(), "Expected player to be complete");
 
-        assert!(!player.is_playing(), "Expected player to not be playing");
+        assert_ne!(
+            player.status(),
+            Status::Playing,
+            "Expected player to not be playing"
+        );
 
         assert!(
             player.current_frame() == player.total_frames() - 1.0,

--- a/dotlottie-rs/tests/play_mode.rs
+++ b/dotlottie-rs/tests/play_mode.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Status};
 
 mod test_utils;
 
@@ -46,11 +46,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -100,11 +104,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -148,11 +156,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -185,7 +197,7 @@ mod play_mode_tests {
         observed_completed = false;
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -237,11 +249,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() >= 3 {
+            if player.status() != Status::Playing || player.current_loop_count() >= 3 {
                 break;
             }
             assert!(
@@ -272,7 +288,7 @@ mod play_mode_tests {
         let _ = player.play();
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 10 {
+            if player.status() != Status::Playing || player.current_loop_count() > 10 {
                 break;
             }
             assert!(
@@ -388,7 +404,11 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         let mut rendered_frames: Vec<f32> = vec![];
@@ -443,11 +463,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -496,7 +520,11 @@ mod play_mode_tests {
             "Animation should load"
         );
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         let mut rendered_frames: Vec<f32> = vec![];
@@ -548,11 +576,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -604,7 +636,11 @@ mod play_mode_tests {
 
         let mut rendered_frames: Vec<f32> = vec![];
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         while !player.is_complete() {
@@ -672,10 +708,14 @@ mod play_mode_tests {
             Ok(()),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -723,7 +763,11 @@ mod play_mode_tests {
             "Animation should load"
         );
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         let mut rendered_frames: Vec<f32> = vec![];
 
@@ -792,10 +836,14 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(

--- a/dotlottie-rs/tests/play_mode.rs
+++ b/dotlottie-rs/tests/play_mode.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player};
+use dotlottie_rs::{ColorSpace, Player, Status};
 
 mod test_utils;
 
@@ -46,11 +46,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -100,11 +104,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -148,11 +156,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -185,7 +197,7 @@ mod play_mode_tests {
         observed_completed = false;
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -237,11 +249,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() >= 3 {
+            if player.status() != Status::Playing || player.current_loop_count() >= 3 {
                 break;
             }
             assert!(
@@ -272,7 +288,7 @@ mod play_mode_tests {
         let _ = player.play();
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 10 {
+            if player.status() != Status::Playing || player.current_loop_count() > 10 {
                 break;
             }
             assert!(
@@ -388,7 +404,11 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         let mut rendered_frames: Vec<f32> = vec![];
@@ -443,11 +463,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -496,7 +520,11 @@ mod play_mode_tests {
             "Animation should load"
         );
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         let mut rendered_frames: Vec<f32> = vec![];
@@ -548,11 +576,15 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -604,7 +636,11 @@ mod play_mode_tests {
 
         let mut rendered_frames: Vec<f32> = vec![];
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
         assert!(!player.is_complete(), "Animation should not be complete");
 
         while !player.is_complete() {
@@ -672,10 +708,14 @@ mod play_mode_tests {
             Ok(()),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(
@@ -723,7 +763,11 @@ mod play_mode_tests {
             "Animation should load"
         );
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         let mut rendered_frames: Vec<f32> = vec![];
 
@@ -792,10 +836,14 @@ mod play_mode_tests {
             player.load_animation_path(&path).is_ok(),
             "Animation should load"
         );
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         for tick in 0..MAX_TICKS {
-            if player.is_paused() || player.is_stopped() || player.current_loop_count() > 5 {
+            if player.status() != Status::Playing || player.current_loop_count() > 5 {
                 break;
             }
             assert!(

--- a/dotlottie-rs/tests/segments.rs
+++ b/dotlottie-rs/tests/segments.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Mode, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Mode, Segment, Status};
 
 #[cfg(test)]
 mod tests {
@@ -33,7 +33,11 @@ mod tests {
         }));
         assert!(result.is_err(), "Invalid segment should be rejected");
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         let total_frames = player.total_frames();
 

--- a/dotlottie-rs/tests/segments.rs
+++ b/dotlottie-rs/tests/segments.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Mode, Player, Segment};
+use dotlottie_rs::{ColorSpace, Mode, Player, Segment, Status};
 
 #[cfg(test)]
 mod tests {
@@ -33,7 +33,11 @@ mod tests {
         }));
         assert!(result.is_err(), "Invalid segment should be rejected");
 
-        assert!(player.is_playing(), "Animation should be playing");
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "Animation should be playing"
+        );
 
         let total_frames = player.total_frames();
 

--- a/dotlottie-rs/tests/speed.rs
+++ b/dotlottie-rs/tests/speed.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -106,7 +106,11 @@ mod tests {
                 player.load_animation_path(&path).is_ok(),
                 "Animation should load"
             );
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             let seg = player.segment().unwrap();
             let expected_duration =

--- a/dotlottie-rs/tests/speed.rs
+++ b/dotlottie-rs/tests/speed.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player, Segment};
+use dotlottie_rs::{ColorSpace, Player, Segment, Status};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -106,7 +106,11 @@ mod tests {
                 player.load_animation_path(&path).is_ok(),
                 "Animation should load"
             );
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             let seg = player.segment().unwrap();
             let expected_duration =

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -7,7 +7,7 @@ mod tests {
 
     use dotlottie_rs::{
         actions::open_url_policy::OpenUrlPolicy, ColorSpace, DotLottiePlayer, Event,
-        StateMachineEngineStatus,
+        StateMachineEngineStatus, Status,
     };
     use std::io::Read;
 
@@ -35,7 +35,7 @@ mod tests {
 
         assert_eq!(player.load_dotlottie_data(&markers_buffer), Ok(()));
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
 
         let sm_id = CString::new("Exploding Pigeon").unwrap();
         let mut sm = player
@@ -363,7 +363,7 @@ mod tests {
         sm.player
             .tween(5.0, 2000.0, [0.0, 0.0, 1.0, 1.0])
             .expect("initial tween should succeed");
-        assert!(sm.player.is_tweening());
+        assert_eq!(sm.player.status(), Status::Tweening);
 
         // Trigger a tweened transition (rating=2 → star_2).
         // tween will fail because the player is already tweening,
@@ -416,8 +416,9 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status when tweened transition targets a state without a segment"
         );
-        assert!(
-            sm.player.is_tweening(),
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
             "player should be tweening after a tweened transition to a state without a segment"
         );
 
@@ -461,7 +462,11 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status for a reverse mode state with segment"
         );
-        assert!(sm.player.is_tweening(), "player should be tweening");
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
+            "player should be tweening"
+        );
 
         assert_eq!(sm.get_current_state_name(), "forward_state");
 
@@ -513,7 +518,11 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status for a reverse mode state without segment"
         );
-        assert!(sm.player.is_tweening(), "player should be tweening");
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
+            "player should be tweening"
+        );
 
         assert_eq!(sm.get_current_state_name(), "forward_state");
 

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -7,7 +7,7 @@ mod tests {
 
     use dotlottie_rs::{
         actions::open_url_policy::OpenUrlPolicy, ColorSpace, Event, Player,
-        StateMachineEngineStatus,
+        StateMachineEngineStatus, Status,
     };
     use std::io::Read;
 
@@ -35,7 +35,7 @@ mod tests {
 
         assert_eq!(player.load_dotlottie_data(&markers_buffer), Ok(()));
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
 
         let sm_id = CString::new("Exploding Pigeon").unwrap();
         let mut sm = player
@@ -363,7 +363,7 @@ mod tests {
         sm.player
             .tween(5.0, 2000.0, [0.0, 0.0, 1.0, 1.0])
             .expect("initial tween should succeed");
-        assert!(sm.player.is_tweening());
+        assert_eq!(sm.player.status(), Status::Tweening);
 
         // Trigger a tweened transition (rating=2 → star_2).
         // tween will fail because the player is already tweening,
@@ -416,8 +416,9 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status when tweened transition targets a state without a segment"
         );
-        assert!(
-            sm.player.is_tweening(),
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
             "player should be tweening after a tweened transition to a state without a segment"
         );
 
@@ -425,6 +426,65 @@ mod tests {
             sm.get_current_state_name(),
             "segment_state",
             "current state should still be the source state while tweening"
+        );
+    }
+
+    #[test]
+    fn stop_during_tweened_transition_aborts_transition() {
+        let sm_json = include_str!("../assets/statemachines/tween_no_segment.json");
+        let mut player = Player::new();
+
+        let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
+        assert!(player
+            .set_sw_target(&mut buffer, 100, 100, ColorSpace::ABGR8888)
+            .is_ok());
+
+        assert!(player
+            .load_dotlottie_data(include_bytes!(
+                "../assets/animations/dotlottie/v1/smiley-slider.lottie"
+            ))
+            .is_ok());
+
+        let mut sm = player
+            .state_machine_load_data(sm_json)
+            .expect("state machine to load successfully");
+
+        sm.start(&OpenUrlPolicy::default())
+            .expect("state machine should start");
+
+        assert_eq!(sm.get_current_state_name(), "segment_state");
+
+        sm.set_numeric_input("trigger", 1.0, true, false)
+            .expect("input should be set");
+
+        assert_eq!(sm.status, StateMachineEngineStatus::Tweening);
+        assert_eq!(sm.player.status(), Status::Tweening);
+
+        sm.player.stop().expect("stop during tween should succeed");
+        assert_eq!(sm.player.status(), Status::Stopped);
+        let frame_after_stop = sm.player.current_frame();
+
+        let _ = sm.tick(16.0);
+
+        assert_eq!(
+            sm.status,
+            StateMachineEngineStatus::Running,
+            "engine should leave Tweening after the tween is cancelled"
+        );
+        assert_eq!(
+            sm.get_current_state_name(),
+            "segment_state",
+            "cancelled tweened transition must not enter the target state"
+        );
+        assert_eq!(
+            sm.player.status(),
+            Status::Stopped,
+            "stop must stick: no autoplay restart from the aborted transition"
+        );
+        assert_eq!(
+            sm.player.current_frame(),
+            frame_after_stop,
+            "frame must not teleport to the tween target"
         );
     }
 
@@ -461,7 +521,11 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status for a reverse mode state with segment"
         );
-        assert!(sm.player.is_tweening(), "player should be tweening");
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
+            "player should be tweening"
+        );
 
         assert_eq!(sm.get_current_state_name(), "forward_state");
 
@@ -513,7 +577,11 @@ mod tests {
             StateMachineEngineStatus::Tweening,
             "state machine should be in Tweening status for a reverse mode state without segment"
         );
-        assert!(sm.player.is_tweening(), "player should be tweening");
+        assert_eq!(
+            sm.player.status(),
+            Status::Tweening,
+            "player should be tweening"
+        );
 
         assert_eq!(sm.get_current_state_name(), "forward_state");
 

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError, Mode, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError, Mode, Segment, Status};
 
 #[cfg(test)]
 mod tests {
@@ -95,7 +95,11 @@ mod tests {
                 "Animation should load"
             );
 
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             let Segment {
                 start: start_frame,
@@ -107,13 +111,19 @@ mod tests {
 
             assert_eq!(player.set_frame(mid_frame), Ok(()), "Frame should be set");
             assert_eq!(player.render(), Ok(()), "Frame should render");
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             assert_eq!(player.stop(), Ok(()), "Animation should stop");
 
-            assert!(!player.is_playing(), "Animation should not be playing");
-            assert!(player.is_stopped(), "Animation should be stopped");
-            assert!(!player.is_paused(), "Animation should not be paused");
+            assert_eq!(
+                player.status(),
+                Status::Stopped,
+                "Animation should be stopped"
+            );
 
             // based on the mode the current frame should be at the start or end
             match player.mode() {

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Mode, Player, PlayerError, Segment};
+use dotlottie_rs::{ColorSpace, Mode, Player, PlayerError, Segment, Status};
 
 #[cfg(test)]
 mod tests {
@@ -95,7 +95,11 @@ mod tests {
                 "Animation should load"
             );
 
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             let Segment {
                 start: start_frame,
@@ -107,13 +111,19 @@ mod tests {
 
             assert_eq!(player.set_frame(mid_frame), Ok(()), "Frame should be set");
             assert_eq!(player.render(), Ok(()), "Frame should render");
-            assert!(player.is_playing(), "Animation should be playing");
+            assert_eq!(
+                player.status(),
+                Status::Playing,
+                "Animation should be playing"
+            );
 
             assert_eq!(player.stop(), Ok(()), "Animation should stop");
 
-            assert!(!player.is_playing(), "Animation should not be playing");
-            assert!(player.is_stopped(), "Animation should be stopped");
-            assert!(!player.is_paused(), "Animation should not be paused");
+            assert_eq!(
+                player.status(),
+                Status::Stopped,
+                "Animation should be stopped"
+            );
 
             // based on the mode the current frame should be at the start or end
             match player.mode() {

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError, Status};
 use std::ffi::CString;
 
 mod test_utils;
@@ -42,7 +42,7 @@ mod tests {
         );
         assert_eq!(player.theme_id(), Some(valid_theme_id.as_c_str()));
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
             "Expected theme to not load"
         );
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(player.load_animation_data(&data), Ok(()));
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(player.load_animation_path(&path), Ok(()));
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
             .is_ok());
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -290,6 +290,6 @@ mod tests {
             "Theme should persist after load_animation within the same .lottie container"
         );
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 }

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, Player, PlayerError};
+use dotlottie_rs::{ColorSpace, Player, PlayerError, Status};
 use std::ffi::CString;
 
 mod test_utils;
@@ -42,7 +42,7 @@ mod tests {
         );
         assert_eq!(player.theme_id(), Some(valid_theme_id.as_c_str()));
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
             "Expected theme to not load"
         );
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(player.load_animation_data(&data), Ok(()));
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(player.load_animation_path(&path), Ok(()));
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
             .is_ok());
         assert!(player.theme_id().is_none());
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod tests {
             "Theme should persist after load_animation within the same .lottie container"
         );
 
-        assert!(player.is_playing());
+        assert_eq!(player.status(), Status::Playing);
     }
 
     #[test]

--- a/dotlottie-rs/tests/tween.rs
+++ b/dotlottie-rs/tests/tween.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, TweenStatus};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Status, TweenStatus};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -70,7 +70,7 @@ mod tests {
         player
             .tween(20.0, 1.0, [0.0, 0.0, 1.0, 1.0])
             .expect("tween should start");
-        assert!(player.is_tweening());
+        assert_eq!(player.status(), Status::Tweening);
 
         // Pass enough dt to complete the 1ms tween
         let result = player.tween_advance(10.0);
@@ -79,8 +79,9 @@ mod tests {
             Ok(TweenStatus::Completed),
             "tween_advance should return Ok(Completed) when tween completes"
         );
-        assert!(
-            !player.is_tweening(),
+        assert_ne!(
+            player.status(),
+            Status::Tweening,
             "should not be tweening after tween completes"
         );
     }
@@ -97,13 +98,15 @@ mod tests {
         player
             .tween(20.0, 1.0, [0.0, 0.0, 1.0, 1.0])
             .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
 
         // Tick with enough dt to complete the 1ms tween
         let result = player.tick(10.0);
         assert!(result.is_ok(), "tick() should succeed, got {result:?}");
-        assert!(
-            !player.is_tweening(),
-            "should not be tweening after tick completes the tween"
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "should resume Playing after tween completes"
         );
 
         let result = player.tick(1000.0 / 60.0);
@@ -117,6 +120,88 @@ mod tests {
         assert!(
             (frame - 20.0).abs() < total_frames * 0.5,
             "frame after tween should be near target (20.0), not jumped far ahead; got {frame}"
+        );
+    }
+
+    #[test]
+    fn tween_from_stopped_resumes_to_stopped() {
+        let (mut player, _buf) = setup_player();
+
+        assert_eq!(player.status(), Status::Stopped);
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from stopped should succeed");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.tween_advance(10.0);
+        assert_eq!(result, Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Stopped,
+            "should resume Stopped after tween completes"
+        );
+    }
+
+    #[test]
+    fn tween_from_paused_resumes_to_paused() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+        player.pause().expect("pause should succeed");
+        assert_eq!(player.status(), Status::Paused);
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from paused should succeed");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.tween_advance(10.0);
+        assert_eq!(result, Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Paused,
+            "should resume Paused after tween completes"
+        );
+    }
+
+    #[test]
+    fn play_during_tweening_returns_error() {
+        let (mut player, _buf) = setup_player();
+
+        player
+            .tween(10.0, 0.5, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+
+        let result = player.play();
+        assert!(
+            result.is_err(),
+            "play() during tweening should return error"
+        );
+    }
+
+    #[test]
+    fn stop_during_tweening_cancels_tween() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+
+        player
+            .tween(10.0, 0.5, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.stop();
+        assert!(result.is_ok(), "stop() during tweening should succeed");
+        assert_eq!(
+            player.status(),
+            Status::Stopped,
+            "should be Stopped after cancelling tween"
+        );
+        assert_ne!(
+            player.status(),
+            Status::Tweening,
+            "should not be tweening after stop"
         );
     }
 }

--- a/dotlottie-rs/tests/tween.rs
+++ b/dotlottie-rs/tests/tween.rs
@@ -181,6 +181,29 @@ mod tests {
     }
 
     #[test]
+    fn pause_during_tweening_returns_error() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+
+        player
+            .tween(10.0, 0.5, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.pause();
+        assert!(
+            result.is_err(),
+            "pause() during tweening should return error"
+        );
+        assert_eq!(
+            player.status(),
+            Status::Tweening,
+            "status should remain Tweening after rejected pause"
+        );
+    }
+
+    #[test]
     fn stop_during_tweening_cancels_tween() {
         let (mut player, _buf) = setup_player();
 

--- a/dotlottie-rs/tests/tween.rs
+++ b/dotlottie-rs/tests/tween.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player, TweenStatus};
+use dotlottie_rs::{ColorSpace, Player, PlayerEvent, Status, TweenStatus};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -70,7 +70,7 @@ mod tests {
         player
             .tween(20.0, 1.0, [0.0, 0.0, 1.0, 1.0])
             .expect("tween should start");
-        assert!(player.is_tweening());
+        assert_eq!(player.status(), Status::Tweening);
 
         // Pass enough dt to complete the 1ms tween
         let result = player.tween_advance(10.0);
@@ -79,8 +79,9 @@ mod tests {
             Ok(TweenStatus::Completed),
             "tween_advance should return Ok(Completed) when tween completes"
         );
-        assert!(
-            !player.is_tweening(),
+        assert_ne!(
+            player.status(),
+            Status::Tweening,
             "should not be tweening after tween completes"
         );
     }
@@ -97,13 +98,15 @@ mod tests {
         player
             .tween(20.0, 1.0, [0.0, 0.0, 1.0, 1.0])
             .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
 
         // Tick with enough dt to complete the 1ms tween
         let result = player.tick(10.0);
         assert!(result.is_ok(), "tick() should succeed, got {result:?}");
-        assert!(
-            !player.is_tweening(),
-            "should not be tweening after tick completes the tween"
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "should resume Playing after tween completes"
         );
 
         let result = player.tick(1000.0 / 60.0);
@@ -117,6 +120,164 @@ mod tests {
         assert!(
             (frame - 20.0).abs() < total_frames * 0.5,
             "frame after tween should be near target (20.0), not jumped far ahead; got {frame}"
+        );
+    }
+
+    #[test]
+    fn tween_from_stopped_resumes_to_stopped() {
+        let (mut player, _buf) = setup_player();
+
+        assert_eq!(player.status(), Status::Stopped);
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from stopped should succeed");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.tween_advance(10.0);
+        assert_eq!(result, Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Stopped,
+            "should resume Stopped after tween completes"
+        );
+    }
+
+    #[test]
+    fn tween_from_paused_resumes_to_paused() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+        player.pause().expect("pause should succeed");
+        assert_eq!(player.status(), Status::Paused);
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from paused should succeed");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.tween_advance(10.0);
+        assert_eq!(result, Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Paused,
+            "should resume Paused after tween completes"
+        );
+    }
+
+    #[test]
+    fn play_during_tweening_retargets_resume() {
+        let (mut player, _buf) = setup_player();
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from stopped should succeed");
+        assert_eq!(player.status(), Status::Tweening);
+
+        while player.poll_event().is_some() {}
+
+        assert_eq!(player.play(), Ok(()), "play() during tween should succeed");
+        assert_eq!(
+            player.status(),
+            Status::Tweening,
+            "player should keep tweening after retarget"
+        );
+        assert!(
+            matches!(player.poll_event(), Some(PlayerEvent::Play)),
+            "retarget should emit PlayerEvent::Play"
+        );
+
+        assert_eq!(player.tween_advance(10.0), Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Playing,
+            "should resume Playing after retargeted tween completes"
+        );
+    }
+
+    #[test]
+    fn play_during_tweening_from_playing_returns_error() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+
+        assert!(
+            player.play().is_err(),
+            "play() should fail when the tween already resumes to Playing"
+        );
+        assert_eq!(player.status(), Status::Tweening);
+    }
+
+    #[test]
+    fn pause_during_tweening_retargets_resume() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
+
+        while player.poll_event().is_some() {}
+
+        assert_eq!(
+            player.pause(),
+            Ok(()),
+            "pause() during tween should succeed"
+        );
+        assert_eq!(
+            player.status(),
+            Status::Tweening,
+            "player should keep tweening after retarget"
+        );
+        assert!(
+            matches!(player.poll_event(), Some(PlayerEvent::Pause)),
+            "retarget should emit PlayerEvent::Pause"
+        );
+
+        assert_eq!(player.tween_advance(10.0), Ok(TweenStatus::Completed));
+        assert_eq!(
+            player.status(),
+            Status::Paused,
+            "should resume Paused after retargeted tween completes"
+        );
+    }
+
+    #[test]
+    fn pause_during_tweening_from_stopped_returns_error() {
+        let (mut player, _buf) = setup_player();
+
+        player
+            .tween(10.0, 1.0, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween from stopped should succeed");
+
+        assert!(
+            player.pause().is_err(),
+            "pause() should fail when the tween does not resume to Playing"
+        );
+        assert_eq!(player.status(), Status::Tweening);
+    }
+
+    #[test]
+    fn stop_during_tweening_cancels_tween() {
+        let (mut player, _buf) = setup_player();
+
+        player.play().expect("play should succeed");
+
+        player
+            .tween(10.0, 0.5, [0.0, 0.0, 1.0, 1.0])
+            .expect("tween should start");
+        assert_eq!(player.status(), Status::Tweening);
+
+        let result = player.stop();
+        assert!(result.is_ok(), "stop() during tweening should succeed");
+        assert_eq!(
+            player.status(),
+            Status::Stopped,
+            "should be Stopped after cancelling tween"
         );
     }
 }

--- a/web-example.html
+++ b/web-example.html
@@ -360,6 +360,7 @@
       let ctx2d = null; // only set in SW mode
 
       let player         = null;
+      let Status = null;
       let raf            = null;
       let activeRenderer = 'sw';
       let scrubbing      = false;  
@@ -472,7 +473,7 @@
 
         // Re-loop when animation completes during playback
         if (
-          player.is_playing() &&
+          player.status() === Status.Playing &&
           player.is_complete() &&
           document.getElementById("chk-loop").checked
         ) {
@@ -504,6 +505,7 @@
             const mod = await import('./release/wasm/dotlottie_rs.js');
             await mod.default({ module_or_path: "./release/wasm/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
+            Status = mod.Status;
             // Grab the 2D context after the canvas is fresh.
             ctx2d = canvas.getContext('2d');
 
@@ -513,6 +515,7 @@
             const mod = await import('./release/wasm-webgl/dotlottie_rs.js');
             await mod.default({ module_or_path: "./release/wasm-webgl/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
+            Status = mod.Status;
             // Pass the WebGL2 context into the WASM layer before loading.
             newPlayer.set_webgl_context(gl);
           } else if (rendererType === "webgpu") {
@@ -534,6 +537,7 @@
             const mod = await import('./release/wasm-webgpu/dotlottie_rs.js');
             await mod.default({ module_or_path: "./release/wasm-webgpu/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
+            Status = mod.Status;
             newPlayer.set_webgpu_device(gpuDevice);
             newPlayer.set_webgpu_surface(gpuCtx);
           }
@@ -611,7 +615,7 @@
       scrubRange.addEventListener("pointerdown", () => {
         if (!player) return;
         scrubbing = true;
-        wasPlaying = player.is_playing();
+        wasPlaying = player.status() === Status.Playing;
         if (wasPlaying) player.pause();
       });
 


### PR DESCRIPTION
Replaces the hand-synced `is_loaded` + `PlaybackState` + tween flag with a single `Status` enum (`Idle`, `Playing`, `Paused`, `Stopped`, `Tweening`) so invalid states can't be represented, and swaps the five `is_*` getters for one `status()` across the Rust, C, and WASM APIs.

Also fixes two bugs this surfaced: play/pause during a tween now take effect instead of being silently dropped, and stopping mid-tween cancels the tween cleanly instead of the state machine re-applying it a tick later.

Breaking (C API): `dotlottie_playback_status` → `dotlottie_status`, `dotlottie_is_loaded` removed, and `Idle` is now distinct from `Stopped` (you previously got `Stopped` both when nothing was loaded and when a loaded animation was stopped).
