### PR TITLE
refactor: remove unused clear and buffer APIs

### DIFF
--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -840,14 +840,6 @@ pub unsafe extern "C" fn dotlottie_tick(
     ))
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dotlottie_clear(ptr: *mut Player) -> DotLottieResult {
-    exec_dotlottie_player_op!(ptr, |dotlottie_player| {
-        dotlottie_player.clear();
-        DotLottieResult::Success
-    })
-}
-
 /// Returns whether the animation has completed playback.
 #[no_mangle]
 pub unsafe extern "C" fn dotlottie_is_complete(ptr: *mut Player) -> bool {

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -104,11 +104,6 @@ pub trait LottieRenderer {
     fn duration(&self) -> Result<f32, LottieRendererError>;
 
     fn current_frame(&self) -> f32;
-
-    fn buffer(&self) -> &[u32];
-
-    fn clear(&mut self);
-
     fn render(&mut self) -> Result<(), LottieRendererError>;
 
     fn set_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) -> Result<(), LottieRendererError>;
@@ -215,7 +210,6 @@ impl dyn LottieRenderer {
             current_frame: 0.0,
             updated: false,
             background: Rgba::TRANSPARENT,
-            buffer: vec![],
             layout: Layout::default(),
             user_transform: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
             batch_slot_code: None,
@@ -239,7 +233,6 @@ struct LottieRendererImpl<R: Renderer> {
     current_frame: f32,
     updated: bool,
     background: Rgba,
-    buffer: Vec<u32>,
     layout: Layout,
     user_transform: [f32; 9],
     /// ThorVG slot code for the current batch of all active slots
@@ -256,7 +249,6 @@ struct LottieRendererImpl<R: Renderer> {
 impl<R: Renderer> LottieRendererImpl<R> {
     fn clear(&mut self) -> Result<(), LottieRendererError> {
         if self.animation.is_some() || self.background_shape.is_some() {
-            self.renderer.clear().map_err(into_lottie::<R>)?;
             self.animation = None;
             self.background_shape = None;
         }
@@ -598,16 +590,6 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
 
     fn current_frame(&self) -> f32 {
         self.current_frame
-    }
-
-    #[inline]
-    fn buffer(&self) -> &[u32] {
-        &self.buffer
-    }
-
-    #[inline]
-    fn clear(&mut self) {
-        self.buffer.clear()
     }
 
     fn render(&mut self) -> Result<(), LottieRendererError> {

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -593,10 +593,6 @@ impl Player {
         ]
     }
 
-    pub fn clear(&mut self) {
-        self.renderer.clear()
-    }
-
     pub fn set_marker(&mut self, marker_name: Option<&CStr>) {
         if let Some(name) = marker_name {
             if self.active_marker.as_deref() == Some(name) {
@@ -823,7 +819,6 @@ impl Player {
     where
         F: FnOnce(&mut dyn LottieRenderer) -> Result<(), LottieRendererError>,
     {
-        self.clear();
         self.playback_state = PlaybackState::Stopped;
         self.elapsed_frames = 0.0;
         self.current_loop_count = 0;

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -427,7 +427,6 @@ impl DotLottiePlayerWasm {
     pub fn clear(&mut self) {
         #[cfg(feature = "webgl")]
         self.activate_gl();
-        self.player.clear();
     }
 
     // ── SW pixel buffer ───────────────────────────────────────────────────────


### PR DESCRIPTION
Removes the unused `clear()` and `buffer()` methods from `LottieRenderer`, the `Player::clear()` wrapper, the `dotlottie_clear` C API, and the dead `buffer` field. The wasm `clear` binding is kept as a no-op (aside from GL activation) for API compatibility.