### PR TITLE
refactor: rename DotLottiePlayerError to PlayerError

### DIFF
--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{DotLottiePlayer, PlayerError, Layout, Mode, Rgba, Segment};
+use crate::{DotLottiePlayer, Layout, Mode, PlayerError, Rgba, Segment};
 
 use crate::ColorSpace;
 

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{DotLottiePlayer, DotLottiePlayerError, Layout, Mode, Rgba, Segment};
+use crate::{DotLottiePlayer, PlayerError, Layout, Mode, Rgba, Segment};
 
 use crate::ColorSpace;
 
@@ -1034,7 +1034,7 @@ pub unsafe extern "C" fn dotlottie_set_slots_str(
         let json = CStr::from_ptr(slots_json);
         match json.to_str() {
             Ok(json_str) => dotlottie_player.set_slots_str(json_str),
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn dotlottie_clear_slot(
         let id = CStr::from_ptr(slot_id);
         match id.to_str() {
             Ok(id_str) => dotlottie_player.clear_slot(id_str),
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1082,7 +1082,7 @@ pub unsafe extern "C" fn dotlottie_set_color_slot(
                 let slot = ColorSlot::static_value(ColorValue([r, g, b]));
                 dotlottie_player.set_color_slot(id_str, slot)
             }
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1104,7 +1104,7 @@ pub unsafe extern "C" fn dotlottie_set_scalar_slot(
                 let slot = ScalarSlot::static_value(ScalarValue(value));
                 dotlottie_player.set_scalar_slot(id_str, slot)
             }
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1127,7 +1127,7 @@ pub unsafe extern "C" fn dotlottie_set_text_slot(
                 let slot = TextSlot::with_document(TextDocument::new(text_str.to_string()));
                 dotlottie_player.set_text_slot(id_str, slot)
             }
-            _ => Err(DotLottiePlayerError::InvalidParameter),
+            _ => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1150,7 +1150,7 @@ pub unsafe extern "C" fn dotlottie_set_vector_slot(
                 let slot = VectorSlot::static_value([x, y]);
                 dotlottie_player.set_vector_slot(id_str, slot)
             }
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1173,7 +1173,7 @@ pub unsafe extern "C" fn dotlottie_set_position_slot(
                 let slot = PositionSlot::static_value([x, y]);
                 dotlottie_player.set_position_slot(id_str, slot)
             }
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1196,7 +1196,7 @@ pub unsafe extern "C" fn dotlottie_set_image_slot_path(
                 let slot = ImageSlot::from_path(path_str.to_string());
                 dotlottie_player.set_image_slot(id_str, slot)
             }
-            _ => Err(DotLottiePlayerError::InvalidParameter),
+            _ => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1219,7 +1219,7 @@ pub unsafe extern "C" fn dotlottie_set_image_slot_data_url(
                 let slot = ImageSlot::from_data_url(url_str.to_string());
                 dotlottie_player.set_image_slot(id_str, slot)
             }
-            _ => Err(DotLottiePlayerError::InvalidParameter),
+            _ => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1402,7 +1402,7 @@ pub unsafe extern "C" fn dotlottie_set_slot_str(
         let json_cstr = CStr::from_ptr(json);
         match (id.to_str(), json_cstr.to_str()) {
             (Ok(id_str), Ok(json_str)) => dotlottie_player.set_slot_str(id_str, json_str),
-            _ => Err(DotLottiePlayerError::InvalidParameter),
+            _ => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1420,7 +1420,7 @@ pub unsafe extern "C" fn dotlottie_reset_slot(
         let id = CStr::from_ptr(slot_id);
         match id.to_str() {
             Ok(id_str) => dotlottie_player.reset_slot(id_str),
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     })
 }
@@ -1432,7 +1432,7 @@ pub unsafe extern "C" fn dotlottie_reset_slots(ptr: *mut DotLottiePlayer) -> Dot
         if dotlottie_player.reset_slots() {
             Ok(())
         } else {
-            Err(DotLottiePlayerError::Unknown)
+            Err(PlayerError::Unknown)
         }
     })
 }

--- a/dotlottie-rs/src/c_api/types.rs
+++ b/dotlottie-rs/src/c_api/types.rs
@@ -9,7 +9,7 @@ use crate::state_machine_engine::events::Event;
 use core::str::FromStr;
 
 use crate::lottie_renderer::LottieRendererError;
-use crate::DotLottiePlayerError;
+use crate::PlayerError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
@@ -31,14 +31,14 @@ pub enum DotLottieResult {
     FeatureNotEnabled = 6,
 }
 
-impl From<DotLottiePlayerError> for DotLottieResult {
-    fn from(err: DotLottiePlayerError) -> Self {
+impl From<PlayerError> for DotLottieResult {
+    fn from(err: PlayerError) -> Self {
         match err {
-            DotLottiePlayerError::Unknown => DotLottieResult::Error,
-            DotLottiePlayerError::InvalidParameter => DotLottieResult::InvalidParameter,
-            DotLottiePlayerError::ManifestNotAvailable => DotLottieResult::ManifestNotAvailable,
-            DotLottiePlayerError::AnimationNotLoaded => DotLottieResult::AnimationNotLoaded,
-            DotLottiePlayerError::InsufficientCondition => DotLottieResult::InsufficientCondition,
+            PlayerError::Unknown => DotLottieResult::Error,
+            PlayerError::InvalidParameter => DotLottieResult::InvalidParameter,
+            PlayerError::ManifestNotAvailable => DotLottieResult::ManifestNotAvailable,
+            PlayerError::AnimationNotLoaded => DotLottieResult::AnimationNotLoaded,
+            PlayerError::InsufficientCondition => DotLottieResult::InsufficientCondition,
         }
     }
 }

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -5,7 +5,7 @@ use std::{fs, mem};
 #[cfg(feature = "audio")]
 use crate::audio::AudioManager;
 use crate::poll_events::{DotLottieEvent, EventQueue};
-use crate::DotLottiePlayerError;
+use crate::PlayerError;
 use crate::{
     layout::Layout,
     lottie_renderer::{LottieRenderer, LottieRendererError},
@@ -105,15 +105,15 @@ impl DotLottiePlayer {
     }
 
     #[cfg(feature = "tvg")]
-    pub fn load_font(name: &str, data: &[u8]) -> Result<(), DotLottiePlayerError> {
+    pub fn load_font(name: &str, data: &[u8]) -> Result<(), PlayerError> {
         use crate::lottie_renderer::Renderer;
-        crate::TvgRenderer::load_font(name, data).map_err(|_| DotLottiePlayerError::Unknown)
+        crate::TvgRenderer::load_font(name, data).map_err(|_| PlayerError::Unknown)
     }
 
     #[cfg(feature = "tvg")]
-    pub fn unload_font(name: &str) -> Result<(), DotLottiePlayerError> {
+    pub fn unload_font(name: &str) -> Result<(), PlayerError> {
         use crate::lottie_renderer::Renderer;
-        crate::TvgRenderer::unload_font(name).map_err(|_| DotLottiePlayerError::Unknown)
+        crate::TvgRenderer::unload_font(name).map_err(|_| PlayerError::Unknown)
     }
 
     pub fn with_renderer<R: Renderer>(renderer: R) -> Self {
@@ -199,12 +199,12 @@ impl DotLottiePlayer {
         matches!(self.playback_state, PlaybackState::Stopped)
     }
 
-    pub fn play(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn play(&mut self) -> Result<(), PlayerError> {
         if !self.is_loaded {
-            return Err(DotLottiePlayerError::AnimationNotLoaded);
+            return Err(PlayerError::AnimationNotLoaded);
         }
         if self.is_playing() {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
 
         if self.is_complete() && self.is_stopped() {
@@ -239,12 +239,12 @@ impl DotLottiePlayer {
         Ok(())
     }
 
-    pub fn pause(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn pause(&mut self) -> Result<(), PlayerError> {
         if !self.is_loaded {
-            return Err(DotLottiePlayerError::AnimationNotLoaded);
+            return Err(PlayerError::AnimationNotLoaded);
         }
         if !self.is_playing() {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
         self.playback_state = PlaybackState::Paused;
 
@@ -257,12 +257,12 @@ impl DotLottiePlayer {
         Ok(())
     }
 
-    pub fn stop(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn stop(&mut self) -> Result<(), PlayerError> {
         if !self.is_loaded {
-            return Err(DotLottiePlayerError::AnimationNotLoaded);
+            return Err(PlayerError::AnimationNotLoaded);
         }
         if self.is_stopped() {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
 
         self.playback_state = PlaybackState::Stopped;
@@ -478,9 +478,9 @@ impl DotLottiePlayer {
     ///
     /// Internal: set the renderer frame, push events, sync audio.
     /// Does NOT update `elapsed_frames`.
-    fn apply_frame(&mut self, no: f32) -> Result<(), DotLottiePlayerError> {
+    fn apply_frame(&mut self, no: f32) -> Result<(), PlayerError> {
         if no < self.start_frame() || no > self.end_frame() {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
 
         self.renderer.set_frame(no)?;
@@ -500,7 +500,7 @@ impl DotLottiePlayer {
     /// Set the frame number and sync playback position.
     ///
     /// Playback will continue from this frame on the next `tick()`.
-    pub fn set_frame(&mut self, no: f32) -> Result<(), DotLottiePlayerError> {
+    pub fn set_frame(&mut self, no: f32) -> Result<(), PlayerError> {
         self.apply_frame(no)?;
         self.elapsed_frames = match self.direction {
             Direction::Forward => no - self.start_frame(),
@@ -515,7 +515,7 @@ impl DotLottiePlayer {
         y: i32,
         w: i32,
         h: i32,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_viewport(x, y, w, h)?;
         Ok(())
     }
@@ -532,7 +532,7 @@ impl DotLottiePlayer {
         });
     }
 
-    pub fn render(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn render(&mut self) -> Result<(), PlayerError> {
         self.renderer.render()?;
 
         let frame_no = self.current_frame();
@@ -677,10 +677,10 @@ impl DotLottiePlayer {
         }
     }
 
-    pub fn set_background(&mut self, color: Rgba) -> Result<(), DotLottiePlayerError> {
+    pub fn set_background(&mut self, color: Rgba) -> Result<(), PlayerError> {
         self.renderer
             .set_background(color)
-            .map_err(|_| DotLottiePlayerError::Unknown)
+            .map_err(|_| PlayerError::Unknown)
     }
 
     pub fn background(&self) -> Rgba {
@@ -743,18 +743,18 @@ impl DotLottiePlayer {
     pub fn set_segment(
         &mut self,
         segment: Option<crate::Segment>,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer
             .set_segment(segment)
-            .map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+            .map_err(|_| PlayerError::InvalidParameter)?;
         self.active_marker = None;
         Ok(())
     }
 
-    pub fn segment(&self) -> Result<crate::Segment, DotLottiePlayerError> {
+    pub fn segment(&self) -> Result<crate::Segment, PlayerError> {
         self.renderer
             .segment()
-            .map_err(|_| DotLottiePlayerError::Unknown)
+            .map_err(|_| PlayerError::Unknown)
     }
 
     /// Set software rendering target using a safe Rust slice.
@@ -770,10 +770,10 @@ impl DotLottiePlayer {
         width: u32,
         height: u32,
         color_space: ColorSpace,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         let required_size = (width * height) as usize;
         if buffer.len() < required_size {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
 
         let stride = width;
@@ -803,7 +803,7 @@ impl DotLottiePlayer {
         id: i32,
         width: u32,
         height: u32,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer
             .set_gl_target(display, surface, context, id, width, height)?;
         Ok(())
@@ -825,13 +825,13 @@ impl DotLottiePlayer {
         width: u32,
         height: u32,
         target_type: crate::lottie_renderer::WgpuTargetType,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer
             .set_wg_target(device, instance, target, width, height, target_type)?;
         Ok(())
     }
 
-    fn load_animation_common<F>(&mut self, loader: F) -> Result<(), DotLottiePlayerError>
+    fn load_animation_common<F>(&mut self, loader: F) -> Result<(), PlayerError>
     where
         F: FnOnce(&mut dyn LottieRenderer) -> Result<(), LottieRendererError>,
     {
@@ -843,7 +843,7 @@ impl DotLottiePlayer {
         let loaded = loader(&mut *self.renderer).is_ok();
 
         if self.renderer.set_layout(&self.layout).is_err() {
-            return Err(DotLottiePlayerError::Unknown);
+            return Err(PlayerError::Unknown);
         }
 
         self.is_loaded = loaded;
@@ -867,14 +867,14 @@ impl DotLottiePlayer {
         if loaded {
             Ok(())
         } else {
-            Err(DotLottiePlayerError::Unknown)
+            Err(PlayerError::Unknown)
         }
     }
 
     pub fn load_animation_data(
         &mut self,
         animation_data: &CStr,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         #[cfg(feature = "dotlottie")]
         {
             self.dotlottie_manager = None;
@@ -899,7 +899,7 @@ impl DotLottiePlayer {
         result
     }
 
-    pub fn load_animation_path(&mut self, file_path: &CStr) -> Result<(), DotLottiePlayerError> {
+    pub fn load_animation_path(&mut self, file_path: &CStr) -> Result<(), PlayerError> {
         #[cfg(feature = "dotlottie")]
         {
             self.dotlottie_manager = None;
@@ -912,10 +912,10 @@ impl DotLottiePlayer {
         let result = (|| {
             let path_str = file_path
                 .to_str()
-                .map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+                .map_err(|_| PlayerError::InvalidParameter)?;
             let data =
-                fs::read_to_string(path_str).map_err(|_| DotLottiePlayerError::InvalidParameter)?;
-            let c_data = CString::new(data).map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+                fs::read_to_string(path_str).map_err(|_| PlayerError::InvalidParameter)?;
+            let c_data = CString::new(data).map_err(|_| PlayerError::InvalidParameter)?;
 
             self.load_animation_data(&c_data)
         })();
@@ -926,7 +926,7 @@ impl DotLottiePlayer {
     }
 
     #[cfg(feature = "dotlottie")]
-    pub fn load_dotlottie_data(&mut self, file_data: &[u8]) -> Result<(), DotLottiePlayerError> {
+    pub fn load_dotlottie_data(&mut self, file_data: &[u8]) -> Result<(), PlayerError> {
         #[cfg(feature = "dotlottie")]
         {
             self.animation_id = None;
@@ -936,7 +936,7 @@ impl DotLottiePlayer {
             self.theme_id = None;
         }
         let manager =
-            DotLottieManager::new(file_data).map_err(|_| DotLottiePlayerError::Unknown)?;
+            DotLottieManager::new(file_data).map_err(|_| PlayerError::Unknown)?;
 
         let (active_animation, active_animation_id) =
             if let Some(anim_id) = self.animation_id.as_deref().and_then(|c| c.to_str().ok()) {
@@ -948,10 +948,10 @@ impl DotLottiePlayer {
                 )
             };
 
-        let animation_data = active_animation.map_err(|_| DotLottiePlayerError::Unknown)?;
+        let animation_data = active_animation.map_err(|_| PlayerError::Unknown)?;
 
         let animation_data_cstr =
-            CString::new(animation_data).map_err(|_| DotLottiePlayerError::Unknown)?;
+            CString::new(animation_data).map_err(|_| PlayerError::Unknown)?;
 
         self.dotlottie_manager = Some(manager);
 
@@ -985,10 +985,10 @@ impl DotLottiePlayer {
     }
 
     #[cfg(feature = "dotlottie")]
-    pub fn load_animation(&mut self, animation_id: &CStr) -> Result<(), DotLottiePlayerError> {
+    pub fn load_animation(&mut self, animation_id: &CStr) -> Result<(), PlayerError> {
         let anim_id_str = animation_id
             .to_str()
-            .map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+            .map_err(|_| PlayerError::InvalidParameter)?;
 
         if let Some(manager) = &mut self.dotlottie_manager {
             #[cfg(feature = "theming")]
@@ -1007,7 +1007,7 @@ impl DotLottiePlayer {
                         CString::new(animation_data).expect("Failed to create CString");
                     self.load_animation_common(|renderer| renderer.load_data(&animation_data_cstr))
                 }
-                Err(_error) => Err(DotLottiePlayerError::Unknown),
+                Err(_error) => Err(PlayerError::Unknown),
             };
 
             if result.is_ok() {
@@ -1038,7 +1038,7 @@ impl DotLottiePlayer {
 
             result
         } else {
-            Err(DotLottiePlayerError::Unknown)
+            Err(PlayerError::Unknown)
         }
     }
 
@@ -1075,7 +1075,7 @@ impl DotLottiePlayer {
     }
 
     #[cfg(feature = "theming")]
-    pub fn set_theme(&mut self, theme_id: &CStr) -> Result<(), DotLottiePlayerError> {
+    pub fn set_theme(&mut self, theme_id: &CStr) -> Result<(), PlayerError> {
         if self.theme_id.as_deref() == Some(theme_id) {
             return Ok(());
         }
@@ -1084,12 +1084,12 @@ impl DotLottiePlayer {
             self.theme_id = None;
             self.renderer
                 .clear_slots()
-                .map_err(|_| DotLottiePlayerError::Unknown)?;
+                .map_err(|_| PlayerError::Unknown)?;
             return Ok(());
         }
 
         if self.dotlottie_manager.is_none() {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
 
         let theme_exists = self
@@ -1102,7 +1102,7 @@ impl DotLottiePlayer {
             });
 
         if !theme_exists {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
 
         let can_set_theme = self.manifest().is_some_and(|manifest| {
@@ -1115,11 +1115,11 @@ impl DotLottiePlayer {
         });
 
         if !can_set_theme {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
 
         let Ok(theme_id_str) = theme_id.to_str() else {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         };
 
         let result = self
@@ -1136,7 +1136,7 @@ impl DotLottiePlayer {
                 let slots = theme.to_slot_types(anim_id_str);
                 self.apply_slot_types(slots)
             })
-            .unwrap_or(Err(DotLottiePlayerError::Unknown));
+            .unwrap_or(Err(PlayerError::Unknown));
 
         if result.is_ok() {
             self.theme_id = Some(theme_id.to_owned());
@@ -1146,21 +1146,21 @@ impl DotLottiePlayer {
     }
 
     #[cfg(feature = "theming")]
-    pub fn reset_theme(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn reset_theme(&mut self) -> Result<(), PlayerError> {
         self.theme_id = None;
         self.renderer.clear_slots()?;
         Ok(())
     }
 
     #[cfg(feature = "theming")]
-    pub fn set_theme_data(&mut self, theme_data: &CStr) -> Result<(), DotLottiePlayerError> {
+    pub fn set_theme_data(&mut self, theme_data: &CStr) -> Result<(), PlayerError> {
         let theme_data_str = theme_data
             .to_str()
-            .map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+            .map_err(|_| PlayerError::InvalidParameter)?;
 
         let theme = theme_data_str
             .parse::<crate::theme::Theme>()
-            .map_err(|_| DotLottiePlayerError::InvalidParameter)?;
+            .map_err(|_| PlayerError::InvalidParameter)?;
 
         let anim_id_str = self
             .animation_id
@@ -1177,7 +1177,7 @@ impl DotLottiePlayer {
     fn apply_slot_types(
         &mut self,
         slots: std::collections::BTreeMap<String, crate::lottie_renderer::SlotType>,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         use crate::lottie_renderer::SlotType;
 
         for (slot_id, slot_type) in slots {
@@ -1199,7 +1199,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::ColorSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_color_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1208,7 +1208,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::GradientSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_gradient_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1217,7 +1217,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::ImageSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_image_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1226,7 +1226,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::TextSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_text_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1235,7 +1235,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::ScalarSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_scalar_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1244,7 +1244,7 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::VectorSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_vector_slot(slot_id, slot)?;
         Ok(())
     }
@@ -1253,17 +1253,17 @@ impl DotLottiePlayer {
         &mut self,
         slot_id: &str,
         slot: crate::lottie_renderer::PositionSlot,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_position_slot(slot_id, slot)?;
         Ok(())
     }
 
-    pub fn clear_slots(&mut self) -> Result<(), DotLottiePlayerError> {
+    pub fn clear_slots(&mut self) -> Result<(), PlayerError> {
         self.renderer.clear_slots()?;
         Ok(())
     }
 
-    pub fn clear_slot(&mut self, slot_id: &str) -> Result<(), DotLottiePlayerError> {
+    pub fn clear_slot(&mut self, slot_id: &str) -> Result<(), PlayerError> {
         self.renderer.clear_slot(slot_id)?;
         Ok(())
     }
@@ -1271,12 +1271,12 @@ impl DotLottiePlayer {
     pub fn set_slots(
         &mut self,
         slots: std::collections::BTreeMap<String, crate::lottie_renderer::SlotType>,
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         self.renderer.set_slots(slots)?;
         Ok(())
     }
 
-    pub fn set_slots_str(&mut self, slots_json: &str) -> Result<(), DotLottiePlayerError> {
+    pub fn set_slots_str(&mut self, slots_json: &str) -> Result<(), PlayerError> {
         use crate::lottie_renderer::slots::slots_from_json_string;
 
         if slots_json.is_empty() {
@@ -1304,7 +1304,7 @@ impl DotLottiePlayer {
                 }
                 Ok(())
             }
-            Err(_) => Err(DotLottiePlayerError::InvalidParameter),
+            Err(_) => Err(PlayerError::InvalidParameter),
         }
     }
 
@@ -1324,12 +1324,12 @@ impl DotLottiePlayer {
         self.renderer.get_slots_str()
     }
 
-    pub fn set_slot_str(&mut self, slot_id: &str, json: &str) -> Result<(), DotLottiePlayerError> {
+    pub fn set_slot_str(&mut self, slot_id: &str, json: &str) -> Result<(), PlayerError> {
         self.renderer.set_slot_str(slot_id, json)?;
         Ok(())
     }
 
-    pub fn reset_slot(&mut self, slot_id: &str) -> Result<(), DotLottiePlayerError> {
+    pub fn reset_slot(&mut self, slot_id: &str) -> Result<(), PlayerError> {
         self.renderer.reset_slot(slot_id)?;
         Ok(())
     }
@@ -1338,7 +1338,7 @@ impl DotLottiePlayer {
         self.renderer.reset_slots()
     }
 
-    pub fn set_quality(&mut self, quality: u8) -> Result<(), DotLottiePlayerError> {
+    pub fn set_quality(&mut self, quality: u8) -> Result<(), PlayerError> {
         self.renderer.set_quality(quality)?;
         Ok(())
     }
@@ -1363,9 +1363,9 @@ impl DotLottiePlayer {
         to: f32,
         duration: f32,
         easing: [f32; 4],
-    ) -> Result<(), DotLottiePlayerError> {
+    ) -> Result<(), PlayerError> {
         if self.is_tweening() {
-            return Err(DotLottiePlayerError::InsufficientCondition);
+            return Err(PlayerError::InsufficientCondition);
         }
         let from = self.current_frame();
         self.tween_state = Some(TweenState::new(from, to, duration, easing)?);
@@ -1385,11 +1385,11 @@ impl DotLottiePlayer {
         };
     }
 
-    pub fn tween_advance(&mut self, dt: f32) -> Result<TweenStatus, DotLottiePlayerError> {
+    pub fn tween_advance(&mut self, dt: f32) -> Result<TweenStatus, PlayerError> {
         let tween = self
             .tween_state
             .as_mut()
-            .ok_or(DotLottiePlayerError::InsufficientCondition)?;
+            .ok_or(PlayerError::InsufficientCondition)?;
 
         let (status, progress) = tween.update(dt);
         let from = tween.from;
@@ -1415,9 +1415,9 @@ impl DotLottiePlayer {
             .to_vec()
     }
 
-    pub fn set_transform(&mut self, transform: Vec<f32>) -> Result<(), DotLottiePlayerError> {
+    pub fn set_transform(&mut self, transform: Vec<f32>) -> Result<(), PlayerError> {
         if transform.len() != 9 {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
         let transform_array: [f32; 9] = [
             transform[0],
@@ -1445,7 +1445,7 @@ impl DotLottiePlayer {
     ///
     /// Returns `Ok(true)` when a new frame was rendered, `Ok(false)` when the
     /// frame was unchanged and rendering was skipped.
-    pub fn tick(&mut self, dt: f32) -> Result<bool, DotLottiePlayerError> {
+    pub fn tick(&mut self, dt: f32) -> Result<bool, PlayerError> {
         let dt = dt.max(0.0);
 
         if self.is_tweening() {

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -509,13 +509,7 @@ impl DotLottiePlayer {
         Ok(())
     }
 
-    pub fn set_viewport(
-        &mut self,
-        x: i32,
-        y: i32,
-        w: i32,
-        h: i32,
-    ) -> Result<(), PlayerError> {
+    pub fn set_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) -> Result<(), PlayerError> {
         self.renderer.set_viewport(x, y, w, h)?;
         Ok(())
     }
@@ -740,10 +734,7 @@ impl DotLottiePlayer {
         self.use_frame_interpolation
     }
 
-    pub fn set_segment(
-        &mut self,
-        segment: Option<crate::Segment>,
-    ) -> Result<(), PlayerError> {
+    pub fn set_segment(&mut self, segment: Option<crate::Segment>) -> Result<(), PlayerError> {
         self.renderer
             .set_segment(segment)
             .map_err(|_| PlayerError::InvalidParameter)?;
@@ -752,9 +743,7 @@ impl DotLottiePlayer {
     }
 
     pub fn segment(&self) -> Result<crate::Segment, PlayerError> {
-        self.renderer
-            .segment()
-            .map_err(|_| PlayerError::Unknown)
+        self.renderer.segment().map_err(|_| PlayerError::Unknown)
     }
 
     /// Set software rendering target using a safe Rust slice.
@@ -871,10 +860,7 @@ impl DotLottiePlayer {
         }
     }
 
-    pub fn load_animation_data(
-        &mut self,
-        animation_data: &CStr,
-    ) -> Result<(), PlayerError> {
+    pub fn load_animation_data(&mut self, animation_data: &CStr) -> Result<(), PlayerError> {
         #[cfg(feature = "dotlottie")]
         {
             self.dotlottie_manager = None;
@@ -913,8 +899,7 @@ impl DotLottiePlayer {
             let path_str = file_path
                 .to_str()
                 .map_err(|_| PlayerError::InvalidParameter)?;
-            let data =
-                fs::read_to_string(path_str).map_err(|_| PlayerError::InvalidParameter)?;
+            let data = fs::read_to_string(path_str).map_err(|_| PlayerError::InvalidParameter)?;
             let c_data = CString::new(data).map_err(|_| PlayerError::InvalidParameter)?;
 
             self.load_animation_data(&c_data)
@@ -935,8 +920,7 @@ impl DotLottiePlayer {
         {
             self.theme_id = None;
         }
-        let manager =
-            DotLottieManager::new(file_data).map_err(|_| PlayerError::Unknown)?;
+        let manager = DotLottieManager::new(file_data).map_err(|_| PlayerError::Unknown)?;
 
         let (active_animation, active_animation_id) =
             if let Some(anim_id) = self.animation_id.as_deref().and_then(|c| c.to_str().ok()) {
@@ -950,8 +934,7 @@ impl DotLottiePlayer {
 
         let animation_data = active_animation.map_err(|_| PlayerError::Unknown)?;
 
-        let animation_data_cstr =
-            CString::new(animation_data).map_err(|_| PlayerError::Unknown)?;
+        let animation_data_cstr = CString::new(animation_data).map_err(|_| PlayerError::Unknown)?;
 
         self.dotlottie_manager = Some(manager);
 
@@ -1358,12 +1341,7 @@ impl DotLottiePlayer {
         self.state_machine_id.as_deref()
     }
 
-    pub fn tween(
-        &mut self,
-        to: f32,
-        duration: f32,
-        easing: [f32; 4],
-    ) -> Result<(), PlayerError> {
+    pub fn tween(&mut self, to: f32, duration: f32, easing: [f32; 4]) -> Result<(), PlayerError> {
         if self.is_tweening() {
             return Err(PlayerError::InsufficientCondition);
         }

--- a/dotlottie-rs/src/result.rs
+++ b/dotlottie-rs/src/result.rs
@@ -1,7 +1,7 @@
 use crate::LottieRendererError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DotLottiePlayerError {
+pub enum PlayerError {
     Unknown,
     InvalidParameter,
     ManifestNotAvailable,
@@ -9,14 +9,14 @@ pub enum DotLottiePlayerError {
     InsufficientCondition,
 }
 
-impl From<LottieRendererError> for DotLottiePlayerError {
+impl From<LottieRendererError> for PlayerError {
     fn from(err: LottieRendererError) -> Self {
         match err {
             LottieRendererError::InvalidArgument | LottieRendererError::InvalidColor => {
-                DotLottiePlayerError::InvalidParameter
+                PlayerError::InvalidParameter
             }
-            LottieRendererError::AnimationNotLoaded => DotLottiePlayerError::AnimationNotLoaded,
-            _ => DotLottiePlayerError::Unknown,
+            LottieRendererError::AnimationNotLoaded => PlayerError::AnimationNotLoaded,
+            _ => PlayerError::Unknown,
         }
     }
 }

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -423,7 +423,7 @@ impl<'a> StateMachineEngine<'a> {
         state_machine_state_check_pipeline(state_machine)
     }
 
-    pub fn start(&mut self, open_url: &OpenUrlPolicy) -> Result<(), crate::DotLottiePlayerError> {
+    pub fn start(&mut self, open_url: &OpenUrlPolicy) -> Result<(), crate::PlayerError> {
         // Reset to first frame
         let _ = self.player.stop();
         self.player.set_mode(Mode::Forward);
@@ -434,7 +434,7 @@ impl<'a> StateMachineEngine<'a> {
 
         // Start can still be called even if load failed. If load failed initial and states will be empty.
         if self.state_machine.initial.is_empty() || self.state_machine.states.is_empty() {
-            return Err(crate::DotLottiePlayerError::Unknown);
+            return Err(crate::PlayerError::Unknown);
         }
 
         self.open_url_requires_user_interaction = open_url.require_user_interaction;
@@ -460,7 +460,7 @@ impl<'a> StateMachineEngine<'a> {
 
                 self.observe_on_error(message.as_str());
 
-                return Err(crate::DotLottiePlayerError::Unknown);
+                return Err(crate::PlayerError::Unknown);
             }
         }
 
@@ -1265,16 +1265,16 @@ impl<'a> StateMachineEngine<'a> {
         &mut self,
         state_name: &str,
         do_tick: bool,
-    ) -> Result<(), crate::DotLottiePlayerError> {
+    ) -> Result<(), crate::PlayerError> {
         if self.set_current_state(state_name, None, false).is_err() {
-            return Err(crate::DotLottiePlayerError::Unknown);
+            return Err(crate::PlayerError::Unknown);
         }
 
         if do_tick {
             return if self.run_current_state_pipeline().is_ok() {
                 Ok(())
             } else {
-                Err(crate::DotLottiePlayerError::Unknown)
+                Err(crate::PlayerError::Unknown)
             };
         }
 
@@ -1403,7 +1403,7 @@ impl<'a> StateMachineEngine<'a> {
         }
     }
 
-    pub fn tick(&mut self, dt: f32) -> Result<bool, crate::DotLottiePlayerError> {
+    pub fn tick(&mut self, dt: f32) -> Result<bool, crate::PlayerError> {
         let ticked = self.player.tick(dt);
 
         self.check_completion();

--- a/dotlottie-rs/src/tween.rs
+++ b/dotlottie-rs/src/tween.rs
@@ -1,4 +1,4 @@
-use crate::DotLottiePlayerError;
+use crate::PlayerError;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TweenStatus {
@@ -22,9 +22,9 @@ impl TweenState {
         to: f32,
         duration: f32,
         easing: [f32; 4],
-    ) -> Result<Self, DotLottiePlayerError> {
+    ) -> Result<Self, PlayerError> {
         if duration <= 0.0 {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
 
         let [x1, y1, x2, y2] = easing;
@@ -33,7 +33,7 @@ impl TweenState {
             || !y1.is_finite()
             || !y2.is_finite()
         {
-            return Err(DotLottiePlayerError::InvalidParameter);
+            return Err(PlayerError::InvalidParameter);
         }
 
         Ok(Self {

--- a/dotlottie-rs/src/tween.rs
+++ b/dotlottie-rs/src/tween.rs
@@ -17,12 +17,7 @@ pub(crate) struct TweenState {
 }
 
 impl TweenState {
-    pub fn new(
-        from: f32,
-        to: f32,
-        duration: f32,
-        easing: [f32; 4],
-    ) -> Result<Self, PlayerError> {
+    pub fn new(from: f32, to: f32, duration: f32, easing: [f32; 4]) -> Result<Self, PlayerError> {
         if duration <= 0.0 {
             return Err(PlayerError::InvalidParameter);
         }

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use std::ffi::CString;
 
 use crate::test_utils::{HEIGHT, WIDTH};
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError};
 
 #[cfg(test)]
 mod tests {
@@ -21,7 +21,7 @@ mod tests {
 
         assert_eq!(
             player.play(),
-            Err(DotLottiePlayerError::AnimationNotLoaded),
+            Err(PlayerError::AnimationNotLoaded),
             "Expected play to fail when animation is not loaded"
         );
 
@@ -54,7 +54,7 @@ mod tests {
 
         assert_eq!(
             player.play(),
-            Err(DotLottiePlayerError::InsufficientCondition),
+            Err(PlayerError::InsufficientCondition),
             "Expected play to fail when already playing"
         );
     }

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError, Mode, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, Mode, PlayerError, Segment};
 
 #[cfg(test)]
 mod tests {

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError, Mode, Segment};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError, Mode, Segment};
 
 #[cfg(test)]
 mod tests {
@@ -133,7 +133,7 @@ mod tests {
 
             assert_eq!(
                 player.stop(),
-                Err(DotLottiePlayerError::InsufficientCondition),
+                Err(PlayerError::InsufficientCondition),
                 "Animation should not stop again"
             );
         }

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, DotLottiePlayerError};
+use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError};
 use std::ffi::CString;
 
 mod test_utils;
@@ -23,7 +23,7 @@ mod tests {
 
         assert_eq!(
             player.set_theme(&valid_theme_id),
-            Err(DotLottiePlayerError::InsufficientCondition),
+            Err(PlayerError::InsufficientCondition),
             "Expected theme to not load"
         );
 
@@ -59,7 +59,7 @@ mod tests {
 
         assert_eq!(
             player.set_theme(&invalid_theme_id),
-            Err(DotLottiePlayerError::InsufficientCondition),
+            Err(PlayerError::InsufficientCondition),
             "Expected theme to not load"
         );
 
@@ -154,7 +154,7 @@ mod tests {
 
         assert_eq!(
             player.set_theme(&valid_theme_id),
-            Err(DotLottiePlayerError::InsufficientCondition),
+            Err(PlayerError::InsufficientCondition),
             "Expected theme to not load"
         );
 
@@ -195,7 +195,7 @@ mod tests {
 
         assert_eq!(
             player.set_theme(&valid_theme_id),
-            Err(DotLottiePlayerError::InsufficientCondition),
+            Err(PlayerError::InsufficientCondition),
             "Expected theme to not load"
         );
 


### PR DESCRIPTION
Pure mechanical rename. The `DotLottie` prefix was redundant — this type only lives on `Player` (shortly also renamed).