### PR TITLE
feat(audio): drive audio via ThorVG resolver

### DIFF
--- a/dotlottie-rs/examples/audio_player.rs
+++ b/dotlottie-rs/examples/audio_player.rs
@@ -1,8 +1,9 @@
 //! Audio feature demonstration.
 //!
 //! Loads a Lottie animation (JSON or .lottie) that contains audio layers and
-//! plays it. Audio events are printed to stdout as they fire so you can verify
-//! the correct frame boundaries. Audio is played via rodio on native targets.
+//! plays it. Playback lifecycle events (load/play/pause/stop/loop/complete) are
+//! printed to stdout. Audio is played via rodio on native targets; ThorVG's
+//! audio resolver drives start/stop in sync with the timeline.
 //!
 //! Usage:
 //!   cargo run --example audio_player --features audio,dev -- path/to/animation.json
@@ -76,7 +77,6 @@ fn main() {
     player.set_autoplay(false);
     player.set_loop(true);
     player.set_mode(dotlottie_rs::Mode::Forward);
-    // let _ = player.set_background(Some(0x000000));
 
     let mut buffer: Vec<u32> = vec![0; WIDTH * HEIGHT];
 
@@ -123,6 +123,8 @@ fn main() {
     let mut m_was_down = false;
     let mut plus_was_down = false;
     let mut minus_was_down = false;
+    // Volume to restore when unmuting; updated each time we mute.
+    let mut pre_mute_volume = player.audio_volume();
     let mut clock = common::Clock::new();
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
@@ -146,12 +148,19 @@ fn main() {
 
         if m_was_down && !m_down {
             if player.audio_volume() == 0.0 {
-                player.set_audio_volume(1.0);
+                // Restore the pre-mute volume (fall back to full).
+                let restore = if pre_mute_volume > 0.0 {
+                    pre_mute_volume
+                } else {
+                    1.0
+                };
+                player.set_audio_volume(restore);
                 println!(
                     "  ** Unmuted  (volume={:.0}%)",
                     player.audio_volume() * 100.0
                 );
             } else {
+                pre_mute_volume = player.audio_volume();
                 player.set_audio_volume(0.0);
                 println!("  ** Muted");
             }
@@ -200,7 +209,6 @@ fn main() {
 
         // Print audio (and notable playback) events as they arrive.
         while let Some(event) = player.poll_event() {
-            let _ = player.current_frame();
             match event {
                 PlayerEvent::Load => println!("  -- Load  (is_loaded={})", player.is_loaded()),
                 PlayerEvent::LoadError => {

--- a/dotlottie-rs/src/audio/mod.rs
+++ b/dotlottie-rs/src/audio/mod.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
-use serde_json::Value;
+use crate::lottie_renderer::{AudioEvent, AudioSource};
 
 #[cfg(all(feature = "audio", not(target_arch = "wasm32")))]
 mod rodio_player;
@@ -13,273 +13,24 @@ mod web_audio_player;
 #[cfg(all(feature = "audio", target_arch = "wasm32"))]
 use web_audio_player::WebAudioPlayer;
 
-const BASE64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-const DATA_AUDIO_PREFIX: &str = "data:audio/";
-
-/// An audio layer extracted from a Lottie JSON file (`ty == 6`),
-/// with its asset already resolved to a direct index.
-#[derive(Clone)]
-pub struct AudioLayer {
-    /// Index into the asset `Vec` held by `AudioManager`.
-    pub asset_idx: usize,
-    /// In-point frame (inclusive).
-    pub start_frame: f32,
-    /// Out-point frame (exclusive).
-    pub end_frame: f32,
-    /// Normalized volume (0.0–1.0).
-    pub volume: f32,
-    /// Whether this layer's audio is currently active (started but not stopped).
-    pub playing: bool,
-}
-
-fn decode_base64(input: &str) -> Option<Vec<u8>> {
-    // Build reverse lookup table.
-    let mut lookup = [0xFFu8; 256];
-    for (i, &c) in BASE64_CHARS.iter().enumerate() {
-        lookup[c as usize] = i as u8;
-    }
-
-    // Strip padding characters.
-    let input = input.trim_end_matches('=');
-    let input_bytes = input.as_bytes();
-
-    // Validate all characters are in the base64 alphabet.
-    for &b in input_bytes {
-        if lookup[b as usize] == 0xFF {
-            return None;
-        }
-    }
-
-    let output_len = (input_bytes.len() * 3) / 4;
-    let mut output = Vec::with_capacity(output_len);
-
-    let mut i = 0;
-    while i + 3 < input_bytes.len() {
-        let b0 = lookup[input_bytes[i] as usize] as u32;
-        let b1 = lookup[input_bytes[i + 1] as usize] as u32;
-        let b2 = lookup[input_bytes[i + 2] as usize] as u32;
-        let b3 = lookup[input_bytes[i + 3] as usize] as u32;
-        let n = (b0 << 18) | (b1 << 12) | (b2 << 6) | b3;
-        output.push((n >> 16) as u8);
-        output.push((n >> 8) as u8);
-        output.push(n as u8);
-        i += 4;
-    }
-
-    // Handle the last 2 or 3 input characters (1 or 2 output bytes).
-    let remaining = input_bytes.len() - i;
-    if remaining == 2 {
-        let b0 = lookup[input_bytes[i] as usize] as u32;
-        let b1 = lookup[input_bytes[i + 1] as usize] as u32;
-        let n = (b0 << 18) | (b1 << 12);
-        output.push((n >> 16) as u8);
-    } else if remaining == 3 {
-        let b0 = lookup[input_bytes[i] as usize] as u32;
-        let b1 = lookup[input_bytes[i + 1] as usize] as u32;
-        let b2 = lookup[input_bytes[i + 2] as usize] as u32;
-        let n = (b0 << 18) | (b1 << 12) | (b2 << 6);
-        output.push((n >> 16) as u8);
-        output.push((n >> 8) as u8);
-    }
-
-    Some(output)
-}
-
-// ---------------------------------------------------------------------------
-// JSON parsing
-// ---------------------------------------------------------------------------
-
-/// Parse audio assets and layers from a Lottie JSON string.
-///
-/// Returns `(assets, layers)` where each layer's `asset_idx` is already
-/// resolved to its position in the returned `assets` Vec.
-pub fn extract_audio(json_data: &Value) -> (Vec<Arc<[u8]>>, Vec<AudioLayer>) {
-    // --- Pass 1: collect audio assets and build id → index map ---
-    let mut raw_assets: Vec<(String, Arc<[u8]>)> = Vec::new();
-
-    if let Some(assets_arr) = json_data.get("assets").and_then(|v| v.as_array()) {
-        for asset in assets_arr {
-            let id = match asset.get("id").and_then(|v| v.as_str()) {
-                Some(s) => s.to_string(),
-                None => continue,
-            };
-
-            let p = match asset.get("p").and_then(|v| v.as_str()) {
-                Some(s) => s,
-                None => continue,
-            };
-
-            if !p.starts_with(DATA_AUDIO_PREFIX) {
-                continue;
-            }
-
-            let after_prefix = &p[DATA_AUDIO_PREFIX.len()..];
-            let semi_pos = match after_prefix.find(';') {
-                Some(pos) => pos,
-                None => continue,
-            };
-
-            let rest = &after_prefix[semi_pos + 1..];
-            let b64_data = match rest.strip_prefix("base64,") {
-                Some(d) => d,
-                None => continue,
-            };
-
-            let decoded = match decode_base64(b64_data) {
-                Some(d) => d,
-                None => continue,
-            };
-
-            raw_assets.push((id, Arc::from(decoded)));
-        }
-    }
-
-    let id_to_idx: HashMap<&str, usize> = raw_assets
-        .iter()
-        .enumerate()
-        .map(|(i, (id, _))| (id.as_str(), i))
-        .collect();
-
-    // --- Pass 2: build precomp map storing resolved asset indices ---
-    let mut audio_precomp_map: HashMap<&str, Vec<(usize, f32)>> = HashMap::new();
-
-    if let Some(assets_arr) = json_data.get("assets").and_then(|v| v.as_array()) {
-        for asset in assets_arr {
-            let asset_id = match asset.get("id").and_then(|v| v.as_str()) {
-                Some(s) => s,
-                None => continue,
-            };
-
-            let inner_layers = match asset.get("layers").and_then(|v| v.as_array()) {
-                Some(l) => l,
-                None => continue,
-            };
-
-            for inner in inner_layers {
-                if inner.get("ty").and_then(|v| v.as_u64()) != Some(6) {
-                    continue;
-                }
-
-                let ref_id = match inner.get("refId").and_then(|v| v.as_str()) {
-                    Some(s) => s,
-                    None => continue,
-                };
-
-                let asset_idx = match id_to_idx.get(ref_id) {
-                    Some(&i) => i,
-                    None => continue,
-                };
-
-                let volume = parse_volume(inner);
-
-                audio_precomp_map
-                    .entry(asset_id)
-                    .or_default()
-                    .push((asset_idx, volume));
-            }
-        }
-    }
-
-    // --- Pass 3: extract AudioLayers from the main (root) timeline ---
-    let mut layers: Vec<AudioLayer> = Vec::new();
-
-    if let Some(root_layers) = json_data.get("layers").and_then(|v| v.as_array()) {
-        for layer in root_layers {
-            match layer.get("ty").and_then(|v| v.as_u64()) {
-                Some(0) => {
-                    // Precomp instance layer — check if it wraps an audio precomp.
-                    // The ip/op here are in the parent timeline and give us the
-                    // correct playback window for the audio.
-                    let ref_id = match layer.get("refId").and_then(|v| v.as_str()) {
-                        Some(s) => s,
-                        None => continue,
-                    };
-
-                    let audio_infos = match audio_precomp_map.get(ref_id) {
-                        Some(infos) => infos,
-                        None => continue,
-                    };
-
-                    let start_frame =
-                        layer.get("ip").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
-                    let end_frame = layer.get("op").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
-
-                    for &(asset_idx, volume) in audio_infos {
-                        layers.push(AudioLayer {
-                            asset_idx,
-                            start_frame,
-                            end_frame,
-                            volume,
-                            playing: false,
-                        });
-                    }
-                }
-                Some(6) => {
-                    // Direct audio layer in the timeline (not wrapped in a precomp).
-                    let ref_id = match layer.get("refId").and_then(|v| v.as_str()) {
-                        Some(s) => s,
-                        None => continue,
-                    };
-
-                    let asset_idx = match id_to_idx.get(ref_id) {
-                        Some(&i) => i,
-                        None => continue,
-                    };
-
-                    let start_frame =
-                        layer.get("ip").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
-                    let end_frame = layer.get("op").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
-
-                    layers.push(AudioLayer {
-                        asset_idx,
-                        start_frame,
-                        end_frame,
-                        volume: parse_volume(layer),
-                        playing: false,
-                    });
-                }
-                _ => continue,
-            }
-        }
-    }
-
-    let assets = raw_assets.into_iter().map(|(_, data)| data).collect();
-    (assets, layers)
-}
-
-fn parse_volume(layer: &Value) -> f32 {
-    layer
-        .get("au")
-        .and_then(|au| au.get("lv"))
-        .and_then(|lv| lv.get("k"))
-        .and_then(|k| {
-            if let Some(arr) = k.as_array() {
-                arr.first()
-                    .and_then(|v| v.as_f64())
-                    .map(|v| (v / 100.0) as f32)
-            } else {
-                k.as_f64().map(|v| (v / 100.0) as f32)
-            }
-        })
-        .unwrap_or(1.0)
-}
-
-// ---------------------------------------------------------------------------
-// AudioManager
-// ---------------------------------------------------------------------------
-
-/// Manages frame-synchronised audio playback.
-///
-/// On native targets (macOS, iOS, Android) audio is played via
-/// rodio. On `wasm32-unknown-unknown` it delegates to the browser's native
-/// `HtmlAudioElement` so no audio decoder needs to be bundled in the wasm binary.
-pub struct AudioManager {
-    layers: Vec<AudioLayer>,
-    /// Audio data indexed by asset position; Arc allows zero-copy hand-off to the player.
-    assets: Vec<Arc<[u8]>>,
-    /// Global volume multiplier in [0.0, 1.0], applied on top of per-layer volume.
+/// An audio layer within its playback range; retained while paused so it can be
+/// replayed on resume.
+struct ActiveLayer {
+    data: Arc<[u8]>,
+    /// Seek position in seconds.
+    offset: f32,
+    /// Per-layer volume in [0.0, 1.0].
     volume: f32,
+}
+
+/// Frame-synchronised audio playback driven by the renderer's audio resolver.
+/// Uses rodio on native targets and `HtmlAudioElement` on wasm.
+pub struct AudioManager {
+    /// External audio bytes keyed by packaged path (e.g. `u/clip.mp3`); empty
+    /// when audio is embedded in the JSON (bytes then arrive in the event).
+    sources: FxHashMap<String, Arc<[u8]>>,
+    active: FxHashMap<String, ActiveLayer>,
+    playing: bool,
     #[cfg(not(target_arch = "wasm32"))]
     player: RodioPlayer,
     #[cfg(target_arch = "wasm32")]
@@ -287,79 +38,125 @@ pub struct AudioManager {
 }
 
 impl AudioManager {
-    /// Returns `None` if there are no audio layers or if the audio backend fails to initialize.
-    pub fn with_assets(assets: Vec<Arc<[u8]>>, layers: Vec<AudioLayer>) -> Option<Self> {
-        if layers.is_empty() {
-            return None;
+    /// `sources` maps packaged audio paths to bytes (empty for embedded audio).
+    /// The audio device opens lazily on first playback.
+    pub fn new(sources: FxHashMap<String, Arc<[u8]>>) -> Self {
+        AudioManager {
+            sources,
+            active: FxHashMap::default(),
+            playing: false,
+            #[cfg(not(target_arch = "wasm32"))]
+            player: RodioPlayer::new(),
+            #[cfg(target_arch = "wasm32")]
+            player: WebAudioPlayer::new(),
         }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let player = RodioPlayer::new(layers.len()).ok()?;
-        #[cfg(target_arch = "wasm32")]
-        let player = WebAudioPlayer::new(layers.len()).ok()?;
-
-        Some(AudioManager {
-            layers,
-            assets,
-            volume: 1.0,
-            player,
-        })
     }
 
-    /// Synchronise audio state with the current animation frame.
-    pub fn update(&mut self, frame: f32) {
-        for (idx, layer) in self.layers.iter_mut().enumerate() {
-            let should_play = frame >= layer.start_frame && frame < layer.end_frame;
+    /// Handle an audio layer state change reported by the renderer.
+    pub fn on_audio(&mut self, event: AudioEvent) {
+        let key = match &event.source {
+            AudioSource::External(src) => normalize_src(src),
+            // Key embedded layers by their (stable) source pointer.
+            AudioSource::Embedded { bytes, .. } => format!("emb:{:p}", bytes.as_ptr()),
+        };
 
-            if should_play && !layer.playing {
-                layer.playing = true;
-                let data = &self.assets[layer.asset_idx];
-                self.player.play(idx, data.clone());
-                self.player.set_volume(idx, layer.volume * self.volume);
-            } else if !should_play && layer.playing {
-                layer.playing = false;
-                self.player.stop(idx);
+        if !event.active {
+            self.active.remove(&key);
+            self.player.stop(&key);
+            return;
+        }
+
+        let data = match event.source {
+            AudioSource::External(_) => match self.resolve_source(&key) {
+                Some(data) => data,
+                None => return,
+            },
+            AudioSource::Embedded { bytes, .. } => Arc::from(bytes),
+        };
+
+        let layer = ActiveLayer {
+            data,
+            offset: event.offset,
+            volume: event.volume / 100.0,
+        };
+        if self.playing {
+            self.player
+                .play(&key, layer.data.clone(), layer.offset, layer.volume);
+        }
+        self.active.insert(key, layer);
+    }
+
+    /// Look up external audio bytes by normalized `src`, falling back to file name.
+    fn resolve_source(&self, normalized: &str) -> Option<Arc<[u8]>> {
+        if let Some(bytes) = self.sources.get(normalized) {
+            return Some(bytes.clone());
+        }
+        let base = file_name(normalized);
+        self.sources
+            .iter()
+            .find(|(k, _)| file_name(k) == base)
+            .map(|(_, bytes)| bytes.clone())
+    }
+
+    /// Reflect the player's playback state, resuming/pausing sinks and starting
+    /// any layers that became active while paused.
+    pub fn set_playing(&mut self, playing: bool) {
+        if self.playing == playing {
+            return;
+        }
+        self.playing = playing;
+
+        if playing {
+            self.player.resume_all();
+            for (key, layer) in &self.active {
+                if !self.player.is_active(key) {
+                    self.player
+                        .play(key, layer.data.clone(), layer.offset, layer.volume);
+                }
             }
+        } else {
+            self.player.pause_all();
         }
     }
 
-    pub fn pause(&mut self) {
-        for (idx, layer) in self.layers.iter().enumerate() {
-            if layer.playing {
-                self.player.pause(idx);
-            }
-        }
-    }
-
-    pub fn play(&mut self) {
-        for (idx, layer) in self.layers.iter().enumerate() {
-            if layer.playing {
-                self.player.resume(idx);
-            }
-        }
-    }
-
+    /// Stop all sinks. The active set is kept so `set_playing(true)` can replay it.
     pub fn stop(&mut self) {
-        for (idx, layer) in self.layers.iter_mut().enumerate() {
-            if layer.playing {
-                self.player.stop(idx);
-                layer.playing = false;
-            }
+        self.playing = false;
+        self.player.stop_all();
+    }
+
+    /// Restart every in-range layer from the start of its clip (used on loop).
+    pub fn restart(&mut self) {
+        if !self.playing {
+            return;
+        }
+        for (key, layer) in &self.active {
+            self.player.play(key, layer.data.clone(), 0.0, layer.volume);
         }
     }
 
     /// Set the global volume multiplier (clamped to [0.0, 1.0]).
-    /// Applied on top of per-layer volume. Takes effect immediately for any
-    /// currently-playing audio.
     pub fn set_volume(&mut self, volume: f32) {
-        self.volume = volume.clamp(0.0, 1.0);
-        for (idx, layer) in self.layers.iter().enumerate() {
-            let vol = layer.volume * self.volume;
-            self.player.set_volume(idx, vol);
-        }
+        self.player.set_global_volume(volume.clamp(0.0, 1.0));
     }
 
     pub fn volume(&self) -> f32 {
-        self.volume
+        self.player.global_volume()
     }
+
+    /// Number of audio layers currently within their playback range.
+    #[cfg(test)]
+    pub(crate) fn active_layer_count(&self) -> usize {
+        self.active.len()
+    }
+}
+
+/// Normalize a resolver `src` for use as a lookup key: drop leading slashes the
+/// renderer prefixes onto packaged paths (e.g. `//u/clip.mp3` → `u/clip.mp3`).
+fn normalize_src(src: &str) -> String {
+    src.trim_start_matches('/').to_string()
+}
+
+fn file_name(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
 }

--- a/dotlottie-rs/src/audio/rodio_player.rs
+++ b/dotlottie-rs/src/audio/rodio_player.rs
@@ -1,59 +1,107 @@
-use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
+use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink, Source};
+use rustc_hash::FxHashMap;
 use std::io::Cursor;
 use std::sync::Arc;
+use std::time::Duration;
 
-/// Native audio backend powered by rodio (cpal → CoreAudio on Apple, WASAPI on
-/// Windows, ALSA/PulseAudio on Linux, OpenSL ES / AAudio on Android).
+/// Native audio backend powered by rodio. Sinks are keyed by audio source; the
+/// output stream opens lazily on first playback.
 pub struct RodioPlayer {
-    /// Kept alive so the audio output chain stays open.
-    _stream: OutputStream,
-    stream_handle: OutputStreamHandle,
-    /// One slot per layer. None = not playing, Some(sink) = active sink.
-    sinks: Vec<Option<Sink>>,
+    /// Kept alive so the audio output chain stays open; `None` until first use.
+    stream: Option<(OutputStream, OutputStreamHandle)>,
+    sinks: FxHashMap<String, ActiveSink>,
+    /// Global multiplier in [0.0, 1.0], applied on top of per-layer volume.
+    global_volume: f32,
+}
+
+struct ActiveSink {
+    sink: Sink,
+    /// Per-layer volume in [0.0, 1.0], for re-applying the global multiplier.
+    layer_volume: f32,
+}
+
+impl Default for RodioPlayer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RodioPlayer {
-    pub fn new(layer_count: usize) -> Result<Self, String> {
-        let (_stream, stream_handle) = OutputStream::try_default().map_err(|e| e.to_string())?;
-        Ok(Self {
-            _stream,
-            stream_handle,
-            sinks: (0..layer_count).map(|_| None).collect(),
-        })
-    }
-
-    /// Start playing the given audio data in the sink owned by `layer_idx`.
-    pub fn play(&mut self, layer_idx: usize, data: Arc<[u8]>) {
-        self.sinks[layer_idx].take();
-        let cursor = Cursor::new(data);
-        if let Ok(source) = Decoder::new(cursor) {
-            if let Ok(sink) = Sink::try_new(&self.stream_handle) {
-                sink.append(source);
-                self.sinks[layer_idx] = Some(sink);
-            }
+    pub fn new() -> Self {
+        Self {
+            stream: None,
+            sinks: FxHashMap::default(),
+            global_volume: 1.0,
         }
     }
 
-    pub fn pause(&mut self, layer_idx: usize) {
-        if let Some(sink) = self.sinks[layer_idx].as_ref() {
-            sink.pause();
+    /// Open the output stream on demand, returning a handle or `None` if no
+    /// audio device is available.
+    fn handle(&mut self) -> Option<OutputStreamHandle> {
+        if self.stream.is_none() {
+            self.stream = OutputStream::try_default().ok();
+        }
+        self.stream.as_ref().map(|(_, handle)| handle.clone())
+    }
+
+    pub fn play(&mut self, key: &str, data: Arc<[u8]>, offset_secs: f32, layer_volume: f32) {
+        self.sinks.remove(key);
+
+        let Some(handle) = self.handle() else {
+            return;
+        };
+        let Ok(source) = Decoder::new(Cursor::new(data)) else {
+            return;
+        };
+        let Ok(sink) = Sink::try_new(&handle) else {
+            return;
+        };
+
+        sink.set_volume(layer_volume * self.global_volume);
+        // rodio 0.17 has no seek; skip_duration approximates a mid-clip start.
+        sink.append(source.skip_duration(Duration::from_secs_f32(offset_secs.max(0.0))));
+
+        self.sinks
+            .insert(key.to_string(), ActiveSink { sink, layer_volume });
+    }
+
+    pub fn stop(&mut self, key: &str) {
+        self.sinks.remove(key);
+    }
+
+    /// Whether a sink for `key` exists and has not finished playing.
+    pub fn is_active(&self, key: &str) -> bool {
+        self.sinks
+            .get(key)
+            .is_some_and(|active| !active.sink.empty())
+    }
+
+    pub fn pause_all(&mut self) {
+        for active in self.sinks.values() {
+            active.sink.pause();
         }
     }
 
-    pub fn resume(&mut self, layer_idx: usize) {
-        if let Some(sink) = self.sinks[layer_idx].as_ref() {
-            sink.play();
+    pub fn resume_all(&mut self) {
+        for active in self.sinks.values() {
+            active.sink.play();
         }
     }
 
-    pub fn stop(&mut self, layer_idx: usize) {
-        self.sinks[layer_idx].take();
+    pub fn stop_all(&mut self) {
+        self.sinks.clear();
     }
 
-    /// Adjust the volume of a currently-playing sink without stopping it.
-    pub fn set_volume(&mut self, layer_idx: usize, volume: f32) {
-        if let Some(sink) = self.sinks[layer_idx].as_ref() {
-            sink.set_volume(volume);
+    pub fn set_global_volume(&mut self, volume: f32) {
+        self.global_volume = volume;
+        for active in self.sinks.values() {
+            active
+                .sink
+                .set_volume(active.layer_volume * self.global_volume);
         }
+    }
+
+    pub fn global_volume(&self) -> f32 {
+        self.global_volume
     }
 }

--- a/dotlottie-rs/src/audio/web_audio_player.rs
+++ b/dotlottie-rs/src/audio/web_audio_player.rs
@@ -1,31 +1,42 @@
 use js_sys::Array;
+use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use web_sys::{Blob, BlobPropertyBag, HtmlAudioElement, Url};
 
-/// Web audio backend powered by the browser's native `HtmlAudioElement`.
-///
-/// Each audio layer gets its own `<audio>` element. Raw MP3 bytes are wrapped
-/// in a `Blob` and exposed via an object URL so the browser can decode and play
-/// them without bundling any audio decoder in the wasm binary.
+/// One playing audio source, keyed by audio source in `WebAudioPlayer`.
+struct AudioEntry {
+    element: HtmlAudioElement,
+    /// Object URL, revoked on stop.
+    url: String,
+    /// Per-layer volume in [0.0, 1.0], for re-applying the global multiplier.
+    layer_volume: f32,
+}
+
+/// Web audio backend powered by the browser's native `HtmlAudioElement`. MP3
+/// bytes play via a `Blob` object URL, so no decoder ships in the wasm binary.
 pub struct WebAudioPlayer {
-    elements: Vec<Option<HtmlAudioElement>>,
-    /// Object URLs created via `URL.createObjectURL`; kept so we can revoke
-    /// them when a layer stops to avoid leaking browser-side resources.
-    object_urls: Vec<Option<String>>,
+    elements: FxHashMap<String, AudioEntry>,
+    /// Global multiplier in [0.0, 1.0], applied on top of per-layer volume.
+    global_volume: f32,
+}
+
+impl Default for WebAudioPlayer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl WebAudioPlayer {
-    pub fn new(layer_count: usize) -> Result<Self, String> {
-        Ok(Self {
-            elements: (0..layer_count).map(|_| None).collect(),
-            object_urls: (0..layer_count).map(|_| None).collect(),
-        })
+    pub fn new() -> Self {
+        Self {
+            elements: FxHashMap::default(),
+            global_volume: 1.0,
+        }
     }
 
-    /// Start playing the given audio data in the slot owned by `layer_idx`.
-    pub fn play(&mut self, layer_idx: usize, data: Arc<[u8]>) {
-        // Wrap the raw bytes in a Blob with the appropriate MIME type so the
-        // browser knows how to decode the audio.
+    pub fn play(&mut self, key: &str, data: Arc<[u8]>, offset_secs: f32, layer_volume: f32) {
+        self.stop(key);
+
         let uint8_array = js_sys::Uint8Array::from(data.as_ref());
         let array = Array::new();
         array.push(&uint8_array);
@@ -51,39 +62,67 @@ impl WebAudioPlayer {
             }
         };
 
-        // `.play()` returns a Promise; we fire-and-forget since playback is
-        // driven by frame updates rather than a completion callback.
+        element.set_volume((layer_volume * self.global_volume) as f64);
+        if offset_secs > 0.0 {
+            element.set_current_time(offset_secs as f64);
+        }
+
+        // `.play()` returns a Promise; fire-and-forget.
         let _ = element.play();
 
-        self.object_urls[layer_idx] = Some(url);
-        self.elements[layer_idx] = Some(element);
+        self.elements.insert(
+            key.to_string(),
+            AudioEntry {
+                element,
+                url,
+                layer_volume,
+            },
+        );
     }
 
-    pub fn pause(&mut self, layer_idx: usize) {
-        if let Some(elem) = self.elements[layer_idx].as_ref() {
-            let _ = elem.pause();
-        }
-    }
-
-    pub fn resume(&mut self, layer_idx: usize) {
-        if let Some(elem) = self.elements[layer_idx].as_ref() {
-            let _ = elem.play();
-        }
-    }
-
-    pub fn stop(&mut self, layer_idx: usize) {
-        if let Some(elem) = self.elements[layer_idx].take() {
-            let _ = elem.pause();
-        }
-        if let Some(url) = self.object_urls[layer_idx].take() {
-            let _ = Url::revoke_object_url(&url);
+    pub fn stop(&mut self, key: &str) {
+        if let Some(entry) = self.elements.remove(key) {
+            let _ = entry.element.pause();
+            let _ = Url::revoke_object_url(&entry.url);
         }
     }
 
-    /// Adjust the volume of a currently-playing element without stopping it.
-    pub fn set_volume(&mut self, layer_idx: usize, volume: f32) {
-        if let Some(elem) = self.elements[layer_idx].as_ref() {
-            elem.set_volume(volume as f64);
+    /// Whether an element for `key` exists and has not finished playing.
+    pub fn is_active(&self, key: &str) -> bool {
+        self.elements
+            .get(key)
+            .is_some_and(|entry| !entry.element.ended())
+    }
+
+    pub fn pause_all(&mut self) {
+        for entry in self.elements.values() {
+            let _ = entry.element.pause();
         }
+    }
+
+    pub fn resume_all(&mut self) {
+        for entry in self.elements.values() {
+            let _ = entry.element.play();
+        }
+    }
+
+    pub fn stop_all(&mut self) {
+        for (_, entry) in self.elements.drain() {
+            let _ = entry.element.pause();
+            let _ = Url::revoke_object_url(&entry.url);
+        }
+    }
+
+    pub fn set_global_volume(&mut self, volume: f32) {
+        self.global_volume = volume;
+        for entry in self.elements.values() {
+            entry
+                .element
+                .set_volume((entry.layer_volume * self.global_volume) as f64);
+        }
+    }
+
+    pub fn global_volume(&self) -> f32 {
+        self.global_volume
     }
 }

--- a/dotlottie-rs/src/fms/mod.rs
+++ b/dotlottie-rs/src/fms/mod.rs
@@ -4,10 +4,10 @@ mod manifest;
 pub use errors::*;
 pub use manifest::*;
 
-#[cfg(feature = "audio")]
-use crate::audio::{extract_audio, AudioLayer};
 #[cfg(feature = "theming")]
 use crate::theme::Theme;
+#[cfg(feature = "audio")]
+use rustc_hash::FxHashMap;
 use serde_json::Value;
 use std::cell::RefCell;
 use std::io::{self, Read};
@@ -30,8 +30,9 @@ pub struct DotLottieManager {
     manifest: Manifest,
     version: u8,
     archive: RefCell<ZipArchive<io::Cursor<Vec<u8>>>>,
+    /// Audio bytes keyed by packaged path (e.g. `u/clip.mp3`).
     #[cfg(feature = "audio")]
-    audio_data: RefCell<Option<(Vec<Arc<[u8]>>, Vec<AudioLayer>)>>,
+    audio_sources: RefCell<FxHashMap<String, Arc<[u8]>>>,
 }
 
 impl DotLottieManager {
@@ -66,7 +67,7 @@ impl DotLottieManager {
             version,
             archive: RefCell::new(archive),
             #[cfg(feature = "audio")]
-            audio_data: RefCell::new(None),
+            audio_sources: RefCell::new(FxHashMap::default()),
         })
     }
 
@@ -99,13 +100,18 @@ impl DotLottieManager {
         let mut lottie_animation: Value =
             serde_json::from_str(animation_data).map_err(|_| DotLottieError::ReadContentError)?;
 
+        #[cfg(feature = "audio")]
+        let mut audio_sources: FxHashMap<String, Arc<[u8]>> = FxHashMap::default();
+
         if let Some(assets) = lottie_animation
             .get_mut("assets")
             .and_then(|v| v.as_array_mut())
         {
             Self::embed_images(&mut archive, assets, self.version);
             #[cfg(feature = "audio")]
-            Self::embed_audio(&mut archive, assets, self.version);
+            {
+                audio_sources = Self::collect_audio(&mut archive, assets, self.version);
+            }
         }
 
         if self.version == 2 {
@@ -121,7 +127,7 @@ impl DotLottieManager {
 
         #[cfg(feature = "audio")]
         {
-            *self.audio_data.borrow_mut() = Some(extract_audio(&lottie_animation));
+            *self.audio_sources.borrow_mut() = audio_sources;
         }
 
         serde_json::to_string(&lottie_animation).map_err(|_| DotLottieError::ReadContentError)
@@ -171,51 +177,51 @@ impl DotLottieManager {
         }
     }
 
+    /// Read audio assets from the archive as raw bytes, keyed by packaged path
+    /// (e.g. `u/clip.mp3`). Audio is not re-embedded in the JSON since ThorVG
+    /// never renders it.
     #[cfg(feature = "audio")]
-    fn embed_audio<R: Read + io::Seek>(
+    fn collect_audio<R: Read + io::Seek>(
         archive: &mut ZipArchive<R>,
-        assets: &mut Vec<Value>,
+        assets: &[Value],
         version: u8,
-    ) {
+    ) -> FxHashMap<String, Arc<[u8]>> {
         let audio_prefix = if version == 2 { "u/" } else { "audio/" };
-        const SUPPORTED_AUDIO_EXTENSION: &'static str = "mp3";
+        const SUPPORTED_AUDIO_EXTENSION: &str = "mp3";
 
-        for asset in assets.iter_mut() {
-            let Some(asset_obj) = asset.as_object_mut() else {
+        let mut out: FxHashMap<String, Arc<[u8]>> = FxHashMap::default();
+        let mut asset_path = String::with_capacity(128);
+
+        for asset in assets {
+            let Some(asset_obj) = asset.as_object() else {
                 continue;
             };
-            let Some(p_str) = asset_obj
-                .get("p")
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
-            else {
+            let Some(p_str) = asset_obj.get("p").and_then(|v| v.as_str()) else {
                 continue;
             };
 
+            // Embedded data URL: ThorVG delivers the bytes via the resolver.
             if p_str.starts_with(DATA_AUDIO_PREFIX) {
-                asset_obj.insert("e".to_string(), Value::Number(1.into()));
                 continue;
             }
 
-            let p_lower = p_str.to_lowercase();
-            if !p_lower.ends_with(SUPPORTED_AUDIO_EXTENSION) {
+            if !p_str.to_lowercase().ends_with(SUPPORTED_AUDIO_EXTENSION) {
                 continue;
             }
 
-            let asset_path = String::from(format!("{}{}", audio_prefix, p_str));
+            asset_path.clear();
+            asset_path.push_str(audio_prefix);
+            asset_path.push_str(p_str);
+
             if let Ok(mut result) = archive.by_name(&asset_path) {
                 let mut content = Vec::with_capacity(result.size() as usize);
                 if result.read_to_end(&mut content).is_ok() {
-                    let data_url = format!(
-                        "{DATA_AUDIO_PREFIX}{SUPPORTED_AUDIO_EXTENSION}{BASE64_PREFIX}{}",
-                        Self::encode_base64(&content)
-                    );
-                    asset_obj.insert("u".to_string(), Value::String(String::new()));
-                    asset_obj.insert("p".to_string(), Value::String(data_url));
-                    asset_obj.insert("e".to_string(), Value::Number(1.into()));
+                    out.insert(asset_path.clone(), Arc::from(content));
                 }
             }
         }
+
+        out
     }
 
     fn embed_fonts<R: Read + io::Seek>(archive: &mut ZipArchive<R>, font_list: &mut [Value]) {
@@ -351,8 +357,8 @@ impl DotLottieManager {
     }
 
     #[cfg(feature = "audio")]
-    pub fn get_audio_assets(&self) -> Option<(Vec<Arc<[u8]>>, Vec<AudioLayer>)> {
-        self.audio_data.borrow().clone()
+    pub fn get_audio_sources(&self) -> FxHashMap<String, Arc<[u8]>> {
+        self.audio_sources.borrow().clone()
     }
 }
 
@@ -393,5 +399,41 @@ mod tests {
         let empty_input = b"";
         let empty_result = DotLottieManager::encode_base64(empty_input);
         assert_eq!(empty_result, "");
+    }
+
+    // happy_birthday_audio.lottie ships 3 mp3s (223190, 95712, 9613 bytes).
+    #[cfg(feature = "audio")]
+    const AUDIO_LOTTIE: &[u8] =
+        include_bytes!("../../assets/animations/dotlottie/v2/happy_birthday_audio.lottie");
+
+    #[test]
+    #[cfg(feature = "audio")]
+    fn test_audio_assets_extracted_from_dotlottie() {
+        let manager = DotLottieManager::new(AUDIO_LOTTIE).expect("create manager");
+        let _json = manager.get_active_animation().expect("get animation");
+
+        let sources = manager.get_audio_sources();
+
+        assert_eq!(sources.len(), 3, "three decoded audio assets");
+        let mut sizes: Vec<usize> = sources.values().map(|a| a.len()).collect();
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![9613, 95712, 223190], "audio bytes match zip");
+
+        assert!(
+            sources.keys().all(|k| k.starts_with("u/")),
+            "sources keyed by packaged path"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "audio")]
+    fn test_dotlottie_json_excludes_audio_payload() {
+        let manager = DotLottieManager::new(AUDIO_LOTTIE).expect("create manager");
+        let json = manager.get_active_animation().expect("get animation");
+
+        assert!(
+            !json.contains("data:audio/"),
+            "rendered JSON should not embed base64 audio"
+        );
     }
 }

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -15,6 +15,8 @@ pub use renderer::{
     Animation, ColorSpace, Drawable, GlContext, GlDisplay, GlSurface, Marker, Renderer, Rgba,
     Segment, Shape, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType,
 };
+#[cfg(feature = "audio")]
+pub use renderer::{AudioEvent, AudioResolver, AudioSource};
 pub use slots::{
     slots_from_json_string, Bezier, BezierValue, ColorSlot, ColorValue, GradientSlot, GradientStop,
     ImageSlot, LottieKeyframe, LottieProperty, PositionSlot, ScalarSlot, ScalarValue, SlotType,
@@ -90,6 +92,13 @@ pub trait LottieRenderer {
     ) -> Result<(), LottieRendererError>;
 
     fn load_data(&mut self, data: &CStr) -> Result<(), LottieRendererError>;
+
+    /// Register a callback for audio layer playback changes, or `None` to clear.
+    #[cfg(feature = "audio")]
+    fn set_audio_resolver(
+        &mut self,
+        resolver: Option<AudioResolver>,
+    ) -> Result<(), LottieRendererError>;
 
     fn picture_width(&self) -> f32;
 
@@ -555,6 +564,17 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
         self.store_default_slots(default_slots);
 
         Ok(())
+    }
+
+    #[cfg(feature = "audio")]
+    fn set_audio_resolver(
+        &mut self,
+        resolver: Option<AudioResolver>,
+    ) -> Result<(), LottieRendererError> {
+        match self.animation.as_mut() {
+            Some(a) => a.set_audio_resolver(resolver).map_err(into_lottie::<R>),
+            None => Ok(()),
+        }
     }
 
     fn picture_width(&self) -> f32 {

--- a/dotlottie-rs/src/lottie_renderer/renderer.rs
+++ b/dotlottie-rs/src/lottie_renderer/renderer.rs
@@ -231,10 +231,39 @@ pub trait Shape: Default {
     fn reset(&mut self) -> Result<(), Self::Error>;
 }
 
+/// Source of audio data for a Lottie audio layer.
+#[cfg(feature = "audio")]
+pub enum AudioSource<'a> {
+    Embedded {
+        bytes: &'a [u8],
+        mime: Option<&'a str>,
+    },
+    External(&'a str),
+}
+
+/// A playback-state change for a Lottie audio layer, fired when it enters or
+/// leaves its active range.
+#[cfg(feature = "audio")]
+pub struct AudioEvent<'a> {
+    pub source: AudioSource<'a>,
+    /// Seek position in seconds; valid when `active`.
+    pub offset: f32,
+    /// Volume on a 0–100 scale; valid when `active`.
+    pub volume: f32,
+    pub active: bool,
+}
+
+#[cfg(feature = "audio")]
+pub type AudioResolver = Box<dyn for<'a> FnMut(AudioEvent<'a>)>;
+
 pub trait Animation: Default {
     type Error: error::Error;
 
     fn load_data(&mut self, data: &CStr, mimetype: &CStr) -> Result<(), Self::Error>;
+
+    /// Register a callback for audio layer playback changes, or `None` to disable.
+    #[cfg(feature = "audio")]
+    fn set_audio_resolver(&mut self, resolver: Option<AudioResolver>) -> Result<(), Self::Error>;
 
     fn hit_test(&self, point: Point, layer_name: &str) -> Result<bool, Self::Error>;
 

--- a/dotlottie-rs/src/lottie_renderer/thorvg.rs
+++ b/dotlottie-rs/src/lottie_renderer/thorvg.rs
@@ -15,6 +15,8 @@ use super::{
     Animation, ColorSpace, Drawable, GlContext, GlDisplay, GlSurface, Marker, Point, Renderer,
     Rgba, Segment, Shape, WgpuDevice, WgpuInstance, WgpuTarget, WgpuTargetType,
 };
+#[cfg(feature = "audio")]
+use super::{AudioEvent, AudioResolver, AudioSource};
 
 #[expect(non_upper_case_globals)]
 #[allow(non_snake_case)]
@@ -418,6 +420,50 @@ pub struct TvgAnimation {
     total_frames: f32,
     duration: f32,
     layer_id_map: LayerIdMap,
+    // Boxed for a stable address to pass as the callback's user data.
+    #[cfg(feature = "audio")]
+    audio_resolver: Option<Box<AudioResolver>>,
+}
+
+/// Bridges ThorVG's C audio callback to the Rust resolver stored in `data`.
+#[cfg(feature = "audio")]
+unsafe extern "C" fn audio_resolver_trampoline(
+    info: *const tvg::Tvg_Audio_Info,
+    data: *mut std::ffi::c_void,
+) {
+    if info.is_null() || data.is_null() {
+        return;
+    }
+    let resolver = unsafe { &mut *(data as *mut AudioResolver) };
+    let info = unsafe { &*info };
+
+    let source = if info.embedded {
+        let bytes = if info.src.is_null() || info.size == 0 {
+            &[][..]
+        } else {
+            unsafe { std::slice::from_raw_parts(info.src as *const u8, info.size as usize) }
+        };
+        let mime = if info.mimeType.is_null() {
+            None
+        } else {
+            unsafe { CStr::from_ptr(info.mimeType) }.to_str().ok()
+        };
+        AudioSource::Embedded { bytes, mime }
+    } else if info.src.is_null() {
+        return;
+    } else {
+        match unsafe { CStr::from_ptr(info.src) }.to_str() {
+            Ok(s) => AudioSource::External(s),
+            Err(_) => return,
+        }
+    };
+
+    resolver(AudioEvent {
+        source,
+        offset: info.offset,
+        volume: info.volume,
+        active: info.active,
+    });
 }
 
 impl Default for TvgAnimation {
@@ -434,6 +480,8 @@ impl Default for TvgAnimation {
             total_frames: 0.0,
             duration: 0.0,
             layer_id_map: LayerIdMap::new(),
+            #[cfg(feature = "audio")]
+            audio_resolver: None,
         }
     }
 }
@@ -558,6 +606,36 @@ impl Animation for TvgAnimation {
                 self.duration = 0.0;
                 self.layer_id_map.clear();
                 Err(e)
+            }
+        }
+    }
+
+    #[cfg(feature = "audio")]
+    fn set_audio_resolver(&mut self, resolver: Option<AudioResolver>) -> Result<(), TvgError> {
+        match resolver {
+            Some(cb) => {
+                let mut boxed: Box<AudioResolver> = Box::new(cb);
+                let data = (&mut *boxed) as *mut AudioResolver as *mut std::ffi::c_void;
+                let result = unsafe {
+                    tvg::tvg_lottie_animation_set_audio_resolver(
+                        self.raw_animation,
+                        Some(audio_resolver_trampoline),
+                        data,
+                    )
+                };
+                self.audio_resolver = Some(boxed);
+                result.into_result()
+            }
+            None => {
+                let result = unsafe {
+                    tvg::tvg_lottie_animation_set_audio_resolver(
+                        self.raw_animation,
+                        None,
+                        std::ptr::null_mut(),
+                    )
+                };
+                self.audio_resolver = None;
+                result.into_result()
             }
         }
     }
@@ -749,6 +827,87 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Barrier};
     use std::thread;
+
+    #[cfg(all(feature = "dotlottie", feature = "audio"))]
+    #[test]
+    fn audio_resolver_fires_for_external_audio() {
+        use std::ffi::c_void;
+        use std::sync::Mutex;
+
+        static EVENTS: Mutex<Vec<(bool, bool, String)>> = Mutex::new(Vec::new());
+
+        unsafe extern "C" fn cb(info: *const tvg::Tvg_Audio_Info, _data: *mut c_void) {
+            if info.is_null() {
+                return;
+            }
+            let i = unsafe { &*info };
+            let src = if i.src.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(i.src) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            EVENTS.lock().unwrap().push((i.active, i.embedded, src));
+        }
+
+        let data =
+            include_bytes!("../../assets/animations/dotlottie/v2/happy_birthday_audio.lottie");
+        let mgr = crate::DotLottieManager::new(data).unwrap();
+        let json = mgr.get_active_animation().unwrap();
+        let cjson = CString::new(json).unwrap();
+
+        let mut renderer = TvgRenderer::new(0);
+        renderer.create_sw_canvas().unwrap();
+        let canvas = renderer.raw_canvas.unwrap();
+        let mut buf = vec![0u32; 128 * 128];
+        unsafe {
+            tvg::tvg_swcanvas_set_target(
+                canvas,
+                buf.as_mut_ptr(),
+                128,
+                128,
+                128,
+                tvg::Tvg_Colorspace_TVG_COLORSPACE_ABGR8888,
+            );
+        }
+
+        let mut anim = TvgAnimation::default();
+        anim.load_data(&cjson, c"lottie+json").unwrap();
+        let total = anim.total_frames;
+
+        unsafe {
+            tvg::tvg_lottie_animation_set_audio_resolver(
+                anim.raw_animation,
+                Some(cb),
+                std::ptr::null_mut(),
+            );
+            tvg::tvg_canvas_add(canvas, anim.raw_paint);
+        }
+
+        let mut f = 0.0;
+        while f < total {
+            unsafe {
+                tvg::tvg_animation_set_frame(anim.raw_animation, f);
+                tvg::tvg_canvas_update(canvas);
+                tvg::tvg_canvas_draw(canvas, true);
+                tvg::tvg_canvas_sync(canvas);
+            }
+            f += 2.0;
+        }
+
+        let events = EVENTS.lock().unwrap();
+        assert!(
+            events.iter().any(|(active, _, _)| *active),
+            "expected at least one active audio event"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|(_, embedded, src)| !*embedded && src.ends_with(".mp3")),
+            "expected an external .mp3 audio src, got {events:?}"
+        );
+    }
 
     #[test]
     fn test_tvg_renderer_no_deadlock() {

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, CString};
 use std::{fs, mem};
 
 #[cfg(feature = "audio")]
-use crate::audio::{extract_audio, AudioManager};
+use crate::audio::AudioManager;
 use crate::poll_events::{EventQueue, PlayerEvent};
 use crate::PlayerError;
 use crate::{
@@ -17,6 +17,14 @@ use crate::{ColorSpace, Renderer, Rgba};
 use crate::{DotLottieManager, Manifest};
 #[cfg(feature = "state-machines")]
 use crate::{StateMachineEngine, StateMachineEngineError};
+#[cfg(feature = "audio")]
+use rustc_hash::FxHashMap;
+#[cfg(feature = "audio")]
+use std::cell::RefCell;
+#[cfg(feature = "audio")]
+use std::rc::Rc;
+#[cfg(feature = "audio")]
+use std::sync::Arc;
 
 pub enum PlaybackState {
     Playing,
@@ -64,7 +72,7 @@ pub struct Player {
     #[cfg(feature = "dotlottie")]
     dotlottie_manager: Option<DotLottieManager>,
     #[cfg(feature = "audio")]
-    audio_manager: Option<AudioManager>,
+    audio: Option<Rc<RefCell<AudioManager>>>,
     direction: Direction,
     active_marker: Option<CString>,
     event_queue: EventQueue<PlayerEvent, 16>,
@@ -138,7 +146,7 @@ impl Player {
             #[cfg(feature = "dotlottie")]
             dotlottie_manager: None,
             #[cfg(feature = "audio")]
-            audio_manager: None,
+            audio: None,
             direction: Direction::Forward,
             active_marker: None,
             #[cfg(feature = "state-machines")]
@@ -156,14 +164,42 @@ impl Player {
     /// Applied on top of per-layer volume; takes effect immediately.
     #[cfg(feature = "audio")]
     pub fn set_audio_volume(&mut self, volume: f32) {
-        if let Some(am) = &mut self.audio_manager {
-            am.set_volume(volume);
+        if let Some(am) = &self.audio {
+            am.borrow_mut().set_volume(volume);
         }
     }
 
     #[cfg(feature = "audio")]
     pub fn audio_volume(&self) -> f32 {
-        self.audio_manager.as_ref().map_or(1.0, |am| am.volume())
+        self.audio.as_ref().map_or(1.0, |am| am.borrow().volume())
+    }
+
+    /// Create the audio manager and attach the renderer's audio resolver.
+    /// `sources` is empty for raw-JSON animations whose audio is embedded.
+    #[cfg(feature = "audio")]
+    fn setup_audio(&mut self, sources: FxHashMap<String, Arc<[u8]>>) {
+        self.audio = Some(Rc::new(RefCell::new(AudioManager::new(sources))));
+        self.attach_audio_resolver();
+    }
+
+    #[cfg(feature = "audio")]
+    fn attach_audio_resolver(&mut self) {
+        let Some(am) = self.audio.as_ref().map(Rc::clone) else {
+            return;
+        };
+        let resolver: crate::lottie_renderer::AudioResolver = Box::new(move |event| {
+            if let Ok(mut manager) = am.try_borrow_mut() {
+                manager.on_audio(event);
+            }
+        });
+        let _ = self.renderer.set_audio_resolver(Some(resolver));
+    }
+
+    #[cfg(all(test, feature = "audio"))]
+    pub(crate) fn audio_active_count(&self) -> usize {
+        self.audio
+            .as_ref()
+            .map_or(0, |am| am.borrow().active_layer_count())
     }
 
     pub fn pop_completion_event(&mut self) -> CompletionEvent {
@@ -230,8 +266,8 @@ impl Player {
         self.playback_state = PlaybackState::Playing;
 
         #[cfg(feature = "audio")]
-        if let Some(am) = &mut self.audio_manager {
-            am.play();
+        if let Some(am) = &self.audio {
+            am.borrow_mut().set_playing(true);
         }
 
         self.event_queue.push(PlayerEvent::Play);
@@ -249,8 +285,8 @@ impl Player {
         self.playback_state = PlaybackState::Paused;
 
         #[cfg(feature = "audio")]
-        if let Some(am) = &mut self.audio_manager {
-            am.pause();
+        if let Some(am) = &self.audio {
+            am.borrow_mut().set_playing(false);
         }
 
         self.event_queue.push(PlayerEvent::Pause);
@@ -282,8 +318,8 @@ impl Player {
         self.elapsed_frames = 0.0;
 
         #[cfg(feature = "audio")]
-        if let Some(am) = &mut self.audio_manager {
-            am.stop();
+        if let Some(am) = &self.audio {
+            am.borrow_mut().stop();
         }
 
         self.event_queue.push(PlayerEvent::Stop);
@@ -486,13 +522,6 @@ impl Player {
         self.renderer.set_frame(no)?;
         self.event_queue.push(PlayerEvent::Frame { frame_no: no });
 
-        #[cfg(feature = "audio")]
-        if self.is_playing() {
-            if let Some(am) = &mut self.audio_manager {
-                am.update(no);
-            }
-        }
-
         Ok(())
     }
 
@@ -545,10 +574,13 @@ impl Player {
                     let _ = self.stop();
                 }
 
-                // Reset audio state so that audio layers re-trigger on the next loop.
+                // Replay audio on loop; the resolver won't re-announce layers
+                // that stay in range across the wrap.
                 #[cfg(feature = "audio")]
-                if let Some(am) = &mut self.audio_manager {
-                    am.stop();
+                if !count_complete {
+                    if let Some(am) = &self.audio {
+                        am.borrow_mut().restart();
+                    }
                 }
 
                 self.emit_on_loop();
@@ -868,15 +900,9 @@ impl Player {
         let result = self.load_animation_common(|renderer| renderer.load_data(animation_data));
 
         if result.is_ok() {
+            // Embedded audio is delivered via the resolver, so no source map.
             #[cfg(feature = "audio")]
-            {
-                self.audio_manager = animation_data
-                    .to_str()
-                    .ok()
-                    .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
-                    .map(|json| extract_audio(&json))
-                    .and_then(|(assets, layers)| AudioManager::with_assets(assets, layers));
-            }
+            self.setup_audio(FxHashMap::default());
 
             self.event_queue.push(PlayerEvent::Load);
             if self.autoplay {
@@ -942,23 +968,22 @@ impl Player {
 
         self.dotlottie_manager = Some(manager);
 
-        #[cfg(feature = "audio")]
-        {
-            self.audio_manager = self
-                .dotlottie_manager
-                .as_ref()
-                .and_then(|dm| dm.get_audio_assets())
-                .and_then(|(assets, layers)| AudioManager::with_assets(assets, layers));
-        }
-
         let result =
             self.load_animation_common(|renderer| renderer.load_data(&animation_data_cstr));
 
         if result.is_ok() {
             self.animation_id = active_animation_id;
-        }
 
-        if result.is_ok() {
+            #[cfg(feature = "audio")]
+            {
+                let sources = self
+                    .dotlottie_manager
+                    .as_ref()
+                    .map(|dm| dm.get_audio_sources())
+                    .unwrap_or_default();
+                self.setup_audio(sources);
+            }
+
             self.event_queue.push(PlayerEvent::Load);
 
             if self.autoplay {
@@ -1002,11 +1027,12 @@ impl Player {
 
                 #[cfg(feature = "audio")]
                 {
-                    self.audio_manager = self
+                    let sources = self
                         .dotlottie_manager
                         .as_ref()
-                        .and_then(|dm| dm.get_audio_assets())
-                        .and_then(|(assets, layers)| AudioManager::with_assets(assets, layers));
+                        .map(|dm| dm.get_audio_sources())
+                        .unwrap_or_default();
+                    self.setup_audio(sources);
                 }
 
                 #[cfg(feature = "theming")]
@@ -1478,5 +1504,109 @@ impl Player {
         state_machine: &str,
     ) -> Result<StateMachineEngine<'a>, StateMachineEngineError> {
         StateMachineEngine::new(state_machine, self, None)
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "tvg", feature = "dotlottie", feature = "audio"))]
+mod audio_render_tests {
+    use crate::{ColorSpace, Player};
+
+    /// A dotLottie with audio loads, renders, and drives the audio manager.
+    #[test]
+    fn renders_dotlottie_with_audio_and_resolves_layers() {
+        let mut player = Player::new();
+        let mut buffer = vec![0u32; 512 * 512];
+        player
+            .set_sw_target(&mut buffer, 512, 512, ColorSpace::ABGR8888)
+            .unwrap();
+
+        let data = include_bytes!("../assets/animations/dotlottie/v2/happy_birthday_audio.lottie");
+        assert!(
+            player.load_dotlottie_data(data).is_ok(),
+            "audio dotLottie loads"
+        );
+        assert!(player.total_frames() > 0.0, "animation has frames");
+
+        player.set_loop(true);
+        player.set_autoplay(true);
+
+        let mut rendered_any = false;
+        for _ in 0..20 {
+            if player.tick(1000.0 / 60.0).unwrap_or(false) {
+                rendered_any = true;
+            }
+        }
+        assert!(rendered_any, "at least one frame rendered");
+        assert!(
+            player.audio_active_count() > 0,
+            "audio resolver should mark layers active during playback"
+        );
+    }
+
+    fn loaded_audio_player(buffer: &mut [u32]) -> Player {
+        let mut player = Player::new();
+        player
+            .set_sw_target(buffer, 512, 512, ColorSpace::ABGR8888)
+            .unwrap();
+        let data = include_bytes!("../assets/animations/dotlottie/v2/happy_birthday_audio.lottie");
+        assert!(player.load_dotlottie_data(data).is_ok());
+        player.set_loop(true);
+        player
+    }
+
+    fn tick_some(player: &mut Player) {
+        for _ in 0..20 {
+            let _ = player.tick(1000.0 / 60.0);
+        }
+    }
+
+    /// The example's X→P flow: after stop, audio must restart on the next play.
+    #[test]
+    fn audio_restarts_after_stop_then_play() {
+        let mut buffer = vec![0u32; 512 * 512];
+        let mut player = loaded_audio_player(&mut buffer);
+
+        player.play().unwrap();
+        tick_some(&mut player);
+        assert!(
+            player.audio_active_count() > 0,
+            "audio active on first play"
+        );
+
+        player.stop().unwrap();
+
+        player.play().unwrap();
+        tick_some(&mut player);
+        assert!(
+            player.audio_active_count() > 0,
+            "audio must re-activate after stop -> play"
+        );
+    }
+
+    /// The example's S→P flow: pause keeps the active set so resume continues.
+    #[test]
+    fn audio_survives_pause_resume() {
+        let mut buffer = vec![0u32; 512 * 512];
+        let mut player = loaded_audio_player(&mut buffer);
+
+        player.play().unwrap();
+        tick_some(&mut player);
+        let active = player.audio_active_count();
+        assert!(active > 0, "audio active while playing");
+
+        player.pause().unwrap();
+        assert_eq!(
+            player.audio_active_count(),
+            active,
+            "pause retains the active set"
+        );
+
+        player.play().unwrap();
+        tick_some(&mut player);
+        assert!(
+            player.audio_active_count() > 0,
+            "audio still active after resume"
+        );
     }
 }


### PR DESCRIPTION
Audio was base64-encoded into the animation JSON and decoded straight back on every load, and the inflated JSON was then parsed by ThorVG even though it never renders audio. This uses ThorVG's audio resolver instead — it reports audio layer start/stop and we play the bytes read directly from the .lottie zip.

- drops the base64 round-trip and the Rust-side audio JSON parsing
- AudioManager is resolver-driven and opens the audio device lazily
- restarts audio correctly on loop and stop→play (the resolver is edge-triggered)
- switches the audio maps to FxHashMap
- tidies the audio_player example; unmute now restores the previous volume

Default, dev, and dev,audio builds pass with clippy + fmt clean.
