### PR TITLE
fix(wasm): compile ThorVG without exceptions/RTTI (re-release v0.1.58)

### DIFF
--- a/dotlottie-rs/build.rs
+++ b/dotlottie-rs/build.rs
@@ -597,6 +597,10 @@ namespace tvg
             }
         }
 
+        if is_wasm_unknown {
+            cc_build.flag("-fno-exceptions").flag("-fno-rtti");
+        }
+
         // wgpu-native — not used for wasm32-unknown-unknown
         if cfg!(feature = "tvg-wg") && !is_wasm_unknown {
             let (wgpu_include_path, wgpu_lib_path) =


### PR DESCRIPTION
## What broke

The `0.1.58` release workflow failed at the **build-wasm** step. `rust-lld` could not resolve C++ ABI symbols pulled in by ThorVG's Lottie objects:

- `_ZTVN10__cxxabiv1*__class_type_infoE` — RTTI typeinfo vtables
- `__cxa_throw` / `__cxa_allocate_exception` — exception machinery
- `std::bad_function_call` vtable/typeinfo/dtor

`wasm32-unknown-unknown` has no C++ runtime (no libc++abi) to provide these, and ThorVG **v1.0.6**'s Lottie code is the first to reference them. The build only ever linked before by luck of dead-code elimination — which is compiler-version dependent (it still links with clang 21 locally, but CI's clang ~18 emits references that survive to link).

## Fix

Compile ThorVG with `-fno-exceptions -fno-rtti` for `wasm32-unknown-unknown`, so the compiler never generates those references. This mirrors ThorVG's own meson build, which sets the same flags for all non-MSVC compilers (`deps/thorvg/src/meson.build`). Native builds are unaffected (the change is gated on the wasm target).

## Verified locally

- Clean `make wasm` links and produces `release/wasm/{dotlottie_rs_bg.wasm, .js, .d.ts}`.
- The four culprit objects (`tvgLottieBuilder/Modifier/Loader/Parser.o`) now have **0** undefined exception/RTTI symbols (only `__cxa_pure_virtual` remains, already stubbed in `src/wasm/stubs.rs`).

## Release

Merging this (head branch `release`) re-runs the full build matrix with the fix; knope then publishes **v0.1.58** (version already on main — no bump).