### PR TITLE
refactor: rename DotLottiePlayer and DotLottieEvent

### DIFF
--- a/dotlottie-rs/benches/benchmarks.rs
+++ b/dotlottie-rs/benches/benchmarks.rs
@@ -1,13 +1,13 @@
 use std::ffi::CString;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 const WIDTH: u32 = 1000;
 const HEIGHT: u32 = 1000;
 
 fn load_animation_data_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let data_str =
         std::str::from_utf8(include_bytes!("../assets/animations/lottie/test.json")).unwrap();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
@@ -25,7 +25,7 @@ fn load_animation_data_benchmark(c: &mut Criterion) {
 }
 
 fn load_animation_path_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
 
     player
@@ -45,7 +45,7 @@ fn load_animation_path_benchmark(c: &mut Criterion) {
 }
 
 fn load_dotlottie_data_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
 
     player
@@ -61,7 +61,7 @@ fn load_dotlottie_data_benchmark(c: &mut Criterion) {
 }
 
 fn animation_loop_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_autoplay(true);
     player.set_loop(true);
 
@@ -82,7 +82,7 @@ fn animation_loop_benchmark(c: &mut Criterion) {
         });
     });
 
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_autoplay(true);
     player.set_loop(true);
     player.set_use_frame_interpolation(true);
@@ -103,7 +103,7 @@ fn animation_loop_benchmark(c: &mut Criterion) {
 }
 
 fn set_theme_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
 
     player
@@ -120,7 +120,7 @@ fn set_theme_benchmark(c: &mut Criterion) {
 }
 
 fn state_machine_load_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
 
     player
@@ -137,7 +137,7 @@ fn state_machine_load_benchmark(c: &mut Criterion) {
 }
 
 fn state_machine_load_data_benchmark(c: &mut Criterion) {
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT).try_into().unwrap()];
 
     player

--- a/dotlottie-rs/cbindgen.toml
+++ b/dotlottie-rs/cbindgen.toml
@@ -9,7 +9,7 @@ no_includes = false
 sys_includes = ["stdint.h", "stdbool.h"]
 after_includes = """
 /* Type aliases for cleaner C code */
-typedef struct dotlottieDotLottiePlayer DotLottiePlayer;
+typedef struct dotlottiePlayer DotLottiePlayer;
 typedef struct dotlottieDotLottieConfig DotLottieConfig;
 #define DOTLOTTIE_SUCCESS 0
 """

--- a/dotlottie-rs/examples/apply_theme.rs
+++ b/dotlottie-rs/examples/apply_theme.rs
@@ -10,7 +10,7 @@ use std::ffi::CString;
 ///
 /// Themes are a convenient way to bundle multiple slot changes together and switch
 /// between different visual styles of the same animation.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 use minifb::{Key, Window, WindowOptions};
 
 mod common;
@@ -30,7 +30,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load .lottie file
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_loop(true);
     player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/audio_player.rs
+++ b/dotlottie-rs/examples/audio_player.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::print_stdout)]
 
-use dotlottie_rs::{ColorSpace, PlayerEvent, Player};
+use dotlottie_rs::{ColorSpace, Player, PlayerEvent};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs;

--- a/dotlottie-rs/examples/audio_player.rs
+++ b/dotlottie-rs/examples/audio_player.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::print_stdout)]
 
-use dotlottie_rs::{ColorSpace, DotLottieEvent, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, PlayerEvent, Player};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs;
@@ -30,7 +30,7 @@ mod common;
 const WIDTH: usize = 500;
 const HEIGHT: usize = 500;
 
-fn load_animation(player: &mut DotLottiePlayer, path: &PathBuf) {
+fn load_animation(player: &mut Player, path: &PathBuf) {
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
@@ -72,7 +72,7 @@ fn main() {
     // -------------------------------------------------------------------------
     // Player setup
     // -------------------------------------------------------------------------
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_autoplay(false);
     player.set_loop(true);
     player.set_mode(dotlottie_rs::Mode::Forward);
@@ -202,15 +202,15 @@ fn main() {
         while let Some(event) = player.poll_event() {
             let _ = player.current_frame();
             match event {
-                DotLottieEvent::Load => println!("  -- Load  (is_loaded={})", player.is_loaded()),
-                DotLottieEvent::LoadError => {
+                PlayerEvent::Load => println!("  -- Load  (is_loaded={})", player.is_loaded()),
+                PlayerEvent::LoadError => {
                     eprintln!("  !! LoadError — animation failed to load into ThorVG");
                 }
-                DotLottieEvent::Play => println!("  -- Play"),
-                DotLottieEvent::Pause => println!("  -- Pause"),
-                DotLottieEvent::Stop => println!("  -- Stop"),
-                DotLottieEvent::Loop { loop_count } => println!("  -- Loop #{loop_count}"),
-                DotLottieEvent::Complete => println!("  -- Complete"),
+                PlayerEvent::Play => println!("  -- Play"),
+                PlayerEvent::Pause => println!("  -- Pause"),
+                PlayerEvent::Stop => println!("  -- Stop"),
+                PlayerEvent::Loop { loop_count } => println!("  -- Loop #{loop_count}"),
+                PlayerEvent::Complete => println!("  -- Complete"),
                 _ => {}
             }
         }

--- a/dotlottie-rs/examples/color_slot.rs
+++ b/dotlottie-rs/examples/color_slot.rs
@@ -7,7 +7,7 @@
 /// slot with ID "ball_color" that we can modify.
 ///
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSlot, ColorSpace, ColorValue, Player, LottieKeyframe};
+use dotlottie_rs::{ColorSlot, ColorSpace, ColorValue, LottieKeyframe, Player};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 

--- a/dotlottie-rs/examples/color_slot.rs
+++ b/dotlottie-rs/examples/color_slot.rs
@@ -7,7 +7,7 @@
 /// slot with ID "ball_color" that we can modify.
 ///
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSlot, ColorSpace, ColorValue, DotLottiePlayer, LottieKeyframe};
+use dotlottie_rs::{ColorSlot, ColorSpace, ColorValue, Player, LottieKeyframe};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -28,7 +28,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load animation
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_autoplay(true);
     player.set_loop(true);
 

--- a/dotlottie-rs/examples/gradient_slot.rs
+++ b/dotlottie-rs/examples/gradient_slot.rs
@@ -7,7 +7,7 @@
 /// a slot with ID "gradient_fill" that we can modify.
 ///
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, GradientSlot, GradientStop, LottieKeyframe};
+use dotlottie_rs::{ColorSpace, Player, GradientSlot, GradientStop, LottieKeyframe};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -28,7 +28,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load animation
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_loop(true);
     player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/gradient_slot.rs
+++ b/dotlottie-rs/examples/gradient_slot.rs
@@ -7,7 +7,7 @@
 /// a slot with ID "gradient_fill" that we can modify.
 ///
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, Player, GradientSlot, GradientStop, LottieKeyframe};
+use dotlottie_rs::{ColorSpace, GradientSlot, GradientStop, LottieKeyframe, Player};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 

--- a/dotlottie-rs/examples/opengl.rs
+++ b/dotlottie-rs/examples/opengl.rs
@@ -13,7 +13,7 @@ mod common;
 #[cfg(feature = "tvg-gl")]
 mod opengl_impl {
     use dotlottie_rs::{
-        DotLottiePlayer, GlContext as DotGlContext, GlDisplay as DotGlDisplay,
+        Player, GlContext as DotGlContext, GlDisplay as DotGlDisplay,
         GlSurface as DotGlSurface,
     };
     use glutin::config::ConfigTemplateBuilder;
@@ -92,7 +92,7 @@ mod opengl_impl {
         window: Option<Window>,
         gl_context: Option<glutin::context::PossiblyCurrentContext>,
         gl_surface: Option<Surface<WindowSurface>>,
-        player: Option<DotLottiePlayer>,
+        player: Option<Player>,
         first_render: bool,
         clock: super::common::Clock,
     }
@@ -196,7 +196,7 @@ mod opengl_impl {
                 }
             }
 
-            let mut player = DotLottiePlayer::new();
+            let mut player = Player::new();
             player.set_loop(true);
             player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/opengl.rs
+++ b/dotlottie-rs/examples/opengl.rs
@@ -13,8 +13,7 @@ mod common;
 #[cfg(feature = "tvg-gl")]
 mod opengl_impl {
     use dotlottie_rs::{
-        Player, GlContext as DotGlContext, GlDisplay as DotGlDisplay,
-        GlSurface as DotGlSurface,
+        GlContext as DotGlContext, GlDisplay as DotGlDisplay, GlSurface as DotGlSurface, Player,
     };
     use glutin::config::ConfigTemplateBuilder;
     use glutin::context::{ContextAttributesBuilder, NotCurrentGlContext, PossiblyCurrentContext};

--- a/dotlottie-rs/examples/position_slot.rs
+++ b/dotlottie-rs/examples/position_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Position slots support spatial tangents for curved motion paths.
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, LottieKeyframe, LottieProperty};
+use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, LottieProperty};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -29,7 +29,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load animation
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_loop(true);
     player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/position_slot.rs
+++ b/dotlottie-rs/examples/position_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Position slots support spatial tangents for curved motion paths.
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, LottieProperty};
+use dotlottie_rs::{ColorSpace, LottieKeyframe, LottieProperty, Player};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 

--- a/dotlottie-rs/examples/scalar_slot.rs
+++ b/dotlottie-rs/examples/scalar_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Note: Opacity values in Lottie are typically in the range 0-100 (percentage).
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, ScalarSlot, ScalarValue};
+use dotlottie_rs::{ColorSpace, LottieKeyframe, Player, ScalarSlot, ScalarValue};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 

--- a/dotlottie-rs/examples/scalar_slot.rs
+++ b/dotlottie-rs/examples/scalar_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Note: Opacity values in Lottie are typically in the range 0-100 (percentage).
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, LottieKeyframe, ScalarSlot, ScalarValue};
+use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, ScalarSlot, ScalarValue};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -29,7 +29,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load animation
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_loop(true);
     player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/simple_player.rs
+++ b/dotlottie-rs/examples/simple_player.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::print_stdout)]
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Rgba};
+use dotlottie_rs::{ColorSpace, Player, Rgba};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs::{self, File};
@@ -31,7 +31,7 @@ fn get_animation_files() -> Vec<PathBuf> {
     files
 }
 
-fn load_animation(player: &mut DotLottiePlayer, path: &PathBuf) {
+fn load_animation(player: &mut Player, path: &PathBuf) {
     let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match extension {
@@ -81,7 +81,7 @@ fn main() {
     )
     .expect("Failed to create window");
 
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_autoplay(true);
     player.set_loop(true);
 

--- a/dotlottie-rs/examples/sm_playground.rs
+++ b/dotlottie-rs/examples/sm_playground.rs
@@ -2,7 +2,7 @@
 
 use dotlottie_rs::actions::open_url_policy::OpenUrlPolicy;
 use dotlottie_rs::events::Event;
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Rgba, StateMachineEngine, StateMachineEvent};
+use dotlottie_rs::{ColorSpace, Player, Rgba, StateMachineEngine, StateMachineEvent};
 use eframe::egui;
 use std::collections::VecDeque;
 use std::ffi::CString;
@@ -31,7 +31,7 @@ struct InputEntry {
 }
 
 struct Playground {
-    player: Box<DotLottiePlayer>,
+    player: Box<Player>,
     buffer: Vec<u32>,
     engine: Option<StateMachineEngine<'static>>,
     texture: Option<egui::TextureHandle>,
@@ -49,7 +49,7 @@ struct Playground {
 
 impl Playground {
     fn new(file_path: Option<PathBuf>) -> Self {
-        let mut player = Box::new(DotLottiePlayer::new());
+        let mut player = Box::new(Player::new());
         let _ = player.set_background(Rgba::from(0xffffffff));
 
         let mut buffer = vec![0u32; (CANVAS_WIDTH * CANVAS_HEIGHT) as usize];
@@ -150,8 +150,8 @@ impl Playground {
             None => return,
         };
 
-        let player_ptr: *mut DotLottiePlayer = &mut *self.player;
-        let player_ref: &'static mut DotLottiePlayer = unsafe { &mut *player_ptr };
+        let player_ptr: *mut Player = &mut *self.player;
+        let player_ref: &'static mut Player = unsafe { &mut *player_ptr };
 
         let c_id = match CString::new(id.clone()) {
             Ok(c) => c,

--- a/dotlottie-rs/examples/state_machine.rs
+++ b/dotlottie-rs/examples/state_machine.rs
@@ -2,7 +2,7 @@
 
 use dotlottie_rs::actions::open_url_policy::OpenUrlPolicy;
 use dotlottie_rs::events::Event;
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Rgba, StateMachineEngine, StateMachineEvent};
+use dotlottie_rs::{ColorSpace, Player, Rgba, StateMachineEngine, StateMachineEvent};
 use minifb::{Key, MouseButton, Window, WindowOptions};
 use std::ffi::CString;
 use std::fs::{self, File};
@@ -100,7 +100,7 @@ fn process_state_machine_events(engine: &mut StateMachineEngine) {
     }
 }
 
-fn load_animation(player: &mut DotLottiePlayer, path: &PathBuf) -> bool {
+fn load_animation(player: &mut Player, path: &PathBuf) -> bool {
     let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     let success = match extension {
@@ -147,7 +147,7 @@ fn main() {
 
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     let _ = player.set_background(Rgba::from(0xffffffff));
 
     let mut buffer: Vec<u32> = vec![0; WIDTH * HEIGHT];

--- a/dotlottie-rs/examples/text_slot.rs
+++ b/dotlottie-rs/examples/text_slot.rs
@@ -7,7 +7,7 @@
 /// The text.json animation has a slot with ID "my_text" that we can modify.
 ///
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, TextDocument, TextKeyframe, TextSlot};
+use dotlottie_rs::{ColorSpace, Player, TextDocument, TextKeyframe, TextSlot};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -28,7 +28,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
     // Create player and load animation
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
     player.set_loop(true);
     player.set_autoplay(true);
 

--- a/dotlottie-rs/examples/vector_slot.rs
+++ b/dotlottie-rs/examples/vector_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Vector slots are for 2D properties like scale [x, y] without spatial tangents.
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, LottieKeyframe, LottieProperty};
+use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, LottieProperty};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 
@@ -28,7 +28,7 @@ fn main() {
 
     window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
 
-    let mut player = DotLottiePlayer::new();
+    let mut player = Player::new();
 
     player.set_autoplay(true);
     player.set_loop(true);

--- a/dotlottie-rs/examples/vector_slot.rs
+++ b/dotlottie-rs/examples/vector_slot.rs
@@ -8,7 +8,7 @@
 ///
 /// Vector slots are for 2D properties like scale [x, y] without spatial tangents.
 /// Demonstrates both static and animated slot values.
-use dotlottie_rs::{ColorSpace, Player, LottieKeyframe, LottieProperty};
+use dotlottie_rs::{ColorSpace, LottieKeyframe, LottieProperty, Player};
 use minifb::{Key, Window, WindowOptions};
 use std::ffi::CString;
 

--- a/dotlottie-rs/examples/webgpu.rs
+++ b/dotlottie-rs/examples/webgpu.rs
@@ -13,7 +13,7 @@ mod common;
 #[cfg(all(feature = "tvg-wg", target_os = "macos"))]
 mod webgpu_impl {
     use dotlottie_rs::c_api::apple::WgpuContext;
-    use dotlottie_rs::{DotLottiePlayer, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType};
+    use dotlottie_rs::{Player, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType};
     use std::ffi::CString;
 
     // Wrapper types for WebGPU pointers
@@ -140,7 +140,7 @@ mod webgpu_impl {
 
     struct App {
         window: Option<Window>,
-        player: Option<DotLottiePlayer>,
+        player: Option<Player>,
         #[cfg(all(feature = "tvg-wg", target_os = "macos"))]
         wgpu_context: Option<WgpuContext>,
         current_width: u32,
@@ -204,7 +204,7 @@ mod webgpu_impl {
                 let (device, instance, surface) = wgpu_context.as_pointers();
                 println!("✓ WebGPU context created");
 
-                let mut player = DotLottiePlayer::new();
+                let mut player = Player::new();
                 player.set_loop(true);
                 player.set_autoplay(true);
 

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{DotLottiePlayer, Layout, Mode, PlayerError, Rgba, Segment};
+use crate::{Player, Layout, Mode, PlayerError, Rgba, Segment};
 
 use crate::ColorSpace;
 
@@ -95,7 +95,7 @@ impl WgpuTarget for RawWgpuTarget {
     }
 }
 
-// Helper macro for DotLottiePlayer operations - wraps every C API call to check
+// Helper macro for Player operations - wraps every C API call to check
 // if the dotlottie player pointer is valid or not, and converts the body's
 // return value to DotLottieResult
 macro_rules! exec_dotlottie_player_op {
@@ -122,8 +122,8 @@ macro_rules! exec_state_machine_op {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_new_player(threads: u32) -> *mut DotLottiePlayer {
-    let dotlottie_player = Box::new(DotLottiePlayer::with_threads(threads));
+pub unsafe extern "C" fn dotlottie_new_player(threads: u32) -> *mut Player {
+    let dotlottie_player = Box::new(Player::with_threads(threads));
     Box::into_raw(dotlottie_player)
 }
 
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn dotlottie_load_font(
         Err(_) => return DotLottieResult::InvalidParameter,
     };
     let data = slice::from_raw_parts(data, size);
-    DotLottiePlayer::load_font(name, data).into()
+    Player::load_font(name, data).into()
 }
 
 #[no_mangle]
@@ -153,11 +153,11 @@ pub unsafe extern "C" fn dotlottie_unload_font(name: *const c_char) -> DotLottie
         Ok(s) => s,
         Err(_) => return DotLottieResult::InvalidParameter,
     };
-    DotLottiePlayer::unload_font(name).into()
+    Player::unload_font(name).into()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_destroy(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_destroy(ptr: *mut Player) -> DotLottieResult {
     if ptr.is_null() {
         return DotLottieResult::InvalidParameter;
     }
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn dotlottie_destroy(ptr: *mut DotLottiePlayer) -> DotLott
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_load_animation_data(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     animation_data: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn dotlottie_load_animation_data(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_load_animation_path(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     animation_path: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn dotlottie_load_animation_path(
 #[cfg_attr(not(feature = "dotlottie"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_load_animation(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     animation_id: *const c_char,
 ) -> DotLottieResult {
     #[cfg(not(feature = "dotlottie"))]
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn dotlottie_load_animation(
 #[cfg_attr(not(feature = "dotlottie"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_load_dotlottie_data(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     file_data: *const c_char,
     file_size: usize,
 ) -> DotLottieResult {
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn dotlottie_load_dotlottie_data(
 /// Get the manifest as a JSON string.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `buffer`: Buffer to store the JSON, or NULL to query required size
 /// - `size_out`: Pointer to receive the required buffer size (including null terminator)
 ///
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn dotlottie_load_dotlottie_data(
 #[cfg_attr(not(feature = "dotlottie"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_manifest(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut c_char,
     size_out: *mut usize,
 ) -> DotLottieResult {
@@ -304,7 +304,7 @@ pub unsafe extern "C" fn dotlottie_manifest(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_mode(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     mode: Mode,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -315,7 +315,7 @@ pub unsafe extern "C" fn dotlottie_set_mode(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_speed(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     speed: f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn dotlottie_set_speed(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_loop(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     loop_animation: bool,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn dotlottie_set_loop(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_loop_count(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     loop_count: u32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn dotlottie_set_loop_count(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_autoplay(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     autoplay: bool,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn dotlottie_set_autoplay(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_use_frame_interpolation(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     enabled: bool,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn dotlottie_set_use_frame_interpolation(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_background(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     r: u8,
     g: u8,
     b: u8,
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn dotlottie_set_background(
 /// Sets the playback segment for the animation.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `segment`: Pointer to an array of 2 floats [start_frame, end_frame], or NULL to clear
 ///
 /// # Returns
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn dotlottie_set_background(
 /// - `DotLottieResult::InvalidParameter` if the player pointer is invalid
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_segment(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     segment: *const [f32; 2],
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn dotlottie_set_segment(
 /// Sets the active marker for the animation.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `marker`: Pointer to a null-terminated C string with the marker name, or NULL to clear
 ///
 /// # Returns
@@ -417,7 +417,7 @@ pub unsafe extern "C" fn dotlottie_set_segment(
 /// - `DotLottieResult::InvalidParameter` if the player pointer is invalid
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_marker(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     marker: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn dotlottie_set_marker(
 /// Sets the layout configuration for the animation.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `layout`: Layout configuration (fit mode and alignment)
 ///
 /// # Returns
@@ -442,7 +442,7 @@ pub unsafe extern "C" fn dotlottie_set_marker(
 /// - `DotLottieResult::InvalidParameter` if the player pointer is invalid
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_layout(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     layout: Layout,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -457,12 +457,12 @@ pub unsafe extern "C" fn dotlottie_set_layout(
 /// Returns the current playback mode.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// The current Mode, or Mode::Forward if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_mode(ptr: *mut DotLottiePlayer) -> Mode {
+pub unsafe extern "C" fn dotlottie_get_mode(ptr: *mut Player) -> Mode {
     match ptr.as_mut() {
         Some(p) => p.mode(),
         _ => Mode::Forward,
@@ -472,12 +472,12 @@ pub unsafe extern "C" fn dotlottie_get_mode(ptr: *mut DotLottiePlayer) -> Mode {
 /// Returns the current playback speed.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// The current speed multiplier, or 1.0 if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_speed(ptr: *mut DotLottiePlayer) -> f32 {
+pub unsafe extern "C" fn dotlottie_get_speed(ptr: *mut Player) -> f32 {
     match ptr.as_mut() {
         Some(p) => p.speed(),
         _ => 1.0,
@@ -487,12 +487,12 @@ pub unsafe extern "C" fn dotlottie_get_speed(ptr: *mut DotLottiePlayer) -> f32 {
 /// Returns whether looping is enabled.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// true if looping is enabled, false otherwise or if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_loop(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_get_loop(ptr: *mut Player) -> bool {
     match ptr.as_mut() {
         Some(p) => p.loop_animation(),
         _ => false,
@@ -502,12 +502,12 @@ pub unsafe extern "C" fn dotlottie_get_loop(ptr: *mut DotLottiePlayer) -> bool {
 /// Returns the configured loop count (0 = infinite).
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// The configured loop count, or 0 if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_loop_count(ptr: *mut DotLottiePlayer) -> u32 {
+pub unsafe extern "C" fn dotlottie_get_loop_count(ptr: *mut Player) -> u32 {
     match ptr.as_mut() {
         Some(p) => p.loop_count(),
         _ => 0,
@@ -517,12 +517,12 @@ pub unsafe extern "C" fn dotlottie_get_loop_count(ptr: *mut DotLottiePlayer) -> 
 /// Returns whether autoplay is enabled.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// true if autoplay is enabled, false otherwise or if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_autoplay(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_get_autoplay(ptr: *mut Player) -> bool {
     match ptr.as_mut() {
         Some(p) => p.autoplay(),
         _ => false,
@@ -532,12 +532,12 @@ pub unsafe extern "C" fn dotlottie_get_autoplay(ptr: *mut DotLottiePlayer) -> bo
 /// Returns whether frame interpolation is enabled.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// true if frame interpolation is enabled, false otherwise or if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_get_use_frame_interpolation(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_get_use_frame_interpolation(ptr: *mut Player) -> bool {
     match ptr.as_mut() {
         Some(p) => p.use_frame_interpolation(),
         _ => false,
@@ -546,7 +546,7 @@ pub unsafe extern "C" fn dotlottie_get_use_frame_interpolation(ptr: *mut DotLott
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_background(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     r: *mut u8,
     g: *mut u8,
     b: *mut u8,
@@ -568,7 +568,7 @@ pub unsafe extern "C" fn dotlottie_background(
 /// Returns the current segment.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `result`: Pointer to a [f32; 2] array to store [start_frame, end_frame]
 ///
 /// # Returns
@@ -576,7 +576,7 @@ pub unsafe extern "C" fn dotlottie_background(
 /// - `DotLottieResult::InvalidParameter` if pointers are invalid or no segment is set
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_segment(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut [f32; 2],
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -596,7 +596,7 @@ pub unsafe extern "C" fn dotlottie_get_segment(
 /// Returns the current marker name.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `buffer`: Buffer to store the marker name, or NULL to query required size
 /// - `size_out`: Pointer to receive the required buffer size (including null terminator)
 ///
@@ -613,7 +613,7 @@ pub unsafe extern "C" fn dotlottie_get_segment(
 /// - `DotLottieResult::InvalidParameter` if no marker is set or player pointer is invalid
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_active_marker(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut c_char,
     size_out: *mut usize,
 ) -> DotLottieResult {
@@ -644,7 +644,7 @@ pub unsafe extern "C" fn dotlottie_get_active_marker(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_layout(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut Layout,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -658,7 +658,7 @@ pub unsafe extern "C" fn dotlottie_get_layout(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_total_frames(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -673,7 +673,7 @@ pub unsafe extern "C" fn dotlottie_total_frames(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_duration(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -688,7 +688,7 @@ pub unsafe extern "C" fn dotlottie_duration(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_current_frame(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -703,7 +703,7 @@ pub unsafe extern "C" fn dotlottie_current_frame(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_current_loop_count(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut u32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -718,7 +718,7 @@ pub unsafe extern "C" fn dotlottie_current_loop_count(
 
 /// Returns whether an animation is loaded.
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_is_loaded(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_is_loaded(ptr: *mut Player) -> bool {
     match ptr.as_mut() {
         Some(p) => p.is_loaded(),
         _ => false,
@@ -730,13 +730,13 @@ pub unsafe extern "C" fn dotlottie_is_loaded(ptr: *mut DotLottiePlayer) -> bool 
 /// Priority order: Playing > Paused > Stopped
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 ///
 /// # Returns
 /// The current PlaybackStatus (Playing, Paused, or Stopped)
 /// Returns Stopped if the pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_playback_status(ptr: *mut DotLottiePlayer) -> PlaybackStatus {
+pub unsafe extern "C" fn dotlottie_playback_status(ptr: *mut Player) -> PlaybackStatus {
     match ptr.as_mut() {
         Some(p) => {
             if p.is_playing() {
@@ -752,23 +752,23 @@ pub unsafe extern "C" fn dotlottie_playback_status(ptr: *mut DotLottiePlayer) ->
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_play(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_play(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.play())
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_pause(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_pause(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.pause())
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_stop(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_stop(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.stop())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_audio_volume(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     volume: f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -787,7 +787,7 @@ pub unsafe extern "C" fn dotlottie_set_audio_volume(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_audio_volume(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     result: *mut f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -809,14 +809,14 @@ pub unsafe extern "C" fn dotlottie_audio_volume(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_frame(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     no: f32,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.set_frame(no))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_render(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_render(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.render())
 }
 
@@ -839,7 +839,7 @@ pub unsafe extern "C" fn dotlottie_render(ptr: *mut DotLottiePlayer) -> DotLotti
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_tick(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     dt: f32,
     rendered: *mut bool,
 ) -> DotLottieResult {
@@ -853,7 +853,7 @@ pub unsafe extern "C" fn dotlottie_tick(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_clear(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_clear(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         dotlottie_player.clear();
         DotLottieResult::Success
@@ -862,7 +862,7 @@ pub unsafe extern "C" fn dotlottie_clear(ptr: *mut DotLottiePlayer) -> DotLottie
 
 /// Returns whether the animation has completed playback.
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_is_complete(ptr: *mut DotLottiePlayer) -> bool {
+pub unsafe extern "C" fn dotlottie_is_complete(ptr: *mut Player) -> bool {
     match ptr.as_mut() {
         Some(p) => p.is_complete(),
         _ => false,
@@ -872,7 +872,7 @@ pub unsafe extern "C" fn dotlottie_is_complete(ptr: *mut DotLottiePlayer) -> boo
 /// Sets the software rendering target.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `buffer`: Pointer to the pixel buffer (must be width * height in size)
 /// - `width`: Width of the buffer in pixels
 /// - `height`: Height of the buffer in pixels
@@ -883,7 +883,7 @@ pub unsafe extern "C" fn dotlottie_is_complete(ptr: *mut DotLottiePlayer) -> boo
 /// - `DotLottieResult::InvalidParameter` if buffer is too small or pointer is invalid
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_sw_target(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut u32,
     width: u32,
     height: u32,
@@ -897,7 +897,7 @@ pub unsafe extern "C" fn dotlottie_set_sw_target(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_gl_target(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     display: *mut std::ffi::c_void,
     surface: *mut std::ffi::c_void,
     context: *mut std::ffi::c_void,
@@ -915,7 +915,7 @@ pub unsafe extern "C" fn dotlottie_set_gl_target(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_wg_target(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     device: *mut std::ffi::c_void,
     instance: *mut std::ffi::c_void,
     target: *mut std::ffi::c_void,
@@ -941,7 +941,7 @@ pub unsafe extern "C" fn dotlottie_set_wg_target(
 #[cfg_attr(not(feature = "theming"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_theme(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     theme_id: *const c_char,
 ) -> DotLottieResult {
     #[cfg(not(feature = "theming"))]
@@ -962,7 +962,7 @@ pub unsafe extern "C" fn dotlottie_set_theme(
 
 #[cfg_attr(not(feature = "theming"), allow(unused_variables))]
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_reset_theme(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_reset_theme(ptr: *mut Player) -> DotLottieResult {
     #[cfg(not(feature = "theming"))]
     {
         return DotLottieResult::FeatureNotEnabled;
@@ -976,7 +976,7 @@ pub unsafe extern "C" fn dotlottie_reset_theme(ptr: *mut DotLottiePlayer) -> Dot
 /// Sets the theme using raw theme data.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `theme_data`: Null-terminated C string containing the theme JSON data
 ///
 /// # Returns
@@ -986,7 +986,7 @@ pub unsafe extern "C" fn dotlottie_reset_theme(ptr: *mut DotLottiePlayer) -> Dot
 #[cfg_attr(not(feature = "theming"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_theme_data(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     theme_data: *const c_char,
 ) -> DotLottieResult {
     #[cfg(not(feature = "theming"))]
@@ -1024,7 +1024,7 @@ pub unsafe extern "C" fn dotlottie_set_theme_data(
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_slots_str(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slots_json: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -1041,14 +1041,14 @@ pub unsafe extern "C" fn dotlottie_set_slots_str(
 
 /// Clear all slots
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_clear_slots(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_clear_slots(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.clear_slots())
 }
 
 /// Clear a specific slot by ID
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_clear_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -1066,7 +1066,7 @@ pub unsafe extern "C" fn dotlottie_clear_slot(
 /// Set a color slot with RGB values (0.0 to 1.0)
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_color_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     r: f32,
     g: f32,
@@ -1090,7 +1090,7 @@ pub unsafe extern "C" fn dotlottie_set_color_slot(
 /// Set a scalar slot with a single float value
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_scalar_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     value: f32,
 ) -> DotLottieResult {
@@ -1112,7 +1112,7 @@ pub unsafe extern "C" fn dotlottie_set_scalar_slot(
 /// Set a text slot with a text string
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_text_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     text: *const c_char,
 ) -> DotLottieResult {
@@ -1135,7 +1135,7 @@ pub unsafe extern "C" fn dotlottie_set_text_slot(
 /// Set a 2D vector slot
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_vector_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     x: f32,
     y: f32,
@@ -1158,7 +1158,7 @@ pub unsafe extern "C" fn dotlottie_set_vector_slot(
 /// Set a 2D position slot
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_position_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     x: f32,
     y: f32,
@@ -1181,7 +1181,7 @@ pub unsafe extern "C" fn dotlottie_set_position_slot(
 /// Set an image slot from a file path
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_image_slot_path(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     path: *const c_char,
 ) -> DotLottieResult {
@@ -1204,7 +1204,7 @@ pub unsafe extern "C" fn dotlottie_set_image_slot_path(
 /// Set an image slot from a data URL (base64 encoded)
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_image_slot_data_url(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     data_url: *const c_char,
 ) -> DotLottieResult {
@@ -1231,7 +1231,7 @@ pub unsafe extern "C" fn dotlottie_set_image_slot_data_url(
 /// Returns the number of slot IDs in the current animation.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_slot_ids_count(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     count: *mut u32,
 ) -> DotLottieResult {
     if ptr.is_null() || count.is_null() {
@@ -1248,7 +1248,7 @@ pub unsafe extern "C" fn dotlottie_get_slot_ids_count(
 /// Pass `buffer = NULL` to query the required size via `size_out`.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_slot_id(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     index: u32,
     buffer: *mut c_char,
     size_out: *mut usize,
@@ -1283,7 +1283,7 @@ pub unsafe extern "C" fn dotlottie_get_slot_id(
 /// Pass `buffer = NULL` to query the required size via `size_out`.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_slot_type(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     buffer: *mut c_char,
     size_out: *mut usize,
@@ -1323,7 +1323,7 @@ pub unsafe extern "C" fn dotlottie_get_slot_type(
 /// Pass `buffer = NULL` to query the required size via `size_out`.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_slot_str(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     buffer: *mut c_char,
     size_out: *mut usize,
@@ -1363,7 +1363,7 @@ pub unsafe extern "C" fn dotlottie_get_slot_str(
 /// Pass `buffer = NULL` to query the required size via `size_out`.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_slots_str(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut c_char,
     size_out: *mut usize,
 ) -> DotLottieResult {
@@ -1390,7 +1390,7 @@ pub unsafe extern "C" fn dotlottie_get_slots_str(
 /// The JSON should match the format for the slot's type.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_slot_str(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
     json: *const c_char,
 ) -> DotLottieResult {
@@ -1410,7 +1410,7 @@ pub unsafe extern "C" fn dotlottie_set_slot_str(
 /// Reset a single slot to its default value (from the animation).
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_reset_slot(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     slot_id: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
@@ -1427,7 +1427,7 @@ pub unsafe extern "C" fn dotlottie_reset_slot(
 
 /// Reset all slots to their default values (from the animation).
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_reset_slots(ptr: *mut DotLottiePlayer) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_reset_slots(ptr: *mut Player) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         if dotlottie_player.reset_slots() {
             Ok(())
@@ -1440,7 +1440,7 @@ pub unsafe extern "C" fn dotlottie_reset_slots(ptr: *mut DotLottiePlayer) -> Dot
 /// Gets the number of markers in the current animation.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `count`: Pointer to receive the marker count
 ///
 /// # Returns
@@ -1448,7 +1448,7 @@ pub unsafe extern "C" fn dotlottie_reset_slots(ptr: *mut DotLottiePlayer) -> Dot
 /// - `DOTLOTTIE_INVALID_PARAMETER` if pointers are null
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_markers_count(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     count: *mut u32,
 ) -> DotLottieResult {
     if ptr.is_null() || count.is_null() {
@@ -1462,7 +1462,7 @@ pub unsafe extern "C" fn dotlottie_markers_count(
 /// Gets a marker by index.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `idx`: Index of the marker (0-based)
 /// - `name`: Pointer to receive the marker name (library-owned, do not free)
 /// - `start`: Pointer to receive the marker start frame, or NULL to skip
@@ -1473,7 +1473,7 @@ pub unsafe extern "C" fn dotlottie_markers_count(
 /// - `DOTLOTTIE_INVALID_PARAMETER` if ptr/name is null or index is out of bounds
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_marker(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     idx: u32,
     name: *mut *const c_char,
     start: *mut f32,
@@ -1505,7 +1505,7 @@ pub unsafe extern "C" fn dotlottie_marker(
 /// Returns the active animation ID.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `buffer`: Buffer to store the ID, or NULL to query required size
 /// - `size_out`: Pointer to receive the required buffer size (including null terminator)
 ///
@@ -1516,7 +1516,7 @@ pub unsafe extern "C" fn dotlottie_marker(
 #[cfg_attr(not(feature = "dotlottie"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_animation_id(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut c_char,
     size_out: *mut usize,
 ) -> DotLottieResult {
@@ -1554,7 +1554,7 @@ pub unsafe extern "C" fn dotlottie_animation_id(
 /// Returns the active theme ID.
 ///
 /// # Parameters
-/// - `ptr`: Pointer to the DotLottiePlayer instance
+/// - `ptr`: Pointer to the Player instance
 /// - `buffer`: Buffer to store the ID, or NULL to query required size
 /// - `size_out`: Pointer to receive the required buffer size (including null terminator)
 ///
@@ -1565,7 +1565,7 @@ pub unsafe extern "C" fn dotlottie_animation_id(
 #[cfg_attr(not(feature = "theming"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_theme_id(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     buffer: *mut c_char,
     size_out: *mut usize,
 ) -> DotLottieResult {
@@ -1602,7 +1602,7 @@ pub unsafe extern "C" fn dotlottie_theme_id(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_set_viewport(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     x: i32,
     y: i32,
     w: i32,
@@ -1615,7 +1615,7 @@ pub unsafe extern "C" fn dotlottie_set_viewport(
 
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_animation_size(
-    ptr: *mut DotLottiePlayer,
+    ptr: *mut Player,
     picture_width: *mut f32,
     picture_height: *mut f32,
 ) -> DotLottieResult {
@@ -1655,7 +1655,7 @@ pub unsafe extern "C" fn dotlottie_animation_size(
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_poll_event(
-    player: *mut DotLottiePlayer,
+    player: *mut Player,
     event: *mut types::DotLottiePlayerEvent,
 ) -> i32 {
     if player.is_null() || event.is_null() {
@@ -1676,7 +1676,7 @@ pub unsafe extern "C" fn dotlottie_poll_event(
 
 // ============================================================================
 // STATE MACHINE C API
-// Separate StateMachineEngine object with lifetime to DotLottiePlayer
+// Separate StateMachineEngine object with lifetime to Player
 // ============================================================================
 
 /// Load a state machine by ID from the loaded .lottie file
@@ -1692,7 +1692,7 @@ pub unsafe extern "C" fn dotlottie_poll_event(
 #[cfg_attr(not(feature = "state-machines"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_state_machine_load(
-    runtime: *mut DotLottiePlayer,
+    runtime: *mut Player,
     state_machine_id: *const c_char,
 ) -> *mut DotLottieStateMachine {
     #[cfg(not(feature = "state-machines"))]
@@ -1728,7 +1728,7 @@ pub unsafe extern "C" fn dotlottie_state_machine_load(
 #[cfg_attr(not(feature = "state-machines"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_state_machine_load_data(
-    runtime: *mut DotLottiePlayer,
+    runtime: *mut Player,
     state_machine_definition: *const c_char,
 ) -> *mut DotLottieStateMachine {
     #[cfg(not(feature = "state-machines"))]
@@ -1880,7 +1880,7 @@ pub unsafe extern "C" fn dotlottie_state_machine_tick(
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_state_machine_post_event(
     sm: *mut DotLottieStateMachine,
-    event: *const DotLottieEvent,
+    event: *const PlayerEvent,
 ) -> DotLottieResult {
     #[cfg(not(feature = "state-machines"))]
     {
@@ -2648,7 +2648,7 @@ pub unsafe extern "C" fn dotlottie_state_machine_poll_internal_event(
 /// Get the state machine definition as JSON string.
 ///
 /// # Parameters
-/// - `runtime`: Pointer to the DotLottiePlayer instance
+/// - `runtime`: Pointer to the Player instance
 /// - `state_machine_id`: Null-terminated C string with the state machine ID
 /// - `buffer`: Buffer to store the JSON, or NULL to query required size
 /// - `size_out`: Pointer to receive the required buffer size (including null terminator)
@@ -2660,7 +2660,7 @@ pub unsafe extern "C" fn dotlottie_state_machine_poll_internal_event(
 #[cfg_attr(not(feature = "state-machines"), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_get_state_machine(
-    runtime: *mut DotLottiePlayer,
+    runtime: *mut Player,
     state_machine_id: *const c_char,
     buffer: *mut c_char,
     size_out: *mut usize,

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -7,7 +7,7 @@ use crate::lottie_renderer::{
     ColorSlot, ColorValue, GlContext, GlDisplay, GlSurface, ImageSlot, PositionSlot, ScalarSlot,
     ScalarValue, TextDocument, TextSlot, VectorSlot, WgpuDevice, WgpuInstance, WgpuTarget,
 };
-use crate::{Player, Layout, Mode, PlayerError, Rgba, Segment};
+use crate::{Layout, Mode, Player, PlayerError, Rgba, Segment};
 
 use crate::ColorSpace;
 
@@ -303,10 +303,7 @@ pub unsafe extern "C" fn dotlottie_manifest(
 // ============================================================================
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_mode(
-    ptr: *mut Player,
-    mode: Mode,
-) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_set_mode(ptr: *mut Player, mode: Mode) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         dotlottie_player.set_mode(mode);
         DotLottieResult::Success
@@ -314,10 +311,7 @@ pub unsafe extern "C" fn dotlottie_set_mode(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_speed(
-    ptr: *mut Player,
-    speed: f32,
-) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_set_speed(ptr: *mut Player, speed: f32) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         dotlottie_player.set_speed(speed);
         DotLottieResult::Success
@@ -441,10 +435,7 @@ pub unsafe extern "C" fn dotlottie_set_marker(
 /// - `DotLottieResult::Success` on success
 /// - `DotLottieResult::InvalidParameter` if the player pointer is invalid
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_layout(
-    ptr: *mut Player,
-    layout: Layout,
-) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_set_layout(ptr: *mut Player, layout: Layout) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         dotlottie_player.set_layout(layout)
     })
@@ -672,10 +663,7 @@ pub unsafe extern "C" fn dotlottie_total_frames(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_duration(
-    ptr: *mut Player,
-    result: *mut f32,
-) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_duration(ptr: *mut Player, result: *mut f32) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
         if !result.is_null() {
             *result = dotlottie_player.duration();
@@ -808,10 +796,7 @@ pub unsafe extern "C" fn dotlottie_audio_volume(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_frame(
-    ptr: *mut Player,
-    no: f32,
-) -> DotLottieResult {
+pub unsafe extern "C" fn dotlottie_set_frame(ptr: *mut Player, no: f32) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| dotlottie_player.set_frame(no))
 }
 

--- a/dotlottie-rs/src/c_api/types.rs
+++ b/dotlottie-rs/src/c_api/types.rs
@@ -136,7 +136,7 @@ impl DotLottieWgpuTargetType {
 // Input events for state machine (pointer interactions)
 #[allow(dead_code)]
 #[repr(C)]
-pub enum DotLottieEvent {
+pub enum PlayerEvent {
     PointerDown { x: f32, y: f32 },
     PointerUp { x: f32, y: f32 },
     PointerMove { x: f32, y: f32 },
@@ -148,17 +148,17 @@ pub enum DotLottieEvent {
 }
 
 #[cfg(feature = "state-machines")]
-impl DotLottieEvent {
+impl PlayerEvent {
     pub unsafe fn to_event(&self) -> Event {
         match self {
-            DotLottieEvent::PointerDown { x, y } => Event::PointerDown { x: *x, y: *y },
-            DotLottieEvent::PointerUp { x, y } => Event::PointerUp { x: *x, y: *y },
-            DotLottieEvent::PointerMove { x, y } => Event::PointerMove { x: *x, y: *y },
-            DotLottieEvent::PointerEnter { x, y } => Event::PointerEnter { x: *x, y: *y },
-            DotLottieEvent::PointerExit { x, y } => Event::PointerExit { x: *x, y: *y },
-            DotLottieEvent::Click { x, y } => Event::Click { x: *x, y: *y },
-            DotLottieEvent::OnComplete => Event::OnComplete,
-            DotLottieEvent::OnLoopComplete => Event::OnLoopComplete,
+            PlayerEvent::PointerDown { x, y } => Event::PointerDown { x: *x, y: *y },
+            PlayerEvent::PointerUp { x, y } => Event::PointerUp { x: *x, y: *y },
+            PlayerEvent::PointerMove { x, y } => Event::PointerMove { x: *x, y: *y },
+            PlayerEvent::PointerEnter { x, y } => Event::PointerEnter { x: *x, y: *y },
+            PlayerEvent::PointerExit { x, y } => Event::PointerExit { x: *x, y: *y },
+            PlayerEvent::Click { x, y } => Event::Click { x: *x, y: *y },
+            PlayerEvent::OnComplete => Event::OnComplete,
+            PlayerEvent::OnLoopComplete => Event::OnLoopComplete,
         }
     }
 }
@@ -193,42 +193,42 @@ pub struct DotLottiePlayerEvent {
     pub event_type: DotLottiePlayerEventType,
     pub data: DotLottiePlayerEventData,
 }
-impl From<crate::DotLottieEvent> for DotLottiePlayerEvent {
-    fn from(event: crate::DotLottieEvent) -> Self {
+impl From<crate::PlayerEvent> for DotLottiePlayerEvent {
+    fn from(event: crate::PlayerEvent) -> Self {
         match event {
-            crate::DotLottieEvent::Load => DotLottiePlayerEvent {
+            crate::PlayerEvent::Load => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Load,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },
-            crate::DotLottieEvent::LoadError => DotLottiePlayerEvent {
+            crate::PlayerEvent::LoadError => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::LoadError,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },
-            crate::DotLottieEvent::Play => DotLottiePlayerEvent {
+            crate::PlayerEvent::Play => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Play,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },
-            crate::DotLottieEvent::Pause => DotLottiePlayerEvent {
+            crate::PlayerEvent::Pause => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Pause,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },
-            crate::DotLottieEvent::Stop => DotLottiePlayerEvent {
+            crate::PlayerEvent::Stop => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Stop,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },
-            crate::DotLottieEvent::Frame { frame_no } => DotLottiePlayerEvent {
+            crate::PlayerEvent::Frame { frame_no } => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Frame,
                 data: DotLottiePlayerEventData { frame_no },
             },
-            crate::DotLottieEvent::Render { frame_no } => DotLottiePlayerEvent {
+            crate::PlayerEvent::Render { frame_no } => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Render,
                 data: DotLottiePlayerEventData { frame_no },
             },
-            crate::DotLottieEvent::Loop { loop_count } => DotLottiePlayerEvent {
+            crate::PlayerEvent::Loop { loop_count } => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Loop,
                 data: DotLottiePlayerEventData { loop_count },
             },
-            crate::DotLottieEvent::Complete => DotLottiePlayerEvent {
+            crate::PlayerEvent::Complete => DotLottiePlayerEvent {
                 event_type: DotLottiePlayerEventType::Complete,
                 data: DotLottiePlayerEventData { frame_no: 0.0 },
             },

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -4,7 +4,7 @@ use std::{fs, mem};
 
 #[cfg(feature = "audio")]
 use crate::audio::AudioManager;
-use crate::poll_events::{PlayerEvent, EventQueue};
+use crate::poll_events::{EventQueue, PlayerEvent};
 use crate::PlayerError;
 use crate::{
     layout::Layout,
@@ -484,8 +484,7 @@ impl Player {
         }
 
         self.renderer.set_frame(no)?;
-        self.event_queue
-            .push(PlayerEvent::Frame { frame_no: no });
+        self.event_queue.push(PlayerEvent::Frame { frame_no: no });
 
         #[cfg(feature = "audio")]
         if self.is_playing() {

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -4,7 +4,7 @@ use std::{fs, mem};
 
 #[cfg(feature = "audio")]
 use crate::audio::AudioManager;
-use crate::poll_events::{DotLottieEvent, EventQueue};
+use crate::poll_events::{PlayerEvent, EventQueue};
 use crate::PlayerError;
 use crate::{
     layout::Layout,
@@ -55,7 +55,7 @@ pub enum CompletionEvent {
     LoopCompleted,
 }
 
-pub struct DotLottiePlayer {
+pub struct Player {
     pub(crate) renderer: Box<dyn LottieRenderer>,
     playback_state: PlaybackState,
     is_loaded: bool,
@@ -67,7 +67,7 @@ pub struct DotLottiePlayer {
     audio_manager: Option<AudioManager>,
     direction: Direction,
     active_marker: Option<CString>,
-    event_queue: EventQueue<DotLottieEvent, 16>,
+    event_queue: EventQueue<PlayerEvent, 16>,
     completion_event: CompletionEvent,
     // Playback config properties
     mode: Mode,
@@ -87,13 +87,13 @@ pub struct DotLottiePlayer {
 }
 
 #[cfg(feature = "tvg")]
-impl Default for DotLottiePlayer {
+impl Default for Player {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl DotLottiePlayer {
+impl Player {
     #[cfg(feature = "tvg")]
     pub fn new() -> Self {
         Self::with_renderer(crate::TvgRenderer::new(0))
@@ -117,7 +117,7 @@ impl DotLottiePlayer {
     }
 
     pub fn with_renderer<R: Renderer>(renderer: R) -> Self {
-        DotLottiePlayer {
+        Player {
             renderer: <dyn LottieRenderer>::new(renderer),
             playback_state: PlaybackState::Stopped,
             is_loaded: false,
@@ -234,7 +234,7 @@ impl DotLottiePlayer {
             am.play();
         }
 
-        self.event_queue.push(DotLottieEvent::Play);
+        self.event_queue.push(PlayerEvent::Play);
 
         Ok(())
     }
@@ -253,7 +253,7 @@ impl DotLottiePlayer {
             am.pause();
         }
 
-        self.event_queue.push(DotLottieEvent::Pause);
+        self.event_queue.push(PlayerEvent::Pause);
         Ok(())
     }
 
@@ -286,7 +286,7 @@ impl DotLottiePlayer {
             am.stop();
         }
 
-        self.event_queue.push(DotLottieEvent::Stop);
+        self.event_queue.push(PlayerEvent::Stop);
 
         Ok(())
     }
@@ -485,7 +485,7 @@ impl DotLottiePlayer {
 
         self.renderer.set_frame(no)?;
         self.event_queue
-            .push(DotLottieEvent::Frame { frame_no: no });
+            .push(PlayerEvent::Frame { frame_no: no });
 
         #[cfg(feature = "audio")]
         if self.is_playing() {
@@ -516,12 +516,12 @@ impl DotLottiePlayer {
 
     fn emit_on_complete(&mut self) {
         self.completion_event = CompletionEvent::Completed;
-        self.event_queue.push(DotLottieEvent::Complete);
+        self.event_queue.push(PlayerEvent::Complete);
     }
 
     pub fn emit_on_loop(&mut self) {
         self.completion_event = CompletionEvent::LoopCompleted;
-        self.event_queue.push(DotLottieEvent::Loop {
+        self.event_queue.push(PlayerEvent::Loop {
             loop_count: self.current_loop_count(),
         });
     }
@@ -531,7 +531,7 @@ impl DotLottiePlayer {
 
         let frame_no = self.current_frame();
 
-        self.event_queue.push(DotLottieEvent::Render { frame_no });
+        self.event_queue.push(PlayerEvent::Render { frame_no });
 
         // Completion logic only applies during active playback — not when the
         // caller renders manually (e.g. scrubbing while paused/stopped).
@@ -874,12 +874,12 @@ impl DotLottiePlayer {
         let result = self.load_animation_common(|renderer| renderer.load_data(animation_data));
 
         if result.is_ok() {
-            self.event_queue.push(DotLottieEvent::Load);
+            self.event_queue.push(PlayerEvent::Load);
             if self.autoplay {
                 let _ = self.play();
             }
         } else {
-            self.event_queue.push(DotLottieEvent::LoadError);
+            self.event_queue.push(PlayerEvent::LoadError);
         }
 
         result
@@ -906,7 +906,7 @@ impl DotLottiePlayer {
         })();
 
         result.inspect_err(|_| {
-            self.event_queue.push(DotLottieEvent::LoadError);
+            self.event_queue.push(PlayerEvent::LoadError);
         })
     }
 
@@ -955,13 +955,13 @@ impl DotLottiePlayer {
         }
 
         if result.is_ok() {
-            self.event_queue.push(DotLottieEvent::Load);
+            self.event_queue.push(PlayerEvent::Load);
 
             if self.autoplay {
                 let _ = self.play();
             }
         } else {
-            self.event_queue.push(DotLottieEvent::LoadError);
+            self.event_queue.push(PlayerEvent::LoadError);
         }
 
         Ok(())
@@ -1011,12 +1011,12 @@ impl DotLottiePlayer {
                     let _ = self.set_theme(theme_id_cstr);
                 }
 
-                self.event_queue.push(DotLottieEvent::Load);
+                self.event_queue.push(PlayerEvent::Load);
                 if self.autoplay {
                     let _ = self.play();
                 }
             } else {
-                self.event_queue.push(DotLottieEvent::LoadError);
+                self.event_queue.push(PlayerEvent::LoadError);
             }
 
             result
@@ -1415,7 +1415,7 @@ impl DotLottiePlayer {
     /// Poll for the next event from the event queue
     ///
     /// Returns Some(event) if an event is available, None if the queue is empty.
-    pub fn poll_event(&mut self) -> Option<DotLottieEvent> {
+    pub fn poll_event(&mut self) -> Option<PlayerEvent> {
         self.event_queue.poll()
     }
 

--- a/dotlottie-rs/src/poll_events.rs
+++ b/dotlottie-rs/src/poll_events.rs
@@ -4,7 +4,7 @@ pub use crate::event_queue::EventQueue;
 
 /// Events emitted by the DotLottie player.
 #[derive(Debug, Clone, PartialEq)]
-pub enum DotLottieEvent {
+pub enum PlayerEvent {
     Load,
     LoadError,
     Play,

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -25,8 +25,8 @@ use crate::actions::whitelist::Whitelist;
 use crate::poll_events::{EventQueue, StateMachineEvent, StateMachineInternalEvent};
 use crate::state_machine_engine::interactions::Interaction;
 use crate::{
-    event_type_name, state_machine_state_check_pipeline, CompletionEvent, Player,
-    EventName, Layout, Mode, Point, PointerEvent, Rgba, Segment, StateMachineEngineSecurityError,
+    event_type_name, state_machine_state_check_pipeline, CompletionEvent, EventName, Layout, Mode,
+    Player, Point, PointerEvent, Rgba, Segment, StateMachineEngineSecurityError,
 };
 
 use self::state_machine::state_machine_parse;

--- a/dotlottie-rs/src/state_machine_engine/mod.rs
+++ b/dotlottie-rs/src/state_machine_engine/mod.rs
@@ -25,7 +25,7 @@ use crate::actions::whitelist::Whitelist;
 use crate::poll_events::{EventQueue, StateMachineEvent, StateMachineInternalEvent};
 use crate::state_machine_engine::interactions::Interaction;
 use crate::{
-    event_type_name, state_machine_state_check_pipeline, CompletionEvent, DotLottiePlayer,
+    event_type_name, state_machine_state_check_pipeline, CompletionEvent, Player,
     EventName, Layout, Mode, Point, PointerEvent, Rgba, Segment, StateMachineEngineSecurityError,
 };
 
@@ -95,7 +95,7 @@ pub struct StateMachineEngine<'a> {
     pub open_url_requires_user_interaction: bool,
     pub open_url_whitelist: Whitelist,
 
-    pub player: &'a mut DotLottiePlayer,
+    pub player: &'a mut Player,
 
     pub inputs: InputManager,
     curr_event: Option<String>,
@@ -126,7 +126,7 @@ pub struct StateMachineEngine<'a> {
 impl<'a> StateMachineEngine<'a> {
     pub fn new(
         state_machine_definition: &str,
-        player: &'a mut DotLottiePlayer,
+        player: &'a mut Player,
         max_cycle_count: Option<usize>,
     ) -> Result<StateMachineEngine<'a>, StateMachineEngineError> {
         Self::from_definition(state_machine_definition, player, max_cycle_count)
@@ -311,7 +311,7 @@ impl<'a> StateMachineEngine<'a> {
     // Previously called create_state_machine
     pub fn from_definition(
         sm_definition: &str,
-        player: &'a mut DotLottiePlayer,
+        player: &'a mut Player,
         max_cycle_count: Option<usize>,
     ) -> Result<StateMachineEngine<'a>, StateMachineEngineError> {
         let parsed_state_machine = state_machine_parse(sm_definition);

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
 use crate::ColorSpace;
-use crate::{DotLottiePlayer, Fit, Layout, Mode as PlayerMode, Rgba, Segment};
+use crate::{Player, Fit, Layout, Mode as PlayerMode, Rgba, Segment};
 
 // ─── Renderer mode ───────────────────────────────────────────────────────────
 
@@ -206,7 +206,7 @@ pub struct DotLottiePlayerWasm {
     /// dropped first (it holds a raw mutable pointer into `player`).
     #[cfg(feature = "state-machines")]
     state_machine: Option<crate::StateMachineEngine<'static>>,
-    player: std::mem::ManuallyDrop<DotLottiePlayer>,
+    player: std::mem::ManuallyDrop<Player>,
     /// Owned pixel buffer for the SW renderer (ARGB8888 u32 values).
     #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
     sw_buffer: Vec<u32>,
@@ -231,7 +231,7 @@ impl DotLottiePlayerWasm {
         DotLottiePlayerWasm {
             #[cfg(feature = "state-machines")]
             state_machine: None,
-            player: std::mem::ManuallyDrop::new(DotLottiePlayer::new()),
+            player: std::mem::ManuallyDrop::new(Player::new()),
             #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
             sw_buffer: Vec::new(),
             width: 0,
@@ -804,23 +804,23 @@ impl DotLottiePlayerWasm {
             return JsValue::null();
         };
         match evt {
-            crate::DotLottieEvent::Load => js_obj_with_type("Load").into(),
-            crate::DotLottieEvent::LoadError => js_obj_with_type("LoadError").into(),
-            crate::DotLottieEvent::Play => js_obj_with_type("Play").into(),
-            crate::DotLottieEvent::Pause => js_obj_with_type("Pause").into(),
-            crate::DotLottieEvent::Stop => js_obj_with_type("Stop").into(),
-            crate::DotLottieEvent::Complete => js_obj_with_type("Complete").into(),
-            crate::DotLottieEvent::Frame { frame_no } => {
+            crate::PlayerEvent::Load => js_obj_with_type("Load").into(),
+            crate::PlayerEvent::LoadError => js_obj_with_type("LoadError").into(),
+            crate::PlayerEvent::Play => js_obj_with_type("Play").into(),
+            crate::PlayerEvent::Pause => js_obj_with_type("Pause").into(),
+            crate::PlayerEvent::Stop => js_obj_with_type("Stop").into(),
+            crate::PlayerEvent::Complete => js_obj_with_type("Complete").into(),
+            crate::PlayerEvent::Frame { frame_no } => {
                 let obj = js_obj_with_type("Frame");
                 set_f64(&obj, "frameNo", frame_no as f64);
                 obj.into()
             }
-            crate::DotLottieEvent::Render { frame_no } => {
+            crate::PlayerEvent::Render { frame_no } => {
                 let obj = js_obj_with_type("Render");
                 set_f64(&obj, "frameNo", frame_no as f64);
                 obj.into()
             }
-            crate::DotLottieEvent::Loop { loop_count } => {
+            crate::PlayerEvent::Loop { loop_count } => {
                 let obj = js_obj_with_type("Loop");
                 set_f64(&obj, "loopCount", loop_count as f64);
                 obj.into()
@@ -851,12 +851,12 @@ impl DotLottiePlayerWasm {
 
     #[cfg(feature = "tvg")]
     pub fn load_font(&mut self, name: &str, data: &[u8]) -> bool {
-        DotLottiePlayer::load_font(name, data).is_ok()
+        Player::load_font(name, data).is_ok()
     }
 
     #[cfg(feature = "tvg")]
     pub fn unload_font(name: &str) -> bool {
-        DotLottiePlayer::unload_font(name).is_ok()
+        Player::unload_font(name).is_ok()
     }
 
     // ── Theming ───────────────────────────────────────────────────────────────
@@ -1544,5 +1544,5 @@ impl Default for DotLottiePlayerWasm {
 #[wasm_bindgen]
 #[cfg(feature = "tvg")]
 pub fn register_font(name: &str, data: &[u8]) -> bool {
-    DotLottiePlayer::load_font(name, data).is_ok()
+    Player::load_font(name, data).is_ok()
 }

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
 use crate::ColorSpace;
-use crate::{Player, Fit, Layout, Mode as PlayerMode, Rgba, Segment};
+use crate::{Fit, Layout, Mode as PlayerMode, Player, Rgba, Segment};
 
 // ─── Renderer mode ───────────────────────────────────────────────────────────
 

--- a/dotlottie-rs/tests/autoplay.rs
+++ b/dotlottie-rs/tests/autoplay.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -12,14 +12,14 @@ mod tests {
 
     #[test]
     fn test_default_autoplay() {
-        let player = DotLottiePlayer::new();
+        let player = Player::new();
 
         assert!(!player.autoplay());
     }
 
     #[test]
     fn test_set_autoplay() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         player.set_autoplay(true);
 
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_autoplay() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_no_autoplay() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(false);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];

--- a/dotlottie-rs/tests/events.rs
+++ b/dotlottie-rs/tests/events.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 mod test_utils;
 
@@ -9,7 +9,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 #[cfg(test)]
 mod tests {
 
-    use dotlottie_rs::DotLottieEvent;
+    use dotlottie_rs::PlayerEvent;
 
     use super::*;
 
@@ -17,7 +17,7 @@ mod tests {
     fn test_subscribe_unsubscribe() {
         let mut events: Vec<String> = vec![];
 
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
         player.set_loop(true);
         player.set_use_frame_interpolation(false);
@@ -47,18 +47,18 @@ mod tests {
             "on_play".to_string(),
         ];
 
-        let drain = |player: &mut DotLottiePlayer, events: &mut Vec<String>| {
+        let drain = |player: &mut Player, events: &mut Vec<String>| {
             while let Some(event) = player.poll_event() {
                 events.push(match event {
-                    DotLottieEvent::Load => "on_load".to_string(),
-                    DotLottieEvent::LoadError => "on_load_error".to_string(),
-                    DotLottieEvent::Play => "on_play".to_string(),
-                    DotLottieEvent::Pause => "on_pause".to_string(),
-                    DotLottieEvent::Stop => "on_stop".to_string(),
-                    DotLottieEvent::Frame { frame_no } => format!("on_frame: {frame_no}"),
-                    DotLottieEvent::Render { frame_no } => format!("on_render: {frame_no}"),
-                    DotLottieEvent::Loop { loop_count } => format!("on_loop: {loop_count}"),
-                    DotLottieEvent::Complete => "on_complete".to_string(),
+                    PlayerEvent::Load => "on_load".to_string(),
+                    PlayerEvent::LoadError => "on_load_error".to_string(),
+                    PlayerEvent::Play => "on_play".to_string(),
+                    PlayerEvent::Pause => "on_pause".to_string(),
+                    PlayerEvent::Stop => "on_stop".to_string(),
+                    PlayerEvent::Frame { frame_no } => format!("on_frame: {frame_no}"),
+                    PlayerEvent::Render { frame_no } => format!("on_render: {frame_no}"),
+                    PlayerEvent::Loop { loop_count } => format!("on_loop: {loop_count}"),
+                    PlayerEvent::Complete => "on_complete".to_string(),
                 });
             }
         };

--- a/dotlottie-rs/tests/frame_buffer.rs
+++ b/dotlottie-rs/tests/frame_buffer.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 use std::ffi::CString;
 
 mod test_utils;
@@ -10,7 +10,7 @@ mod tests {
 
     #[test]
     fn buflen() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_buffer_len_with_animation_data() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 

--- a/dotlottie-rs/tests/frame_interpolation.rs
+++ b/dotlottie-rs/tests/frame_interpolation.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -10,14 +10,14 @@ mod tests {
 
     #[test]
     fn test_default_use_frame_interpolation() {
-        let player = DotLottiePlayer::new();
+        let player = Player::new();
 
         assert!(player.use_frame_interpolation());
     }
 
     #[test]
     fn test_set_use_frame_interpolation() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         player.set_use_frame_interpolation(false);
 
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn test_disable_frame_interpolation() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
         player.set_use_frame_interpolation(false);
 

--- a/dotlottie-rs/tests/markers.rs
+++ b/dotlottie-rs/tests/markers.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment};
+use dotlottie_rs::{ColorSpace, Player, Segment};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn test_default_marker() {
-        let player = DotLottiePlayer::new();
+        let player = Player::new();
 
         assert!(
             player.active_marker().is_none(),
@@ -22,7 +22,7 @@ mod tests {
 
     #[test]
     fn test_markers() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_set_marker() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_set_frame_outside_segment_rejected() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 

--- a/dotlottie-rs/tests/multi_animation.rs
+++ b/dotlottie-rs/tests/multi_animation.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -13,7 +13,7 @@ mod tests {
     pub fn test_load_animation_with_animation_id() {
         let animation_id = CString::new("crying").unwrap();
 
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     pub fn test_load_animation() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 

--- a/dotlottie-rs/tests/play.rs
+++ b/dotlottie-rs/tests/play.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use std::ffi::CString;
 
 use crate::test_utils::{HEIGHT, WIDTH};
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError};
+use dotlottie_rs::{ColorSpace, Player, PlayerError};
 
 #[cfg(test)]
 mod tests {
@@ -11,7 +11,7 @@ mod tests {
 
     #[test]
     fn test_play_fail_when_animation_is_not_loaded() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -37,7 +37,7 @@ mod tests {
 
     #[test]
     fn test_play_while_playing() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn test_play_after_pause() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_use_frame_interpolation(false);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_play_after_complete() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_use_frame_interpolation(false);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_play_after_setting_frame() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_use_frame_interpolation(false);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_tick_zero_dt_does_not_advance() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_tick_large_dt_completes_without_panic() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_tick_negative_dt_is_clamped_to_zero() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
         player.set_use_frame_interpolation(false);
 

--- a/dotlottie-rs/tests/play_mode.rs
+++ b/dotlottie-rs/tests/play_mode.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 
 mod test_utils;
 
@@ -8,7 +8,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 #[cfg(test)]
 mod play_mode_tests {
-    use dotlottie_rs::{DotLottieEvent, Mode};
+    use dotlottie_rs::{PlayerEvent, Mode};
 
     use super::*;
 
@@ -19,14 +19,14 @@ mod play_mode_tests {
 
     #[test]
     fn test_default_play_mode() {
-        let player = DotLottiePlayer::new();
+        let player = Player::new();
 
         assert_eq!(player.mode(), Mode::Forward);
     }
 
     #[test]
     fn test_loop_count_with_loop_animation_false() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
         player.set_loop(false);
@@ -62,10 +62,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -80,7 +80,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_zero_loop_count() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -115,7 +115,7 @@ mod play_mode_tests {
         }
 
         while let Some(event) = player.poll_event() {
-            if let DotLottieEvent::Loop { loop_count } = event {
+            if let PlayerEvent::Loop { loop_count } = event {
                 observed_loops = loop_count;
             }
         }
@@ -128,7 +128,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_playing_after_loop_has_completed() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -164,10 +164,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -197,10 +197,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -217,7 +217,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_loop_count_paused_mid_play() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -252,10 +252,10 @@ mod play_mode_tests {
         }
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -284,10 +284,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -314,7 +314,7 @@ mod play_mode_tests {
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
 
         for mode in play_modes {
-            let mut player = DotLottiePlayer::new();
+            let mut player = Player::new();
             player.set_mode(mode);
 
             let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -372,7 +372,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_forward_play_mode() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
 
@@ -423,7 +423,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_forward_play_mode_with_loop_count() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Forward);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -459,10 +459,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -479,7 +479,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_reverse_play_mode() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Reverse);
         player.set_autoplay(true);
 
@@ -528,7 +528,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_reverse_play_mode_with_loop_count() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Reverse);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -564,10 +564,10 @@ mod play_mode_tests {
 
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -584,7 +584,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_bounce_play_mode() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Bounce);
         player.set_autoplay(true);
 
@@ -651,7 +651,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_bounce_play_mode_with_loop_count() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::Bounce);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -686,10 +686,10 @@ mod play_mode_tests {
         }
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}
@@ -706,7 +706,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_reverse_bounce_play_mode() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::ReverseBounce);
         player.set_autoplay(true);
 
@@ -772,7 +772,7 @@ mod play_mode_tests {
 
     #[test]
     fn test_reverse_bounce_play_mode_with_loop_count() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_mode(Mode::ReverseBounce);
         player.set_autoplay(true);
         player.set_loop(true);
@@ -806,10 +806,10 @@ mod play_mode_tests {
         }
         while let Some(event) = player.poll_event() {
             match event {
-                DotLottieEvent::Loop { loop_count } => {
+                PlayerEvent::Loop { loop_count } => {
                     observed_loops = loop_count;
                 }
-                DotLottieEvent::Complete => {
+                PlayerEvent::Complete => {
                     observed_completed = true;
                 }
                 _ => {}

--- a/dotlottie-rs/tests/play_mode.rs
+++ b/dotlottie-rs/tests/play_mode.rs
@@ -8,7 +8,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 #[cfg(test)]
 mod play_mode_tests {
-    use dotlottie_rs::{PlayerEvent, Mode};
+    use dotlottie_rs::{Mode, PlayerEvent};
 
     use super::*;
 

--- a/dotlottie-rs/tests/segments.rs
+++ b/dotlottie-rs/tests/segments.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player, Mode, Segment};
+use dotlottie_rs::{ColorSpace, Mode, Player, Segment};
 
 #[cfg(test)]
 mod tests {

--- a/dotlottie-rs/tests/segments.rs
+++ b/dotlottie-rs/tests/segments.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Mode, Segment};
+use dotlottie_rs::{ColorSpace, Player, Mode, Segment};
 
 #[cfg(test)]
 mod tests {
@@ -11,7 +11,7 @@ mod tests {
 
     #[test]
     fn test_invalid_segment_rejected() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_same_start_end_rejected() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
@@ -104,7 +104,7 @@ mod tests {
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
 
         for mode in modes {
-            let mut player = DotLottiePlayer::new();
+            let mut player = Player::new();
             player.set_mode(mode);
             player.set_autoplay(true);
 
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_valid_segments_unchanged() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_set_segment_rejects_invalid() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(false);
 
         let path = CString::new("assets/animations/lottie/test.json").unwrap();

--- a/dotlottie-rs/tests/slots.rs
+++ b/dotlottie-rs/tests/slots.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer};
+use dotlottie_rs::{ColorSpace, Player};
 use std::ffi::CString;
 
 mod test_utils;
@@ -8,8 +8,8 @@ use crate::test_utils::{HEIGHT, WIDTH};
 mod tests {
     use super::*;
 
-    fn load_bouncy_ball() -> DotLottiePlayer {
-        let mut player = DotLottiePlayer::new();
+    fn load_bouncy_ball() -> Player {
+        let mut player = Player::new();
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
         player
             .set_sw_target(&mut buffer, WIDTH, HEIGHT, ColorSpace::ABGR8888)

--- a/dotlottie-rs/tests/speed.rs
+++ b/dotlottie-rs/tests/speed.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Segment};
+use dotlottie_rs::{ColorSpace, Player, Segment};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
@@ -18,14 +18,14 @@ mod tests {
 
     #[test]
     fn test_default_speed() {
-        let player = DotLottiePlayer::new();
+        let player = Player::new();
 
         assert_eq!(player.speed(), 1.0);
     }
 
     #[test]
     fn test_set_speed() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         player.set_speed(2.0);
 
@@ -89,7 +89,7 @@ mod tests {
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
 
         for (config, expected_speed) in configs {
-            let mut player = DotLottiePlayer::new();
+            let mut player = Player::new();
             player.set_speed(config.speed);
             player.set_autoplay(config.autoplay);
             if let Some(seg) = config.segment {
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_zero_speed() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         player.set_speed(0.0);
 
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_negative_speed() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         player.set_speed(-1.0);
 

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -6,14 +6,14 @@ mod tests {
     use std::fs::{self, File};
 
     use dotlottie_rs::{
-        actions::open_url_policy::OpenUrlPolicy, ColorSpace, DotLottiePlayer, Event,
+        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Player, Event,
         StateMachineEngineStatus,
     };
     use std::io::Read;
 
     #[test]
     fn get_state_machine() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (500 * 500) as usize];
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn state_machine_start() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let sm = player.state_machine_load_data("bad_data");
 
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn state_machine_stop() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let sm = player.state_machine_load_data("bad_data");
 
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn state_machine_framework_setup() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let pointer_down =
             include_str!("../assets/statemachines/interaction_tests/interaction_array.json");
 
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn state_machine_post_event() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let pointer_down =
             include_str!("../assets/statemachines/interaction_tests/all_interaction_events.json");
 
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn state_machine_set_get_numeric_input() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let rating = include_str!("../assets/statemachines/normal_usecases/rating.json");
 
         let mut sm = player
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn state_machine_set_get_boolean_input() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let sm = include_str!("../assets/statemachines/toggle.json");
 
         let mut sm = player
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn state_machine_set_get_string_input() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let sm = include_str!("../assets/statemachines/normal_usecases/password.json");
 
         let mut sm = player
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn state_machine_fire_event() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let sm = include_str!("../assets/statemachines/normal_usecases/password_with_events.json");
 
         let mut sm = player
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn final_state() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let sm = include_str!("../assets/statemachines/normal_usecases/final_state.json");
 
         let mut sm = player
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn state_machine_current_state() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let pointer_down =
             include_str!("../assets/statemachines/interaction_tests/all_interaction_events.json");
 
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn tweened_transition_falls_through_when_already_tweening() {
         let sm_json = include_str!("../assets/statemachines/smileys.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
         assert!(player
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn tweened_transition_to_state_without_segment_should_tween() {
         let sm_json = include_str!("../assets/statemachines/tween_no_segment.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
         assert!(player
@@ -431,7 +431,7 @@ mod tests {
     #[test]
     fn tweened_transition_to_reverse_state_with_segment_should_tween() {
         let sm_json = include_str!("../assets/statemachines/tween_reverse_segment.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
         assert!(player
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn tweened_transition_to_reverse_state_without_segment_should_tween() {
         let sm_json = include_str!("../assets/statemachines/tween_reverse_segment.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
         assert!(player
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn state_machine_get_inputs() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         let pointer_down =
             include_str!("../assets/statemachines/sanity_tests/test_get_all_inputs.json");
 

--- a/dotlottie-rs/tests/state_machine.rs
+++ b/dotlottie-rs/tests/state_machine.rs
@@ -6,7 +6,7 @@ mod tests {
     use std::fs::{self, File};
 
     use dotlottie_rs::{
-        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Player, Event,
+        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Event, Player,
         StateMachineEngineStatus,
     };
     use std::io::Read;

--- a/dotlottie-rs/tests/state_machine_actions.rs
+++ b/dotlottie-rs/tests/state_machine_actions.rs
@@ -2,13 +2,13 @@
 #[cfg(test)]
 mod tests {
     use dotlottie_rs::{
-        actions::open_url_policy::OpenUrlPolicy, ColorSpace, DotLottiePlayer, StateMachineEvent,
+        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Player, StateMachineEvent,
     };
 
     #[test]
     fn increment() {
         let global_state = include_str!("../assets/statemachines/action_tests/inc_rating.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn decrement() {
         let global_state = include_str!("../assets/statemachines/action_tests/decr_rating.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn toggle() {
         let global_state = include_str!("../assets/statemachines/action_tests/toggle.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn set_boolean() {
         let global_state = include_str!("../assets/statemachines/action_tests/set_inputs.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn set_numeric() {
         let global_state = include_str!("../assets/statemachines/action_tests/set_inputs.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn set_string() {
         let global_state = include_str!("../assets/statemachines/action_tests/set_inputs.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn fire() {
         let global_state = include_str!("../assets/statemachines/action_tests/fire.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn set_frame() {
         let global_state = include_str!("../assets/statemachines/action_tests/set_frame.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn set_progress() {
         let global_state = include_str!("../assets/statemachines/action_tests/set_progress.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn reset() {
         let reset_sm = include_str!("../assets/statemachines/action_tests/reset.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn fire_custom_event() {
         let reset_sm = include_str!("../assets/statemachines/normal_usecases/rating.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (100 * 100) as usize];
 

--- a/dotlottie-rs/tests/state_machine_cases.rs
+++ b/dotlottie-rs/tests/state_machine_cases.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "state-machines")]
 #[cfg(test)]
 mod tests {
-    use dotlottie_rs::{actions::open_url_policy::OpenUrlPolicy, DotLottiePlayer};
+    use dotlottie_rs::{actions::open_url_policy::OpenUrlPolicy, Player};
 
     #[test]
     pub fn global_and_guardless() {
         let global_state =
             include_str!("../assets/statemachines/sanity_tests/test_global_and_guardless.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -40,7 +40,7 @@ mod tests {
     pub fn guarded_and_guardless() {
         let global_state =
             include_str!("../assets/statemachines/sanity_tests/test_guarded_and_guardless.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -76,7 +76,7 @@ mod tests {
     pub fn guardless_and_event() {
         let global_state =
             include_str!("../assets/statemachines/sanity_tests/test_guardless_and_event.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -110,7 +110,7 @@ mod tests {
         let global_state = include_str!(
             "../assets/statemachines/sanity_tests/test_exit_action_causes_global_to_transition.json"
         );
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -162,7 +162,7 @@ mod tests {
         let global_state = include_str!(
             "../assets/statemachines/sanity_tests/test_exit_action_global_ignored_if_non_valid.json"
         );
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -210,7 +210,7 @@ mod tests {
         let global_state = include_str!(
             "../assets/statemachines/sanity_tests/test_entry_action_causes_global_to_transition.json"
         );
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"
@@ -258,7 +258,7 @@ mod tests {
         let global_state = include_str!(
             "../assets/statemachines/sanity_tests/test_entry_action_global_ignored_if_non_valid.json"
         );
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/smiley-slider.lottie"

--- a/dotlottie-rs/tests/state_machine_guards.rs
+++ b/dotlottie-rs/tests/state_machine_guards.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "state-machines")]
 #[cfg(test)]
 mod tests {
-    use dotlottie_rs::{actions::open_url_policy::OpenUrlPolicy, DotLottiePlayer};
+    use dotlottie_rs::{actions::open_url_policy::OpenUrlPolicy, Player};
 
     #[test]
     pub fn not_equal_test() {
         let global_state = include_str!("../assets/statemachines/guard_tests/equal_not_equal.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -32,7 +32,7 @@ mod tests {
     #[test]
     pub fn equal_test() {
         let global_state = include_str!("../assets/statemachines/guard_tests/equal_not_equal.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -58,7 +58,7 @@ mod tests {
     #[test]
     pub fn greater_than() {
         let global_state = include_str!("../assets/statemachines/guard_tests/greater_than.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -109,7 +109,7 @@ mod tests {
     pub fn greater_than_or_equal() {
         let global_state =
             include_str!("../assets/statemachines/guard_tests/greater_than_equal.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     pub fn less_than_equal() {
         let global_state = include_str!("../assets/statemachines/guard_tests/less_than_equal.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     pub fn less_than() {
         let global_state = include_str!("../assets/statemachines/guard_tests/less_than.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"

--- a/dotlottie-rs/tests/state_machine_interactions.rs
+++ b/dotlottie-rs/tests/state_machine_interactions.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "state-machines")]
 #[cfg(test)]
 mod tests {
-    use dotlottie_rs::{
-        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Player, Event,
-    };
+    use dotlottie_rs::{actions::open_url_policy::OpenUrlPolicy, ColorSpace, Event, Player};
 
     const WIDTH: u32 = 100;
     const HEIGHT: u32 = 100;

--- a/dotlottie-rs/tests/state_machine_interactions.rs
+++ b/dotlottie-rs/tests/state_machine_interactions.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod tests {
     use dotlottie_rs::{
-        actions::open_url_policy::OpenUrlPolicy, ColorSpace, DotLottiePlayer, Event,
+        actions::open_url_policy::OpenUrlPolicy, ColorSpace, Player, Event,
     };
 
     const WIDTH: u32 = 100;
@@ -13,7 +13,7 @@ mod tests {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_down_up.json");
 
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -43,7 +43,7 @@ mod tests {
     pub fn pointer_down_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_down.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -75,7 +75,7 @@ mod tests {
     pub fn pointer_enter_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_enter.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -123,7 +123,7 @@ mod tests {
     pub fn pointer_enter_via_move_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_enter.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -171,7 +171,7 @@ mod tests {
     pub fn pointer_exit_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_exit.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -206,7 +206,7 @@ mod tests {
     pub fn pointer_exit_via_move_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_exit.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -269,7 +269,7 @@ mod tests {
     pub fn pointer_move_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pointer_move.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -310,7 +310,7 @@ mod tests {
     pub fn on_complete_manual_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/on_complete.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -351,7 +351,7 @@ mod tests {
     pub fn on_complete_player_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/pigeon_fsm.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
@@ -392,7 +392,7 @@ mod tests {
     pub fn on_loop_complete_player_test() {
         let global_state =
             include_str!("../assets/statemachines/interaction_tests/on_loop_complete.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 

--- a/dotlottie-rs/tests/state_machine_security.rs
+++ b/dotlottie-rs/tests/state_machine_security.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "state-machines")]
 #[cfg(test)]
 mod tests {
-    use dotlottie_rs::DotLottiePlayer;
+    use dotlottie_rs::Player;
 
     #[test]
     fn check_guards_for_existing_inputs() {
         let global_state = include_str!("../assets/statemachines/security_tests/compare_to.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -25,7 +25,7 @@ mod tests {
     fn check_states_for_guardless_transitions() {
         let global_state =
             include_str!("../assets/statemachines/security_tests/guardless_transitions.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn check_states_for_existing_events() {
         let global_state = include_str!("../assets/statemachines/security_tests/event_guards.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn check_state_for_multiple_global() {
         let global_state = include_str!("../assets/statemachines/security_tests/multi_global.json");
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         assert!(player
             .load_dotlottie_data(include_bytes!(
                 "../assets/animations/dotlottie/v1/star_rating.lottie"

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, Mode, PlayerError, Segment};
+use dotlottie_rs::{ColorSpace, Player, Mode, PlayerError, Segment};
 
 #[cfg(test)]
 mod tests {
@@ -77,7 +77,7 @@ mod tests {
         let path = CString::new("assets/animations/lottie/test.json").unwrap();
 
         for config in configs {
-            let mut player = DotLottiePlayer::new();
+            let mut player = Player::new();
             player.set_mode(config.mode);
             player.set_autoplay(config.autoplay);
             if let Some(seg) = config.segment {

--- a/dotlottie-rs/tests/stop.rs
+++ b/dotlottie-rs/tests/stop.rs
@@ -3,7 +3,7 @@ use crate::test_utils::{HEIGHT, WIDTH};
 
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, Player, Mode, PlayerError, Segment};
+use dotlottie_rs::{ColorSpace, Mode, Player, PlayerError, Segment};
 
 #[cfg(test)]
 mod tests {

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -1,4 +1,4 @@
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, PlayerError};
+use dotlottie_rs::{ColorSpace, Player, PlayerError};
 use std::ffi::CString;
 
 mod test_utils;
@@ -11,7 +11,7 @@ mod tests {
 
     #[test]
     fn test_load_valid_theme() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let valid_theme_id = CString::new("test_theme").expect("Failed to create CString");
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_load_invalid_theme() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let invalid_theme_id = CString::new("invalid_theme").expect("Failed to create CString");
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_unset_theme() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let theme_id = CString::new("test_theme").expect("Failed to create CString");
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_unset_theme_before_load() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         assert_eq!(
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_clear_active_theme_id_after_new_animation_data_is_loaded() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let valid_theme_id = CString::new("test_theme").expect("Failed to create CString");
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_clear_active_theme_id_after_new_animation_path_is_loaded() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let valid_theme_id = CString::new("test_theme").expect("Failed to create CString");
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_clear_active_theme_id_after_new_dotlottie_is_loaded() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_theme_persists_after_load_animation() {
-        let mut player = DotLottiePlayer::new();
+        let mut player = Player::new();
         player.set_autoplay(true);
 
         let theme_id = CString::new("red").expect("Failed to create CString");

--- a/dotlottie-rs/tests/tween.rs
+++ b/dotlottie-rs/tests/tween.rs
@@ -1,12 +1,12 @@
 use std::ffi::CString;
 
-use dotlottie_rs::{ColorSpace, DotLottiePlayer, TweenStatus};
+use dotlottie_rs::{ColorSpace, Player, TweenStatus};
 
 mod test_utils;
 use crate::test_utils::{HEIGHT, WIDTH};
 
-fn setup_player() -> (DotLottiePlayer, Vec<u32>) {
-    let mut player = DotLottiePlayer::new();
+fn setup_player() -> (Player, Vec<u32>) {
+    let mut player = Player::new();
     let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
 
     player


### PR DESCRIPTION
Drops the redundant `DotLottie` prefix on the player struct and its event enum. C-facing API unchanged — `cbindgen.toml` typedefs `struct dotlottiePlayer` back to `DotLottiePlayer`.