### PR TITLE
fix: normalize image slots before handing them to ThorVG

### DIFF
--- a/dotlottie-rs/examples/sm_playground.rs
+++ b/dotlottie-rs/examples/sm_playground.rs
@@ -516,7 +516,7 @@ impl eframe::App for Playground {
                 ui.painter().rect_stroke(
                     rect,
                     0.0,
-                    egui::Stroke::new(1.0, egui::Color32::GRAY),
+                    egui::Stroke::new(1.0_f32, egui::Color32::GRAY),
                     egui::StrokeKind::Outside,
                 );
 

--- a/dotlottie-rs/src/fms/mod.rs
+++ b/dotlottie-rs/src/fms/mod.rs
@@ -285,6 +285,30 @@ impl DotLottieManager {
         self.active_animation_id.to_string()
     }
 
+    /// Read a packaged image by file name and return it as a `data:` URI. Any
+    /// leading directory is ignored.
+    pub fn get_image_data_url(&self, file_name: &str) -> Option<String> {
+        let name = file_name.rsplit('/').next().unwrap_or(file_name);
+
+        if name.is_empty() {
+            return None;
+        }
+
+        let prefix = if self.version == 2 { "i/" } else { "images/" };
+        let mut archive = self.archive.borrow_mut();
+        let mut entry = archive.by_name(&format!("{prefix}{name}")).ok()?;
+
+        let mut content = Vec::with_capacity(entry.size() as usize);
+        entry.read_to_end(&mut content).ok()?;
+
+        let ext = name.rfind('.').map(|i| &name[i + 1..]).unwrap_or(DEFAULT_EXT);
+
+        Some(format!(
+            "{DATA_IMAGE_PREFIX}{ext}{BASE64_PREFIX}{}",
+            Self::encode_base64(&content)
+        ))
+    }
+
     #[inline]
     #[cfg(feature = "theming")]
     pub fn get_theme(&self, theme_id: &str) -> Result<Theme, DotLottieError> {

--- a/dotlottie-rs/src/fms/mod.rs
+++ b/dotlottie-rs/src/fms/mod.rs
@@ -285,8 +285,7 @@ impl DotLottieManager {
         self.active_animation_id.to_string()
     }
 
-    /// Read a packaged image by file name and return it as a `data:` URI. Any
-    /// leading directory is ignored.
+    /// Read a packaged image by file name and return it as a `data:` URI.
     pub fn get_image_data_url(&self, file_name: &str) -> Option<String> {
         let name = file_name.rsplit('/').next().unwrap_or(file_name);
 
@@ -301,7 +300,10 @@ impl DotLottieManager {
         let mut content = Vec::with_capacity(entry.size() as usize);
         entry.read_to_end(&mut content).ok()?;
 
-        let ext = name.rfind('.').map(|i| &name[i + 1..]).unwrap_or(DEFAULT_EXT);
+        let ext = name
+            .rfind('.')
+            .map(|i| &name[i + 1..])
+            .unwrap_or(DEFAULT_EXT);
 
         Some(format!(
             "{DATA_IMAGE_PREFIX}{ext}{BASE64_PREFIX}{}",

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -173,6 +173,9 @@ pub trait LottieRenderer {
 
     fn store_default_slots(&mut self, slots: BTreeMap<String, SlotType>);
 
+    /// The slot's value as declared by the animation, before any override.
+    fn default_slot(&self, slot_id: &str) -> Option<SlotType>;
+
     fn reset_slot(&mut self, slot_id: &str) -> Result<(), LottieRendererError>;
 
     fn reset_slots(&mut self) -> bool;
@@ -822,6 +825,10 @@ impl<R: Renderer> LottieRenderer for LottieRendererImpl<R> {
     fn store_default_slots(&mut self, slots: BTreeMap<String, SlotType>) {
         self.default_slots = slots.clone();
         self.slot_values = slots;
+    }
+
+    fn default_slot(&self, slot_id: &str) -> Option<SlotType> {
+        self.default_slots.get(slot_id).cloned()
     }
 
     fn reset_slot(&mut self, slot_id: &str) -> Result<(), LottieRendererError> {

--- a/dotlottie-rs/src/lottie_renderer/mod.rs
+++ b/dotlottie-rs/src/lottie_renderer/mod.rs
@@ -173,7 +173,6 @@ pub trait LottieRenderer {
 
     fn store_default_slots(&mut self, slots: BTreeMap<String, SlotType>);
 
-    /// The slot's value as declared by the animation, before any override.
     fn default_slot(&self, slot_id: &str) -> Option<SlotType>;
 
     fn reset_slot(&mut self, slot_id: &str) -> Result<(), LottieRendererError>;

--- a/dotlottie-rs/src/lottie_renderer/slots/image.rs
+++ b/dotlottie-rs/src/lottie_renderer/slots/image.rs
@@ -65,4 +65,114 @@ impl ImageSlot {
         self.height = Some(height);
         self
     }
+
+    pub fn is_embedded(&self) -> bool {
+        matches!(self.path.as_deref(), Some(p) if p.starts_with("data:"))
+    }
+
+    pub fn is_remote(&self) -> bool {
+        matches!(self.path.as_deref(), Some(p) if p.starts_with("http://") || p.starts_with("https://"))
+    }
+
+    pub fn file_name(&self) -> Option<&str> {
+        if self.is_embedded() || self.is_remote() {
+            return None;
+        }
+
+        self.path.as_deref().filter(|name| !name.is_empty())
+    }
+
+    /// ThorVG discriminates image assets from audio on `w`/`h` being non-zero,
+    /// so a zero dimension is as good as an absent one.
+    pub fn has_dimensions(&self) -> bool {
+        matches!((self.width, self.height), (Some(w), Some(h)) if w > 0 && h > 0)
+    }
+
+    pub fn inline(&mut self, data_url: String) {
+        self.directory = None;
+        self.path = Some(data_url);
+        self.embed = Some(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ImageSlot;
+
+    #[test]
+    fn data_url_is_embedded_and_has_no_file_name() {
+        let slot = ImageSlot::from_src("data:image/png;base64,AAAA".to_string());
+
+        assert!(slot.is_embedded());
+        assert!(!slot.is_remote());
+        assert_eq!(slot.file_name(), None);
+    }
+
+    #[test]
+    fn http_url_is_remote_and_has_no_file_name() {
+        for src in ["http://example.com/a.png", "https://example.com/a.png"] {
+            let slot = ImageSlot::from_src(src.to_string());
+
+            assert!(slot.is_remote());
+            assert!(!slot.is_embedded());
+            assert_eq!(slot.file_name(), None);
+        }
+    }
+
+    #[test]
+    fn package_paths_all_reduce_to_the_bare_file_name() {
+        for src in ["logo.png", "i/logo.png", "/i/logo.png"] {
+            let slot = ImageSlot::from_src(src.to_string());
+
+            assert_eq!(slot.file_name(), Some("logo.png"), "src = {src}");
+        }
+    }
+
+    #[test]
+    fn inline_replaces_a_package_reference_with_embedded_bytes() {
+        let mut slot = ImageSlot::from_src("/i/logo.png".to_string());
+        assert_eq!(slot.file_name(), Some("logo.png"));
+
+        slot.inline("data:image/png;base64,AAAA".to_string());
+
+        assert!(slot.is_embedded());
+        assert_eq!(slot.directory, None);
+        assert_eq!(slot.file_name(), None);
+        assert_eq!(slot.path.as_deref(), Some("data:image/png;base64,AAAA"));
+    }
+
+    #[test]
+    fn an_empty_src_has_no_file_name() {
+        let slot = ImageSlot::from_src(String::new());
+
+        assert!(!slot.is_embedded());
+        assert!(!slot.is_remote());
+        assert_eq!(slot.file_name(), None);
+    }
+
+    #[test]
+    fn dimensions_are_reported_only_when_both_are_present() {
+        let slot = ImageSlot::from_src("logo.png".to_string());
+        assert!(!slot.has_dimensions());
+
+        assert!(slot.with_dimensions(250, 167).has_dimensions());
+    }
+
+    #[test]
+    fn a_zero_dimension_does_not_count_as_a_dimension() {
+        let slot = ImageSlot::from_src("logo.png".to_string());
+
+        assert!(!slot.clone().with_dimensions(0, 0).has_dimensions());
+        assert!(!slot.clone().with_dimensions(250, 0).has_dimensions());
+        assert!(!slot.with_dimensions(0, 167).has_dimensions());
+    }
+
+    #[test]
+    fn an_embed_flag_does_not_make_a_bare_file_name_embedded() {
+        let mut slot = ImageSlot::from_src("logo.png".to_string());
+        slot.embed = Some(1);
+
+        assert!(!slot.is_embedded());
+        assert_eq!(slot.file_name(), Some("logo.png"));
+    }
 }

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -1237,13 +1237,8 @@ impl Player {
         Ok(())
     }
 
-    /// Bring an image slot into the only shape ThorVG handles correctly: bytes
-    /// inlined as a `data:` URI, with non-zero `w`/`h`.
-    ///
-    /// Package-relative names must be resolved here because ThorVG's wasm build
-    /// has no file I/O and we register no asset resolver. Dimensions must be
-    /// present because ThorVG parses a non-embedded, zero-sized asset as *audio*
-    /// and then casts it to an image, corrupting memory.
+    /// Inline package images as `data:` URIs and ensure non-zero `w`/`h`, the
+    /// only shape ThorVG parses as an image rather than as audio.
     fn normalize_image_slot(
         &self,
         slot_id: &str,

--- a/dotlottie-rs/src/player.rs
+++ b/dotlottie-rs/src/player.rs
@@ -1195,7 +1195,10 @@ impl Player {
             match slot_type {
                 SlotType::Color(slot) => self.renderer.set_color_slot(&slot_id, slot)?,
                 SlotType::Gradient(slot) => self.renderer.set_gradient_slot(&slot_id, slot)?,
-                SlotType::Image(slot) => self.renderer.set_image_slot(&slot_id, slot)?,
+                SlotType::Image(slot) => {
+                    let slot = self.normalize_image_slot(&slot_id, slot)?;
+                    self.renderer.set_image_slot(&slot_id, slot)?
+                }
                 SlotType::Text(slot) => self.renderer.set_text_slot(&slot_id, slot)?,
                 SlotType::Scalar(slot) => self.renderer.set_scalar_slot(&slot_id, slot)?,
                 SlotType::Vector(slot) => self.renderer.set_vector_slot(&slot_id, slot)?,
@@ -1229,8 +1232,76 @@ impl Player {
         slot_id: &str,
         slot: crate::lottie_renderer::ImageSlot,
     ) -> Result<(), PlayerError> {
+        let slot = self.normalize_image_slot(slot_id, slot)?;
         self.renderer.set_image_slot(slot_id, slot)?;
         Ok(())
+    }
+
+    /// Bring an image slot into the only shape ThorVG handles correctly: bytes
+    /// inlined as a `data:` URI, with non-zero `w`/`h`.
+    ///
+    /// Package-relative names must be resolved here because ThorVG's wasm build
+    /// has no file I/O and we register no asset resolver. Dimensions must be
+    /// present because ThorVG parses a non-embedded, zero-sized asset as *audio*
+    /// and then casts it to an image, corrupting memory.
+    fn normalize_image_slot(
+        &self,
+        slot_id: &str,
+        mut slot: crate::lottie_renderer::ImageSlot,
+    ) -> Result<crate::lottie_renderer::ImageSlot, PlayerError> {
+        if !slot.is_embedded() && !slot.is_remote() {
+            let file_name = slot
+                .file_name()
+                .map(str::to_owned)
+                .ok_or(PlayerError::InvalidParameter)?;
+
+            let data_url = self
+                .resolve_package_image(&file_name)
+                .ok_or(PlayerError::InvalidParameter)?;
+
+            slot.inline(data_url);
+        }
+
+        if !slot.has_dimensions() {
+            if let Some(crate::lottie_renderer::SlotType::Image(default)) =
+                self.renderer.default_slot(slot_id)
+            {
+                if let (Some(width), Some(height)) = (default.width, default.height) {
+                    slot = slot.with_dimensions(width, height);
+                }
+            }
+        }
+
+        if !slot.has_dimensions() {
+            return Err(PlayerError::InvalidParameter);
+        }
+
+        Ok(slot)
+    }
+
+    fn normalize_image_slots(
+        &self,
+        slots: &mut std::collections::BTreeMap<String, crate::lottie_renderer::SlotType>,
+    ) -> Result<(), PlayerError> {
+        for (slot_id, slot_type) in slots.iter_mut() {
+            if let crate::lottie_renderer::SlotType::Image(slot) = slot_type {
+                *slot = self.normalize_image_slot(slot_id, slot.clone())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "dotlottie")]
+    fn resolve_package_image(&self, file_name: &str) -> Option<String> {
+        self.dotlottie_manager
+            .as_ref()?
+            .get_image_data_url(file_name)
+    }
+
+    #[cfg(not(feature = "dotlottie"))]
+    fn resolve_package_image(&self, _file_name: &str) -> Option<String> {
+        None
     }
 
     pub fn set_text_slot(
@@ -1281,8 +1352,9 @@ impl Player {
 
     pub fn set_slots(
         &mut self,
-        slots: std::collections::BTreeMap<String, crate::lottie_renderer::SlotType>,
+        mut slots: std::collections::BTreeMap<String, crate::lottie_renderer::SlotType>,
     ) -> Result<(), PlayerError> {
+        self.normalize_image_slots(&mut slots)?;
         self.renderer.set_slots(slots)?;
         Ok(())
     }
@@ -1304,7 +1376,10 @@ impl Player {
                         SlotType::Gradient(slot) => {
                             self.renderer.set_gradient_slot(&slot_id, slot)?
                         }
-                        SlotType::Image(slot) => self.renderer.set_image_slot(&slot_id, slot)?,
+                        SlotType::Image(slot) => {
+                            let slot = self.normalize_image_slot(&slot_id, slot)?;
+                            self.renderer.set_image_slot(&slot_id, slot)?
+                        }
                         SlotType::Text(slot) => self.renderer.set_text_slot(&slot_id, slot)?,
                         SlotType::Scalar(slot) => self.renderer.set_scalar_slot(&slot_id, slot)?,
                         SlotType::Vector(slot) => self.renderer.set_vector_slot(&slot_id, slot)?,
@@ -1336,6 +1411,18 @@ impl Player {
     }
 
     pub fn set_slot_str(&mut self, slot_id: &str, json: &str) -> Result<(), PlayerError> {
+        if self.renderer.get_slot_type(slot_id) == "image" {
+            let parsed = crate::lottie_renderer::slots::parse_slot_from_json("image", json)
+                .ok_or(PlayerError::InvalidParameter)?;
+
+            if let crate::lottie_renderer::SlotType::Image(slot) = parsed {
+                let slot = self.normalize_image_slot(slot_id, slot)?;
+                self.renderer.set_image_slot(slot_id, slot)?;
+
+                return Ok(());
+            }
+        }
+
         self.renderer.set_slot_str(slot_id, json)?;
         Ok(())
     }


### PR DESCRIPTION
`set_image_slot` never worked from WASM.

A slot built from a non-`data:` src has `e: 0` and no `w`/`h`. ThorVG's `parseAsset()` tells image from audio by `!strncmp(data, "data:image/", 11) || width != 0 || height != 0`, so it builds a `LottieAudio` and then `static_cast`s it to `LottieImage*`. The trap unwinds out of wasm without dropping the wasm-bindgen borrow guard, so the player stays mutably borrowed and every later call throws `recursive use of an object detected...` — the error users actually report. And a valid `data:` URI with no `w`/`h` renders at 0×0.

Package names could never have worked: the WASM build has no `THORVG_FILE_IO_SUPPORT` and we register no asset resolver. Packaged images only render because `fms` inlines them at load, which `set_image_slot` bypassed.

## Changes

- `DotLottieManager::get_image_data_url()` — read a packaged image by file name, return it as a `data:` URI.
- `Player::normalize_image_slot()` — inline package names, back-fill `w`/`h` from the slot default, reject anything still without non-zero dimensions. Applied to `set_image_slot`, `set_slots`, `set_slots_str`, `set_slot_str` and theming.
- `ImageSlot`: `is_embedded` / `is_remote` / `file_name` / `has_dimensions` / `inline`. `is_embedded` keys off the `data:` prefix, not `e`, since slot JSON can set `e: 1` on a bare file name; a zero dimension counts as absent, matching ThorVG's discriminator.
- `LottieRenderer::default_slot()` — the pre-override slot value, where the original `w`/`h` come from.
