### PR TITLE
fix: 🐛 reset_theme clear slots instead of reseting the slots

### DIFF
--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -1095,9 +1095,7 @@ impl Player {
 
         if theme_id.is_empty() {
             self.theme_id = None;
-            self.renderer
-                .clear_slots()
-                .map_err(|_| PlayerError::Unknown)?;
+            self.renderer.reset_slots();
             return Ok(());
         }
 
@@ -1161,7 +1159,7 @@ impl Player {
     #[cfg(feature = "theming")]
     pub fn reset_theme(&mut self) -> Result<(), PlayerError> {
         self.theme_id = None;
-        self.renderer.clear_slots()?;
+        self.renderer.reset_slots();
         Ok(())
     }
 

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -292,4 +292,58 @@ mod tests {
 
         assert!(player.is_playing());
     }
+
+    /// Regression: `reset_theme()` must restore slots to their initial
+    /// (default) values, NOT clear them. After resetting the theme the
+    /// animation's own slots should still be present, and any overridden
+    /// values should be back to the loaded defaults.
+    #[test]
+    fn test_reset_theme_restores_slots_to_defaults() {
+        use dotlottie_rs::ColorSlot;
+
+        let mut player = Player::new();
+        let mut buffer: Vec<u32> = vec![0; (WIDTH * HEIGHT) as usize];
+        assert!(player
+            .set_sw_target(&mut buffer, WIDTH, HEIGHT, ColorSpace::ABGR8888)
+            .is_ok());
+
+        // bouncy_ball.json defines slots (ball_color, ball_opacity, ...) whose
+        // initial values are captured at load time.
+        let data = CString::new(include_str!("../assets/animations/lottie/bouncy_ball.json"))
+            .expect("Failed to create CString");
+        assert_eq!(player.load_animation_data(&data), Ok(()));
+
+        let mut original_ids = player.get_slot_ids();
+        original_ids.sort();
+        assert!(
+            !original_ids.is_empty(),
+            "animation should expose its own slots after load"
+        );
+        let default_color = player.get_slot_str("ball_color");
+
+        // Override a slot, then reset the theme.
+        player
+            .set_color_slot("ball_color", ColorSlot::new([1.0, 0.0, 0.0]))
+            .unwrap();
+        assert_ne!(
+            player.get_slot_str("ball_color"),
+            default_color,
+            "override should change the slot value"
+        );
+
+        assert_eq!(player.reset_theme(), Ok(()));
+
+        // Slots must NOT be cleared — they remain, restored to initial values.
+        let mut ids_after_reset = player.get_slot_ids();
+        ids_after_reset.sort();
+        assert_eq!(
+            ids_after_reset, original_ids,
+            "reset_theme must keep the animation's slots, not clear them"
+        );
+        assert_eq!(
+            player.get_slot_str("ball_color"),
+            default_color,
+            "reset_theme must restore the slot to its initial value"
+        );
+    }
 }

--- a/dotlottie-rs/tests/theming.rs
+++ b/dotlottie-rs/tests/theming.rs
@@ -293,10 +293,6 @@ mod tests {
         assert!(player.is_playing());
     }
 
-    /// Regression: `reset_theme()` must restore slots to their initial
-    /// (default) values, NOT clear them. After resetting the theme the
-    /// animation's own slots should still be present, and any overridden
-    /// values should be back to the loaded defaults.
     #[test]
     fn test_reset_theme_restores_slots_to_defaults() {
         use dotlottie_rs::ColorSlot;
@@ -307,8 +303,6 @@ mod tests {
             .set_sw_target(&mut buffer, WIDTH, HEIGHT, ColorSpace::ABGR8888)
             .is_ok());
 
-        // bouncy_ball.json defines slots (ball_color, ball_opacity, ...) whose
-        // initial values are captured at load time.
         let data = CString::new(include_str!("../assets/animations/lottie/bouncy_ball.json"))
             .expect("Failed to create CString");
         assert_eq!(player.load_animation_data(&data), Ok(()));
@@ -321,7 +315,6 @@ mod tests {
         );
         let default_color = player.get_slot_str("ball_color");
 
-        // Override a slot, then reset the theme.
         player
             .set_color_slot("ball_color", ColorSlot::new([1.0, 0.0, 0.0]))
             .unwrap();
@@ -333,7 +326,6 @@ mod tests {
 
         assert_eq!(player.reset_theme(), Ok(()));
 
-        // Slots must NOT be cleared — they remain, restored to initial values.
         let mut ids_after_reset = player.get_slot_ids();
         ids_after_reset.sort();
         assert_eq!(


### PR DESCRIPTION
Issue: Reset theme clears all the slots
Fix: Only reset the slots to default on reset theme