### PR TITLE
feat(theming): single src field for image rules

### DIFF
--- a/dotlottie-rs/examples/image_slot.rs
+++ b/dotlottie-rs/examples/image_slot.rs
@@ -88,7 +88,8 @@ fn main() {
         let dt = clock.dt();
         let now = std::time::Instant::now();
 
-        if window.is_key_down(Key::Space) && now.duration_since(last_space_press).as_millis() > 250
+        if window.is_key_pressed(Key::Space, minifb::KeyRepeat::No)
+            && now.duration_since(last_space_press).as_millis() > 250
         {
             index = (index + 1) % states.len();
             let (label, src) = states[index];

--- a/dotlottie-rs/examples/image_slot.rs
+++ b/dotlottie-rs/examples/image_slot.rs
@@ -1,0 +1,119 @@
+#![allow(clippy::print_stdout)]
+
+/// Image Slot Example
+///
+/// Demonstrates `set_image_slot` together with `ImageSlot::from_src`, the single
+/// source-field resolution introduced by the theming redesign. The `image.json`
+/// animation exposes an image slot with ID "sun_img"; pressing SPACE swaps the sun
+/// for a replacement image and cycles back to the original.
+///
+/// `src` is resolved by its prefix:
+///   - `data:` URI       -> embedded image
+///   - `http(s)://` URL  -> remote image (fetched by the host/renderer)
+///   - otherwise         -> a file in the package `i/` folder, referenced by name
+///
+/// This demo uses `data:` URIs so it stays self-contained; the package-file and
+/// URL forms resolve through the same `from_src` call.
+use dotlottie_rs::{ColorSpace, ImageSlot, Player};
+use minifb::{Key, Window, WindowOptions};
+use std::ffi::CString;
+
+mod common;
+
+const WIDTH: u32 = 600;
+const HEIGHT: u32 = 600;
+
+/// Slot ID declared on the image asset (`sid`) in image.json.
+const SLOT_ID: &str = "sun_img";
+/// The original sun asset is 1362x1362; match it so replacements fill the same box.
+const SLOT_W: u32 = 1362;
+const SLOT_H: u32 = 1362;
+
+// Tiny 24x24 solid-color PNGs, encoded as data URIs for this demo.
+const MAGENTA: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAAH0lEQVR42mO4pjGNKohh1KBRg0YNGjVo1KBRgwbeIADJIY0uOOudVwAAAABJRU5ErkJggg==";
+const TEAL: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAAHklEQVR42mNgWLGCOmjUoFGDRg0aNWjUoFGDBt4gABRe9B/QJEtQAAAAAElFTkSuQmCC";
+const AMBER: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAAH0lEQVR42mP4ukqOKohh1KBRg0YNGjVo1KBRgwbeIADadOluhHvNaQAAAABJRU5ErkJggg==";
+
+fn main() {
+    let mut window = Window::new(
+        "Image Slot Example - Press SPACE to swap, ESC to quit",
+        WIDTH as usize,
+        HEIGHT as usize,
+        WindowOptions::default(),
+    )
+    .expect("Failed to create window");
+
+    window.limit_update_rate(Some(std::time::Duration::from_millis(16)));
+
+    let mut player = Player::new();
+    player.set_autoplay(true);
+    player.set_loop(true);
+
+    let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
+
+    player
+        .set_sw_target(&mut buffer, WIDTH, HEIGHT, ColorSpace::ARGB8888)
+        .unwrap();
+
+    let animation_data = include_str!("../assets/animations/lottie/image.json");
+    let c_data = CString::new(animation_data).expect("CString conversion failed");
+
+    if player.load_animation_data(&c_data).is_err() {
+        eprintln!("Failed to load animation");
+        return;
+    }
+
+    println!("Animation loaded successfully!");
+    println!("Image slot ID: '{SLOT_ID}'");
+    println!("Tip: the rising sun is the slotted image — swaps show as it crosses the frame.");
+    println!("Press SPACE to cycle the replacement image");
+    println!("Press ESC to quit");
+    println!();
+
+    // (label, source). `None` resets the slot back to the original asset.
+    let states: [(&str, Option<&str>); 4] = [
+        ("Original (bundled sun)", None),
+        ("Magenta (data: URI)", Some(MAGENTA)),
+        ("Teal (data: URI)", Some(TEAL)),
+        ("Amber (data: URI)", Some(AMBER)),
+    ];
+
+    let mut index = 0usize;
+    let mut last_space_press = std::time::Instant::now();
+    let mut clock = common::Clock::new();
+
+    println!("State: {}", states[index].0);
+
+    while window.is_open() && !window.is_key_down(Key::Escape) {
+        let dt = clock.dt();
+        let now = std::time::Instant::now();
+
+        if window.is_key_down(Key::Space) && now.duration_since(last_space_press).as_millis() > 250
+        {
+            index = (index + 1) % states.len();
+            let (label, src) = states[index];
+
+            match src {
+                Some(src) => {
+                    let slot = ImageSlot::from_src(src.to_string()).with_dimensions(SLOT_W, SLOT_H);
+                    let _ = player.set_image_slot(SLOT_ID, slot);
+                }
+                None => {
+                    let _ = player.reset_slot(SLOT_ID);
+                }
+            }
+
+            println!("State: {label}");
+            last_space_press = now;
+        }
+
+        if player.tick(dt).unwrap_or(false) {
+            window
+                .update_with_buffer(&buffer, WIDTH as usize, HEIGHT as usize)
+                .expect("Failed to update window");
+        }
+    }
+
+    println!();
+    println!("Example finished!");
+}

--- a/dotlottie-rs/src/c_api/mod.rs
+++ b/dotlottie-rs/src/c_api/mod.rs
@@ -1161,45 +1161,23 @@ pub unsafe extern "C" fn dotlottie_set_position_slot(
     })
 }
 
-/// Set an image slot from a file path
+/// Set an image slot from a source string (a `data:` URI, an `http(s)://` URL,
+/// or a file in the package `i/` folder referenced by name).
 #[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_image_slot_path(
+pub unsafe extern "C" fn dotlottie_set_image_slot_src(
     ptr: *mut Player,
     slot_id: *const c_char,
-    path: *const c_char,
+    src: *const c_char,
 ) -> DotLottieResult {
     exec_dotlottie_player_op!(ptr, |dotlottie_player| {
-        if slot_id.is_null() || path.is_null() {
+        if slot_id.is_null() || src.is_null() {
             return DotLottieResult::InvalidParameter;
         }
         let id = CStr::from_ptr(slot_id);
-        let path_cstr = CStr::from_ptr(path);
-        match (id.to_str(), path_cstr.to_str()) {
-            (Ok(id_str), Ok(path_str)) => {
-                let slot = ImageSlot::from_path(path_str.to_string());
-                dotlottie_player.set_image_slot(id_str, slot)
-            }
-            _ => Err(PlayerError::InvalidParameter),
-        }
-    })
-}
-
-/// Set an image slot from a data URL (base64 encoded)
-#[no_mangle]
-pub unsafe extern "C" fn dotlottie_set_image_slot_data_url(
-    ptr: *mut Player,
-    slot_id: *const c_char,
-    data_url: *const c_char,
-) -> DotLottieResult {
-    exec_dotlottie_player_op!(ptr, |dotlottie_player| {
-        if slot_id.is_null() || data_url.is_null() {
-            return DotLottieResult::InvalidParameter;
-        }
-        let id = CStr::from_ptr(slot_id);
-        let url = CStr::from_ptr(data_url);
-        match (id.to_str(), url.to_str()) {
-            (Ok(id_str), Ok(url_str)) => {
-                let slot = ImageSlot::from_data_url(url_str.to_string());
+        let src_cstr = CStr::from_ptr(src);
+        match (id.to_str(), src_cstr.to_str()) {
+            (Ok(id_str), Ok(src_str)) => {
+                let slot = ImageSlot::from_src(src_str.to_string());
                 dotlottie_player.set_image_slot(id_str, slot)
             }
             _ => Err(PlayerError::InvalidParameter),

--- a/dotlottie-rs/src/lottie_renderer/slots/image.rs
+++ b/dotlottie-rs/src/lottie_renderer/slots/image.rs
@@ -15,6 +15,18 @@ pub struct ImageSlot {
 }
 
 impl ImageSlot {
+    /// Resolve a theme `src` into an image slot by its prefix
+    /// (`data:` → embedded, `http(s)://` → remote, otherwise a package `i/` file).
+    pub fn from_src(src: String) -> Self {
+        if src.starts_with("data:") {
+            Self::from_data_url(src)
+        } else if src.starts_with("http://") || src.starts_with("https://") {
+            Self::from_url(src)
+        } else {
+            Self::from_path(src)
+        }
+    }
+
     pub fn from_path(path: String) -> Self {
         let filename = path.split('/').next_back().unwrap_or(&path).to_string();
         let dir = path.rsplit_once('/').map(|x| x.0.to_string());
@@ -35,6 +47,16 @@ impl ImageSlot {
             directory: None,
             path: Some(data_url),
             embed: Some(1),
+        }
+    }
+
+    pub fn from_url(url: String) -> Self {
+        Self {
+            width: None,
+            height: None,
+            directory: None,
+            path: Some(url),
+            embed: Some(0),
         }
     }
 

--- a/dotlottie-rs/src/theme.rs
+++ b/dotlottie-rs/src/theme.rs
@@ -177,14 +177,11 @@ pub struct ImageRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageValue {
+    pub src: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data_url: Option<String>,
 }
 
 /// Text theme rule - holds text animation/static values
@@ -491,19 +488,7 @@ impl From<&GradientRule> for GradientSlot {
 impl From<&ImageRule> for ImageSlot {
     fn from(rule: &ImageRule) -> Self {
         let value = &rule.value;
-        let mut slot = if let Some(data_url) = &value.data_url {
-            ImageSlot::from_data_url(data_url.clone())
-        } else if let Some(path) = &value.path {
-            ImageSlot::from_path(path.clone())
-        } else {
-            ImageSlot {
-                width: None,
-                height: None,
-                directory: None,
-                path: None,
-                embed: None,
-            }
-        };
+        let mut slot = ImageSlot::from_src(value.src.clone());
 
         if let (Some(w), Some(h)) = (value.width, value.height) {
             slot = slot.with_dimensions(w, h);
@@ -688,5 +673,56 @@ fn parse_caps(caps: &str) -> Option<TextCaps> {
         "AllCaps" => Some(TextCaps::AllCaps),
         "SmallCaps" => Some(TextCaps::SmallCaps),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot_from_rule(json: &str) -> ImageSlot {
+        let rule: ImageRule = serde_json::from_str(json).expect("valid image rule");
+        ImageSlot::from(&rule)
+    }
+
+    #[test]
+    fn image_src_data_url_is_embedded() {
+        let slot =
+            slot_from_rule(r#"{ "id": "logo", "value": { "src": "data:image/png;base64,AAAA" } }"#);
+        assert_eq!(slot.embed, Some(1));
+        assert_eq!(slot.path.as_deref(), Some("data:image/png;base64,AAAA"));
+        assert_eq!(slot.directory, None);
+    }
+
+    #[test]
+    fn image_src_http_url_is_linked_and_intact() {
+        let slot =
+            slot_from_rule(r#"{ "id": "logo", "value": { "src": "https://cdn.x/a/logo.png" } }"#);
+        assert_eq!(slot.embed, Some(0));
+        assert_eq!(slot.path.as_deref(), Some("https://cdn.x/a/logo.png"));
+        assert_eq!(slot.directory, None);
+    }
+
+    #[test]
+    fn image_src_bare_name_resolves_to_package_file() {
+        let slot = slot_from_rule(r#"{ "id": "logo", "value": { "src": "logo_dark.png" } }"#);
+        assert_eq!(slot.embed, Some(0));
+        assert_eq!(slot.path.as_deref(), Some("logo_dark.png"));
+        assert_eq!(slot.directory, None);
+    }
+
+    #[test]
+    fn image_dimensions_are_applied() {
+        let slot = slot_from_rule(
+            r#"{ "id": "logo", "value": { "src": "logo.png", "width": 200, "height": 100 } }"#,
+        );
+        assert_eq!(slot.width, Some(200));
+        assert_eq!(slot.height, Some(100));
+    }
+
+    #[test]
+    fn image_rule_requires_src() {
+        let err = serde_json::from_str::<ImageRule>(r#"{ "id": "logo", "value": {} }"#);
+        assert!(err.is_err(), "image rule with no src must be rejected");
     }
 }


### PR DESCRIPTION
Collapses the theme image rule's `value` to a single `src`, resolved by prefix:

- `data:` → embedded image
- `http(s)://` → remote image
- otherwise → a file in the package `i/` folder, by name

Replaces the old `path` + `dataUrl` split. On the C-API, the two image setters (`set_image_slot_path`, `set_image_slot_data_url`) collapse into a single `dotlottie_set_image_slot_src`. Adds an `image_slot` example.

**Breaking:** theme `path`/`dataUrl` → `src`; C-API image setters → `dotlottie_set_image_slot_src`.