### PR TITLE
ci: parallelize check-pr workflow

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -11,9 +11,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-pr:
+  fmt:
     if: github.head_ref != 'release'
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ningenMe/setup-rustup@v1.1.0
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path=./dotlottie-rs/Cargo.toml --all -- --check
+
+  check:
+    if: github.head_ref != 'release'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: Test
+            cmd: cargo test --manifest-path=./dotlottie-rs/Cargo.toml --features="dev" -- --test-threads=1
+          - name: Lint
+            cmd: cargo clippy --manifest-path=./dotlottie-rs/Cargo.toml --features="dev" --all-targets -- -D clippy::print_stdout
+            rustflags: "-Dwarnings"
     env:
       CC: clang
       CXX: clang++
@@ -39,20 +60,7 @@ jobs:
       - name: Setup Conan
         uses: turtlebrowser/get-conan@main
 
-      - name: Build
-        run: |
-          cargo build --manifest-path=./dotlottie-rs/Cargo.toml --features="dev"
-
-      - name: Test
-        run: |
-          cargo test --manifest-path=./dotlottie-rs/Cargo.toml --features="dev" -- --test-threads=1
-
-      - name: Lint
-        run: |
-          cargo clippy --manifest-path=./dotlottie-rs/Cargo.toml  --features="dev" --all-targets -- -D clippy::print_stdout
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.cmd }}
         env:
-          RUSTFLAGS: "-Dwarnings"
-
-      - name: Check formatting
-        run: |
-          cargo fmt --manifest-path=./dotlottie-rs/Cargo.toml --all -- --check
+          RUSTFLAGS: ${{ matrix.rustflags }}

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -52,6 +52,13 @@ jobs:
       - name: Setup Rust
         uses: ningenMe/setup-rustup@v1.1.0
 
+      - name: Cache cargo
+        if: matrix.native
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          cache-on-failure: true
+
       - name: ${{ matrix.name }}
         run: ${{ matrix.cmd }}
         env:

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   check:
     name: ${{ matrix.name }}

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -10,19 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
-  fmt:
-    if: github.head_ref != 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: ningenMe/setup-rustup@v1.1.0
-
-      - name: Check formatting
-        run: cargo fmt --manifest-path=./dotlottie-rs/Cargo.toml --all -- --check
-
   check:
     name: ${{ matrix.name }}
     if: github.head_ref != 'release'
@@ -31,10 +22,14 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          - name: Fmt
+            cmd: cargo fmt --manifest-path=./dotlottie-rs/Cargo.toml --all -- --check
           - name: Test
             cmd: cargo test --manifest-path=./dotlottie-rs/Cargo.toml --features="dev" -- --test-threads=1
+            native: true
           - name: Lint
             cmd: cargo clippy --manifest-path=./dotlottie-rs/Cargo.toml --features="dev" --all-targets -- -D clippy::print_stdout
+            native: true
             rustflags: "-Dwarnings"
     env:
       CC: clang
@@ -47,19 +42,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
-          fetch-depth: 0
+          submodules: ${{ matrix.native == true }}
+          fetch-depth: ${{ matrix.native && 0 || 1 }}
 
       - name: Install build dependencies
+        if: matrix.native
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential clang llvm-dev libclang-dev
 
       - name: Setup Rust
         uses: ningenMe/setup-rustup@v1.1.0
-
-      - name: Setup Conan
-        uses: turtlebrowser/get-conan@main
 
       - name: ${{ matrix.name }}
         run: ${{ matrix.cmd }}

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -53,6 +53,7 @@ jobs:
         if: matrix.native
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: dotlottie-rs
           shared-key: ${{ matrix.name }}
           cache-on-failure: true
 

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -40,7 +40,7 @@ jobs:
       CXXFLAGS: -O2
       BINDGEN_EXTRA_CLANG_ARGS: "-I/usr/include"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: ${{ matrix.native == true }}
           fetch-depth: ${{ matrix.native && 0 || 1 }}

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -45,12 +45,6 @@ jobs:
           submodules: ${{ matrix.native == true }}
           fetch-depth: ${{ matrix.native && 0 || 1 }}
 
-      - name: Install build dependencies
-        if: matrix.native
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang llvm-dev libclang-dev
-
       - name: Setup Rust
         uses: ningenMe/setup-rustup@v1.1.0
 

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.native
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: check
+          shared-key: ${{ matrix.name }}
           cache-on-failure: true
 
       - name: ${{ matrix.name }}

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -45,6 +45,10 @@ jobs:
           submodules: ${{ matrix.native == true }}
           fetch-depth: ${{ matrix.native && 0 || 1 }}
 
+      - name: Install LLVM tools
+        if: matrix.native
+        run: sudo apt-get update && sudo apt-get install -y llvm
+
       - name: Setup Rust
         uses: ningenMe/setup-rustup@v1.1.0
 

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -24,6 +24,7 @@ jobs:
         run: cargo fmt --manifest-path=./dotlottie-rs/Cargo.toml --all -- --check
 
   check:
+    name: ${{ matrix.name }}
     if: github.head_ref != 'release'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Split the sequential build/test/lint/fmt pipeline into parallel jobs.

- `fmt` runs standalone without clang/conan/submodules setup.
- `check` matrix runs `Test` and `Lint` in parallel with `fail-fast: true`.
- Dropped the redundant `Build` step — `cargo test` and `cargo clippy --all-targets` already compile the full graph.