### PR TITLE
chore: fix wgpu app store release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,40 +70,6 @@ jobs:
       - name: Setup Apple
         run: make apple-setup
 
-      - name: Setup signing
-        run: |
-          # Create temporary keychain
-          security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Add to search list
-          security list-keychains -d user -s build.keychain login.keychain
-
-          # Import certificate (suppress all output)
-          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 --decode > certificate.p12
-          security import certificate.p12 -k build.keychain -P "${{ secrets.CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -A > /dev/null 2>&1
-
-          # Set partition list with more permissive settings
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Unlock again to ensure access
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Set signing identity
-          CODESIGN_IDENTITY=$(security find-identity -v build.keychain | grep -E "(Developer ID|Apple Development)" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-          echo "KEYCHAIN_PASSWORD=${{ secrets.KEYCHAIN_PASSWORD }}" >> $GITHUB_ENV
-
-
-          if [ -z "$CODESIGN_IDENTITY" ]; then
-            echo "No codesigning identity found!"
-            exit 1
-          fi
-
-          echo "Successfully configured signing certificate"
-          rm certificate.p12
-
       - name: Set Features
         run: |
           features=""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,39 +25,6 @@ jobs:
       - name: Setup Apple
         run: make apple-setup
 
-      - name: Setup signing
-        run: |
-          # Create temporary keychain
-          security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Add to search list
-          security list-keychains -d user -s build.keychain login.keychain
-
-          # Import certificate (suppress all output)
-          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 --decode > certificate.p12
-          security import certificate.p12 -k build.keychain -P "${{ secrets.CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -A > /dev/null 2>&1
-
-          # Set partition list with more permissive settings
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Unlock again to ensure access
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-
-          # Set signing identity
-          CODESIGN_IDENTITY=$(security find-identity -v build.keychain | grep -E "(Developer ID|Apple Development)" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-          echo "KEYCHAIN_PASSWORD=${{ secrets.KEYCHAIN_PASSWORD }}" >> $GITHUB_ENV
-
-          if [ -z "$CODESIGN_IDENTITY" ]; then
-            echo "No codesigning identity found!"
-            exit 1
-          fi
-
-          echo "Successfully configured signing certificate"
-          rm certificate.p12
-
       - name: Build Apple
         run: make apple
 

--- a/make/apple.mk
+++ b/make/apple.mk
@@ -182,12 +182,8 @@ WGPU_CACHE_DIR := $(CARGO_HOME_DIR)/wgpu-native-cache/$(WGPU_NATIVE_VERSION)
 WGPU_DYLIB := libwgpu_native.dylib
 WGPU_NATIVE_MODULE ?= WgpuNative
 WGPU_NATIVE_FRAMEWORK := $(WGPU_NATIVE_MODULE).framework
-# The dylib is shipped wrapped in WgpuNative.framework: App Store validation
-# rejects raw .dylib files in an app's Frameworks/ directory (ITMS-90429), and
-# CocoaPods refuses to vendor them at all.
 WGPU_INSTALL_NAME := @rpath/$(WGPU_NATIVE_FRAMEWORK)/$(WGPU_NATIVE_MODULE)
 WGPU_NATIVE_XCFRAMEWORK := $(WGPU_NATIVE_MODULE).xcframework
-# CFBundle versions must be at most three dot-separated numbers ("v27.0.4.0" -> "27.0.4").
 WGPU_FRAMEWORK_VERSION = $(shell echo $(WGPU_NATIVE_VERSION) | sed 's/^v//' | cut -d. -f1-3)
 WGPU_STAGE_DIR := $(APPLE_BUILD_DIR)/wgpu
 # Cache artifact per slice — mirrors artifact_name() in dotlottie-rs/build.rs.
@@ -197,9 +193,6 @@ WGPU_ARTIFACT_ios_arm64 := wgpu-ios-aarch64-release
 WGPU_ARTIFACT_ios_sim_arm64 := wgpu-ios-aarch64-simulator-release
 WGPU_ARTIFACT_ios_x86_64 := wgpu-ios-x86_64-simulator-release
 
-# Copy a cached wgpu dylib to $(2) and normalise its install_name to the
-# framework install name (the upstream iOS dylib ships with a CI build path
-# as its id).
 # $(1)=cache artifact name  $(2)=destination dylib path
 define stage_wgpu_dylib
 	@mkdir -p $(dir $(2))
@@ -207,9 +200,6 @@ define stage_wgpu_dylib
 	@$(INSTALL_NAME_TOOL) -id $(WGPU_INSTALL_NAME) "$(2)"
 endef
 
-# Wrap a staged wgpu dylib into a flat (iOS-style) WgpuNative.framework.
-# $(1)=staged dylib  $(2)=framework parent dir  $(3)=CFBundleSupportedPlatforms entry
-# $(4)=minimum-OS-version plist key  $(5)=minimum OS version
 define make_wgpu_framework
 	@rm -rf $(2)/$(WGPU_NATIVE_FRAMEWORK)
 	@mkdir -p $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_HEADERS)/webgpu $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_MODULES)

--- a/make/apple.mk
+++ b/make/apple.mk
@@ -138,6 +138,12 @@ VISIONOS_SIMULATOR_SDK = $(XCODE_PATH)/Platforms/XRSimulator.platform/Developer/
 WATCHOS_SDK = $(XCODE_PATH)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk
 WATCHOS_SIMULATOR_SDK = $(XCODE_PATH)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk
 
+# Installed SDK versions, used as the `sdk` field when re-stamping the wgpu
+# dylibs' Mach-O build-version load command (see restamp_build_version).
+IOS_SDK_VERSION := $(shell xcrun --sdk iphoneos --show-sdk-version 2>/dev/null)
+IOS_SIM_SDK_VERSION := $(shell xcrun --sdk iphonesimulator --show-sdk-version 2>/dev/null)
+MACOS_SDK_VERSION := $(shell xcrun --sdk macosx --show-sdk-version 2>/dev/null)
+
 # Apple targets
 APPLE_TARGETS = aarch64-apple-darwin x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim aarch64-apple-ios-macabi x86_64-apple-ios-macabi aarch64-apple-visionos aarch64-apple-visionos-sim aarch64-apple-tvos aarch64-apple-tvos-sim aarch64-apple-watchos arm64_32-apple-watchos armv7k-apple-watchos aarch64-apple-watchos-sim
 
@@ -200,10 +206,28 @@ define stage_wgpu_dylib
 	@$(INSTALL_NAME_TOOL) -id $(WGPU_INSTALL_NAME) "$(2)"
 endef
 
+# Rewrite a Mach-O's version load command as a modern LC_BUILD_VERSION.
+# The upstream wgpu-native iOS dylibs ship LC_VERSION_MIN_IPHONEOS 10.0 (cargo's
+# historical default deployment target), which sits below Apple's Swift
+# ABI-stability threshold (12.2) and gets embedding apps rejected on App Store
+# upload with ITMS-90426 ("Invalid Swift Support"). Apple reads the binary's
+# load commands, not the framework Info.plist, so wrapping alone doesn't clear
+# it. -replace drops any existing LC_VERSION_MIN_*/LC_BUILD_VERSION and writes a
+# single LC_BUILD_VERSION. vtool operates across all slices of a fat binary.
+# $(1)=mach-o  $(2)=vtool platform (ios | 7 | macos)  $(3)=minos  $(4)=sdk
+define restamp_build_version
+	@xcrun vtool -set-build-version $(2) $(3) $(4) -replace -output "$(1).stamped" "$(1)"
+	@mv "$(1).stamped" "$(1)"
+endef
+
+# $(1)=source dylib  $(2)=stage dir  $(3)=CFBundleSupportedPlatforms value
+# $(4)=min-version plist key  $(5)=min OS version
+# $(6)=vtool platform (ios | 7 | macos)  $(7)=SDK version
 define make_wgpu_framework
 	@rm -rf $(2)/$(WGPU_NATIVE_FRAMEWORK)
 	@mkdir -p $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_HEADERS)/webgpu $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_MODULES)
 	@cp "$(1)" $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(WGPU_NATIVE_MODULE)
+	$(call restamp_build_version,$(2)/$(WGPU_NATIVE_FRAMEWORK)/$(WGPU_NATIVE_MODULE),$(6),$(5),$(7))
 	@cp $(WGPU_CACHE_DIR)/$(WGPU_ARTIFACT_macos_arm64)/include/webgpu/*.h $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_HEADERS)/webgpu/
 	@printf 'framework module %s {\n  header "webgpu/wgpu.h"\n  export *\n}\n' "$(WGPU_NATIVE_MODULE)" > $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_MODULES)/$(MODULE_MAP)
 	@$(PLISTBUDDY_EXEC) \
@@ -253,7 +277,7 @@ define fixup_wgpu_rpath
 endef
 
 # Apple-specific phony targets
-.PHONY: apple apple-macos apple-ios apple-maccatalyst apple-visionos apple-tvos apple-watchos apple-macos-arm64 apple-macos-x86_64 apple-ios-arm64 apple-ios-x86_64 apple-ios-sim-arm64 apple-maccatalyst-arm64 apple-maccatalyst-x86_64 apple-visionos-arm64 apple-visionos-sim-arm64 apple-tvos-arm64 apple-tvos-sim-arm64 apple-watchos-arm64 apple-watchos-arm64_32 apple-watchos-armv7k apple-watchos-sim-arm64 apple-setup apple-clean apple-code-sign
+.PHONY: apple apple-macos apple-ios apple-maccatalyst apple-visionos apple-tvos apple-watchos apple-macos-arm64 apple-macos-x86_64 apple-ios-arm64 apple-ios-x86_64 apple-ios-sim-arm64 apple-maccatalyst-arm64 apple-maccatalyst-x86_64 apple-visionos-arm64 apple-visionos-sim-arm64 apple-tvos-arm64 apple-tvos-sim-arm64 apple-watchos-arm64 apple-watchos-arm64_32 apple-watchos-armv7k apple-watchos-sim-arm64 apple-setup apple-clean
 
 
 
@@ -814,11 +838,6 @@ $(WATCHOS_SIMULATOR_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK): apple-watchos-
 apple-frameworks: $(MACOS_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(IOS_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(IOS_SIMULATOR_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(VISIONOS_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(VISIONOS_SIMULATOR_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(TVOS_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(TVOS_SIMULATOR_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(WATCHOS_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(WATCHOS_SIMULATOR_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK) $(MACCATALYST_FRAMEWORK_DIR)/$(DOTLOTTIE_PLAYER_FRAMEWORK)
 	@echo "✓ All Apple frameworks created"
 
-# Code signing target
-apple-code-sign:
-	@echo "→ Code signing XCFramework..."
-	$(call perform_codesigning,$(APPLE_RELEASE_DIR)/$(DOTLOTTIE_PLAYER_XCFRAMEWORK))
-
 # Package Apple release
 apple-package: apple-frameworks
 	@echo "→ Creating Apple release package..."
@@ -895,9 +914,9 @@ apple-wgpu-package: apple-package
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_sim_arm64),$(WGPU_STAGE_DIR)/ios-sim-arm64.dylib)
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_x86_64),$(WGPU_STAGE_DIR)/ios-sim-x86_64.dylib)
 	@$(LIPO) -create $(WGPU_STAGE_DIR)/ios-sim-arm64.dylib $(WGPU_STAGE_DIR)/ios-sim-x86_64.dylib -o $(WGPU_STAGE_DIR)/ios-sim.dylib
-	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios.dylib,$(WGPU_STAGE_DIR)/ios,iPhoneOS,MinimumOSVersion,$(MIN_IOS_VERSION))
-	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios-sim.dylib,$(WGPU_STAGE_DIR)/ios-sim,iPhoneSimulator,MinimumOSVersion,$(MIN_IOS_VERSION))
-	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/macos.dylib,$(WGPU_STAGE_DIR)/macos,MacOSX,LSMinimumSystemVersion,$(MIN_MACOS_VERSION))
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios.dylib,$(WGPU_STAGE_DIR)/ios,iPhoneOS,MinimumOSVersion,$(MIN_IOS_VERSION),ios,$(IOS_SDK_VERSION))
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios-sim.dylib,$(WGPU_STAGE_DIR)/ios-sim,iPhoneSimulator,MinimumOSVersion,$(MIN_IOS_VERSION),7,$(IOS_SIM_SDK_VERSION))
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/macos.dylib,$(WGPU_STAGE_DIR)/macos,MacOSX,LSMinimumSystemVersion,$(MIN_MACOS_VERSION),macos,$(MACOS_SDK_VERSION))
 	$(call deepify_wgpu_framework,$(WGPU_STAGE_DIR)/macos/$(WGPU_NATIVE_FRAMEWORK))
 	@rm -rf $(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK)
 	@$(XCODEBUILD) -create-xcframework \

--- a/make/apple.mk
+++ b/make/apple.mk
@@ -71,10 +71,6 @@ INSTALL_NAME_TOOL := install_name_tool
 XCODEBUILD := xcodebuild
 CODESIGN := codesign
 
-# Code signing variables
-# Set CODESIGN_IDENTITY to enable code signing (e.g., "Developer ID Application: Your Name")
-# Set KEYCHAIN_PASSWORD if using a custom keychain (used in CI environments)
-
 # Get version information
 CRATE_VERSION = $(shell grep -m 1 'version =' dotlottie-rs/Cargo.toml | grep -o '[0-9][0-9.]*')
 
@@ -87,20 +83,6 @@ framework module $(MODULE_NAME) {
   export *
   module * { export * }
 }
-endef
-
-# Code signing function
-define perform_codesigning
-	@if [ -n "$(CODESIGN_IDENTITY)" ]; then \
-		echo "→ Unlocking keychain for signing..."; \
-		security unlock-keychain -p "$(KEYCHAIN_PASSWORD)" build.keychain; \
-		echo "→ Signing XCFramework with identity: $(CODESIGN_IDENTITY)"; \
-		$(CODESIGN) --sign "$(CODESIGN_IDENTITY)" --timestamp --options runtime $(1); \
-		$(CODESIGN) --verify --verbose $(1); \
-		echo "✓ Code signing completed"; \
-	else \
-		echo "→ Skipping code signing (no identity provided)"; \
-	fi
 endef
 
 # Helper function to create framework structure and Info.plist
@@ -266,9 +248,13 @@ endef
 # No-op for software builds (binary has no wgpu-native dependency).
 # $(1)=path to the DotLottiePlayer mach-o binary
 define fixup_wgpu_rpath
-	@wgpu_ref=$$(otool -L "$(1)" | awk '/libwgpu_native\.dylib/{print $$1; exit}'); \
-	if [ -n "$$wgpu_ref" ]; then \
-		[ "$$wgpu_ref" = "$(WGPU_INSTALL_NAME)" ] || $(INSTALL_NAME_TOOL) -change "$$wgpu_ref" $(WGPU_INSTALL_NAME) "$(1)"; \
+	@wgpu_refs=$$(for arch in $$($(LIPO) -archs "$(1)"); do \
+		otool -arch $$arch -L "$(1)"; \
+	done | awk '/libwgpu_native\.dylib/{print $$1}' | sort -u); \
+	if [ -n "$$wgpu_refs" ]; then \
+		for ref in $$wgpu_refs; do \
+			$(INSTALL_NAME_TOOL) -change "$$ref" $(WGPU_INSTALL_NAME) "$(1)"; \
+		done; \
 		for rp in @executable_path/Frameworks @loader_path/.. @loader_path/Frameworks @loader_path/../../..; do \
 			$(INSTALL_NAME_TOOL) -add_rpath "$$rp" "$(1)" 2>/dev/null || true; \
 		done; \
@@ -885,10 +871,7 @@ apple-package: apple-frameworks
 			ln -s Versions/Current/Resources Resources \
 		) || exit 1; \
 	done
-	
-	# Code sign the XCFramework
-	$(call perform_codesigning,$(APPLE_RELEASE_DIR)/$(DOTLOTTIE_PLAYER_XCFRAMEWORK))
-	
+		
 	# Create version file and final tarball
 	@echo "dlplayer-version=$(CRATE_VERSION)-$(COMMIT_HASH)" > $(APPLE_RELEASE_DIR)/version.txt
 	
@@ -924,7 +907,6 @@ apple-wgpu-package: apple-package
 		-framework $(WGPU_STAGE_DIR)/ios/$(WGPU_NATIVE_FRAMEWORK) \
 		-framework $(WGPU_STAGE_DIR)/ios-sim/$(WGPU_NATIVE_FRAMEWORK) \
 		-output $(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK) >/dev/null
-	$(call perform_codesigning,$(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK))
 	@echo "✓ $(WGPU_NATIVE_XCFRAMEWORK) created at $(APPLE_RELEASE_DIR)/"
 
 # Check if Xcode or Command Line Tools are available

--- a/make/apple.mk
+++ b/make/apple.mk
@@ -180,9 +180,15 @@ WGPU_NATIVE_VERSION ?= v27.0.4.0
 CARGO_HOME_DIR := $(if $(CARGO_HOME),$(CARGO_HOME),$(HOME)/.cargo)
 WGPU_CACHE_DIR := $(CARGO_HOME_DIR)/wgpu-native-cache/$(WGPU_NATIVE_VERSION)
 WGPU_DYLIB := libwgpu_native.dylib
-WGPU_INSTALL_NAME := @rpath/$(WGPU_DYLIB)
 WGPU_NATIVE_MODULE ?= WgpuNative
+WGPU_NATIVE_FRAMEWORK := $(WGPU_NATIVE_MODULE).framework
+# The dylib is shipped wrapped in WgpuNative.framework: App Store validation
+# rejects raw .dylib files in an app's Frameworks/ directory (ITMS-90429), and
+# CocoaPods refuses to vendor them at all.
+WGPU_INSTALL_NAME := @rpath/$(WGPU_NATIVE_FRAMEWORK)/$(WGPU_NATIVE_MODULE)
 WGPU_NATIVE_XCFRAMEWORK := $(WGPU_NATIVE_MODULE).xcframework
+# CFBundle versions must be at most three dot-separated numbers ("v27.0.4.0" -> "27.0.4").
+WGPU_FRAMEWORK_VERSION = $(shell echo $(WGPU_NATIVE_VERSION) | sed 's/^v//' | cut -d. -f1-3)
 WGPU_STAGE_DIR := $(APPLE_BUILD_DIR)/wgpu
 # Cache artifact per slice — mirrors artifact_name() in dotlottie-rs/build.rs.
 WGPU_ARTIFACT_macos_arm64 := wgpu-macos-aarch64-release
@@ -191,8 +197,9 @@ WGPU_ARTIFACT_ios_arm64 := wgpu-ios-aarch64-release
 WGPU_ARTIFACT_ios_sim_arm64 := wgpu-ios-aarch64-simulator-release
 WGPU_ARTIFACT_ios_x86_64 := wgpu-ios-x86_64-simulator-release
 
-# Copy a cached wgpu dylib to $(2) and normalise its install_name to @rpath
-# (the upstream iOS dylib ships with a CI build path as its id).
+# Copy a cached wgpu dylib to $(2) and normalise its install_name to the
+# framework install name (the upstream iOS dylib ships with a CI build path
+# as its id).
 # $(1)=cache artifact name  $(2)=destination dylib path
 define stage_wgpu_dylib
 	@mkdir -p $(dir $(2))
@@ -200,8 +207,48 @@ define stage_wgpu_dylib
 	@$(INSTALL_NAME_TOOL) -id $(WGPU_INSTALL_NAME) "$(2)"
 endef
 
-# Repoint a DotLottiePlayer binary's wgpu-native dependency to @rpath and add the
-# rpaths needed to resolve libwgpu_native.dylib from the app's Frameworks/ dir.
+# Wrap a staged wgpu dylib into a flat (iOS-style) WgpuNative.framework.
+# $(1)=staged dylib  $(2)=framework parent dir  $(3)=CFBundleSupportedPlatforms entry
+# $(4)=minimum-OS-version plist key  $(5)=minimum OS version
+define make_wgpu_framework
+	@rm -rf $(2)/$(WGPU_NATIVE_FRAMEWORK)
+	@mkdir -p $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_HEADERS)/webgpu $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_MODULES)
+	@cp "$(1)" $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(WGPU_NATIVE_MODULE)
+	@cp $(WGPU_CACHE_DIR)/$(WGPU_ARTIFACT_macos_arm64)/include/webgpu/*.h $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_HEADERS)/webgpu/
+	@printf 'framework module %s {\n  header "webgpu/wgpu.h"\n  export *\n}\n' "$(WGPU_NATIVE_MODULE)" > $(2)/$(WGPU_NATIVE_FRAMEWORK)/$(FRAMEWORK_MODULES)/$(MODULE_MAP)
+	@$(PLISTBUDDY_EXEC) \
+		-c "Add :CFBundleIdentifier string com.dotlottie.$(WGPU_NATIVE_MODULE)" \
+		-c "Add :CFBundleName string $(WGPU_NATIVE_MODULE)" \
+		-c "Add :CFBundleVersion string $(WGPU_FRAMEWORK_VERSION)" \
+		-c "Add :CFBundleShortVersionString string $(WGPU_FRAMEWORK_VERSION)" \
+		-c "Add :CFBundlePackageType string FMWK" \
+		-c "Add :CFBundleExecutable string $(WGPU_NATIVE_MODULE)" \
+		-c "Add :$(4) string $(5)" \
+		-c "Add :CFBundleSupportedPlatforms array" \
+		-c "Add :CFBundleSupportedPlatforms:0 string $(3)" \
+		$(2)/$(WGPU_NATIVE_FRAMEWORK)/$(INFO_PLIST)
+endef
+
+# Convert a flat WgpuNative.framework into the deep (versioned) bundle layout
+# required for macOS frameworks, mirroring the DotLottiePlayer macOS
+# post-processing in apple-package.
+# $(1)=path to the WgpuNative.framework
+define deepify_wgpu_framework
+	@(cd $(1) && \
+		mkdir -p Versions/A/Resources && \
+		mv $(WGPU_NATIVE_MODULE) $(FRAMEWORK_HEADERS) $(FRAMEWORK_MODULES) Versions/A/ && \
+		mv $(INFO_PLIST) Versions/A/Resources/ && \
+		ln -s A Versions/Current && \
+		ln -s Versions/Current/$(WGPU_NATIVE_MODULE) $(WGPU_NATIVE_MODULE) && \
+		ln -s Versions/Current/$(FRAMEWORK_HEADERS) $(FRAMEWORK_HEADERS) && \
+		ln -s Versions/Current/$(FRAMEWORK_MODULES) $(FRAMEWORK_MODULES) && \
+		ln -s Versions/Current/Resources Resources)
+	@$(INSTALL_NAME_TOOL) -id @rpath/$(WGPU_NATIVE_FRAMEWORK)/Versions/A/$(WGPU_NATIVE_MODULE) $(1)/Versions/A/$(WGPU_NATIVE_MODULE)
+endef
+
+# Repoint a DotLottiePlayer binary's wgpu-native dependency to the WgpuNative
+# framework install name and add the rpaths needed to resolve it from the
+# app's Frameworks/ dir.
 # No-op for software builds (binary has no wgpu-native dependency).
 # $(1)=path to the DotLottiePlayer mach-o binary
 define fixup_wgpu_rpath
@@ -843,25 +890,30 @@ apple-package: apple-frameworks
 # target wipes and repopulates APPLE_RELEASE_DIR; this must run afterwards.
 # Pulls the prebuilt dylibs from the wgpu-native cache populated during the
 # macOS/iOS cargo builds (Mac Catalyst links wgpu statically — no slice here).
+# Each slice is wrapped into a proper WgpuNative.framework: shipping the raw
+# .dylib gets apps rejected by App Store validation (ITMS-90429 "Invalid
+# Swift Support") and is unsupported by CocoaPods.
 .PHONY: apple-wgpu-package
 apple-wgpu-package: apple-package
 	@echo "→ Packaging $(WGPU_NATIVE_XCFRAMEWORK)..."
 	@rm -rf $(WGPU_STAGE_DIR)
-	@mkdir -p $(WGPU_STAGE_DIR)/macos $(WGPU_STAGE_DIR)/ios $(WGPU_STAGE_DIR)/ios-sim $(WGPU_STAGE_DIR)/include/webgpu
+	@mkdir -p $(WGPU_STAGE_DIR)/macos $(WGPU_STAGE_DIR)/ios $(WGPU_STAGE_DIR)/ios-sim
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_macos_arm64),$(WGPU_STAGE_DIR)/macos-arm64.dylib)
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_macos_x86_64),$(WGPU_STAGE_DIR)/macos-x86_64.dylib)
-	@$(LIPO) -create $(WGPU_STAGE_DIR)/macos-arm64.dylib $(WGPU_STAGE_DIR)/macos-x86_64.dylib -o $(WGPU_STAGE_DIR)/macos/$(WGPU_DYLIB)
-	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_arm64),$(WGPU_STAGE_DIR)/ios/$(WGPU_DYLIB))
+	@$(LIPO) -create $(WGPU_STAGE_DIR)/macos-arm64.dylib $(WGPU_STAGE_DIR)/macos-x86_64.dylib -o $(WGPU_STAGE_DIR)/macos.dylib
+	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_arm64),$(WGPU_STAGE_DIR)/ios.dylib)
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_sim_arm64),$(WGPU_STAGE_DIR)/ios-sim-arm64.dylib)
 	$(call stage_wgpu_dylib,$(WGPU_ARTIFACT_ios_x86_64),$(WGPU_STAGE_DIR)/ios-sim-x86_64.dylib)
-	@$(LIPO) -create $(WGPU_STAGE_DIR)/ios-sim-arm64.dylib $(WGPU_STAGE_DIR)/ios-sim-x86_64.dylib -o $(WGPU_STAGE_DIR)/ios-sim/$(WGPU_DYLIB)
-	@cp $(WGPU_CACHE_DIR)/$(WGPU_ARTIFACT_macos_arm64)/include/webgpu/*.h $(WGPU_STAGE_DIR)/include/webgpu/
-	@printf 'module %s {\n  header "webgpu/wgpu.h"\n  export *\n}\n' "$(WGPU_NATIVE_MODULE)" > $(WGPU_STAGE_DIR)/include/module.modulemap
+	@$(LIPO) -create $(WGPU_STAGE_DIR)/ios-sim-arm64.dylib $(WGPU_STAGE_DIR)/ios-sim-x86_64.dylib -o $(WGPU_STAGE_DIR)/ios-sim.dylib
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios.dylib,$(WGPU_STAGE_DIR)/ios,iPhoneOS,MinimumOSVersion,$(MIN_IOS_VERSION))
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/ios-sim.dylib,$(WGPU_STAGE_DIR)/ios-sim,iPhoneSimulator,MinimumOSVersion,$(MIN_IOS_VERSION))
+	$(call make_wgpu_framework,$(WGPU_STAGE_DIR)/macos.dylib,$(WGPU_STAGE_DIR)/macos,MacOSX,LSMinimumSystemVersion,$(MIN_MACOS_VERSION))
+	$(call deepify_wgpu_framework,$(WGPU_STAGE_DIR)/macos/$(WGPU_NATIVE_FRAMEWORK))
 	@rm -rf $(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK)
 	@$(XCODEBUILD) -create-xcframework \
-		-library $(WGPU_STAGE_DIR)/macos/$(WGPU_DYLIB) -headers $(WGPU_STAGE_DIR)/include \
-		-library $(WGPU_STAGE_DIR)/ios/$(WGPU_DYLIB) -headers $(WGPU_STAGE_DIR)/include \
-		-library $(WGPU_STAGE_DIR)/ios-sim/$(WGPU_DYLIB) -headers $(WGPU_STAGE_DIR)/include \
+		-framework $(WGPU_STAGE_DIR)/macos/$(WGPU_NATIVE_FRAMEWORK) \
+		-framework $(WGPU_STAGE_DIR)/ios/$(WGPU_NATIVE_FRAMEWORK) \
+		-framework $(WGPU_STAGE_DIR)/ios-sim/$(WGPU_NATIVE_FRAMEWORK) \
 		-output $(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK) >/dev/null
 	$(call perform_codesigning,$(APPLE_RELEASE_DIR)/$(WGPU_NATIVE_XCFRAMEWORK))
 	@echo "✓ $(WGPU_NATIVE_XCFRAMEWORK) created at $(APPLE_RELEASE_DIR)/"


### PR DESCRIPTION
- Restamps wgpu dylib by removing LC_VERSION_MIN_IPHONEOS (outdated for App Store)
- Moves wgpu dylib in to its owns xcframework unblock spm release
- Removed codesign process (gets overwritten by users')
