### PR TITLE
refactor(wasm): replace hand-written libc stubs with tinyrlibc

### DIFF
--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -62,6 +62,20 @@ rodio = { version = "0.17", optional = true, default-features = false, features 
 wasm-bindgen = "0.2.100"
 js-sys = "0.3"
 nostd-printf = "0.1.4"
+tinyrlibc = { version = "0.5.1", default-features = false, features = [
+    "alloc",
+    "atoi",
+    "isdigit",
+    "isspace",
+    "strcat",
+    "strchr",
+    "strcmp",
+    "strcpy",
+    "strncasecmp",
+    "strncmp",
+    "strstr",
+    "strtol",
+] }
 web-sys = { version = "=0.3.77", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 

--- a/dotlottie-rs/src/wasm/mod.rs
+++ b/dotlottie-rs/src/wasm/mod.rs
@@ -11,8 +11,9 @@
 /// Minimal libc/C++ runtime stubs for `wasm32-unknown-unknown`.
 ///
 /// Unlike `wasm32-unknown-emscripten` or `wasm32-wasi`, the `unknown-unknown`
-/// target has no system C runtime. ThorVG's C++ sources reference libc symbols
-/// (`malloc`, `strcmp`, `snprintf`, …) that must be provided by us.
+/// target has no system C runtime. Most libc symbols ThorVG references come
+/// from the `tinyrlibc` crate (`malloc`, `strcmp`, …) and `nostd-printf`
+/// (`snprintf`); this module provides the rest (C++ ABI, math, …).
 mod stubs;
 
 /// cbindgen:ignore

--- a/dotlottie-rs/src/wasm/stubs.rs
+++ b/dotlottie-rs/src/wasm/stubs.rs
@@ -1,23 +1,26 @@
-#![expect(dead_code)]
 #![allow(non_snake_case)]
 
 //! libc/C++ runtime stubs for wasm32-unknown-unknown.
 //!
 //! ThorVG's C++ sources reference a number of libc symbols that are normally
 //! provided by the platform's C runtime. For `wasm32-unknown-unknown` there is
-//! no such runtime, so we supply minimal Rust implementations here.
+//! no such runtime; most libc symbols (`malloc`/`free`/`realloc`/`calloc`,
+//! `str*`, `atoi`/`strtol`, `is*`) come from the `tinyrlibc` crate and
+//! `snprintf`/`vsnprintf` from `nostd-printf`. This file provides only what no
+//! crate covers: C++ ABI/runtime symbols, libc++ internals, math functions,
+//! `strdup`/`tolower`/`bsearch`, `__assert_fail`, setjmp/longjmp, and `rand`
+//! (kept local so random() sequences stay identical across releases).
 
 use std::{
-    alloc::{self, Layout},
     ffi::CStr,
-    mem, process, ptr,
-    ptr::NonNull,
-    slice,
+    process, ptr, slice,
     sync::atomic::{AtomicU32, Ordering},
 };
 
 // Imports snprintf.
 use nostd_printf as _;
+// Imports malloc/free/realloc/calloc, str*, atoi/strtol, isdigit/isspace.
+use tinyrlibc as _;
 
 #[no_mangle]
 unsafe extern "C" fn modff(val: f32, i: *mut f32) -> f32 {
@@ -28,102 +31,17 @@ unsafe extern "C" fn modff(val: f32, i: *mut f32) -> f32 {
     val.fract()
 }
 
-#[derive(Clone, Copy, Debug)]
-struct Info {
-    ptr: NonNull<u8>,
-    layout: Layout,
-}
-
-fn with_allocator<F: FnOnce(Layout) -> *mut u8>(size: usize, allocator: F) -> Option<NonNull<u8>> {
-    Layout::from_size_align(size, 16)
-        .and_then(|layout| Layout::new::<Info>().extend(layout))
-        .ok()
-        .and_then(|(layout, offset)| {
-            let ptr = NonNull::new(allocator(layout))?;
-
-            let alloc_ptr = unsafe { ptr.add(offset) };
-            let info_ptr = unsafe { alloc_ptr.sub(mem::size_of::<Info>()).cast() };
-
-            unsafe {
-                info_ptr.write_unaligned(Info { ptr, layout });
-            }
-
-            Some(alloc_ptr)
-        })
-}
-
-unsafe fn read_info(alloc_ptr: NonNull<u8>) -> Info {
-    let info_ptr = unsafe { alloc_ptr.sub(mem::size_of::<Info>()) };
-    unsafe { info_ptr.cast().read_unaligned() }
-}
-
 #[no_mangle]
-unsafe extern "C" fn malloc(size: usize) -> Option<NonNull<u8>> {
-    with_allocator(size, |layout| unsafe { alloc::alloc(layout) })
-}
-
-#[no_mangle]
-unsafe extern "C" fn free(ptr: Option<NonNull<u8>>) {
-    if let Some(alloc_ptr) = ptr {
-        let info: Info = read_info(alloc_ptr);
-
-        unsafe {
-            alloc::dealloc(info.ptr.as_ptr(), info.layout);
-        }
-    }
-}
-
-#[no_mangle]
-unsafe extern "C" fn realloc(ptr: Option<NonNull<u8>>, size: usize) -> Option<NonNull<u8>> {
-    let Some(alloc_ptr) = ptr else {
-        return malloc(size);
-    };
-
-    let info: Info = read_info(alloc_ptr);
-
-    let new_layout = Layout::from_size_align(size, 16)
-        .and_then(|layout| Layout::new::<Info>().extend(layout))
-        .ok()?
-        .0;
-
-    with_allocator(size, |_| unsafe {
-        alloc::realloc(info.ptr.as_ptr(), info.layout, new_layout.size())
-    })
-}
-
-#[no_mangle]
-unsafe extern "C" fn calloc(num: usize, size: usize) -> Option<NonNull<u8>> {
-    with_allocator(num * size, |layout| unsafe { alloc::alloc_zeroed(layout) })
-}
-
-#[no_mangle]
-unsafe extern "C" fn _ZdlPvm(ptr: Option<NonNull<u8>>, _size: usize) {
-    free(ptr)
+unsafe extern "C" fn _ZdlPvm(ptr: *mut u8, _size: usize) {
+    // C++ operator delete(void*, size_t). ThorVG's operator new allocates via
+    // the C malloc symbol, so this must pair with tinyrlibc's free.
+    tinyrlibc::free(ptr)
 }
 
 #[no_mangle]
 unsafe extern "C" fn _ZdaPvm(ptr: *mut u8, _size: usize) {
     // C++ operator delete[](void*, size_t) - sized array deallocation
-    if !ptr.is_null() {
-        free(Some(NonNull::new_unchecked(ptr)));
-    }
-}
-
-#[no_mangle]
-unsafe extern "C" fn atoi(s: Option<NonNull<i8>>) -> i32 {
-    fn conv(s: Option<NonNull<i8>>) -> Option<i32> {
-        let s = unsafe { CStr::from_ptr(s?.as_ptr()).to_str().ok()? };
-
-        let trimmed = s.trim_start();
-        let trimmed = trimmed
-            .get(..11)
-            .unwrap_or(trimmed)
-            .trim_end_matches(|c: char| !c.is_ascii_digit());
-
-        trimmed.parse().ok()
-    }
-
-    conv(s).unwrap_or_default()
+    tinyrlibc::free(ptr)
 }
 
 #[no_mangle]
@@ -169,83 +87,23 @@ unsafe extern "C" fn __assert_fail(
 }
 
 #[no_mangle]
-unsafe extern "C" fn strchr(s: Option<NonNull<i8>>, c: u32) -> Option<NonNull<i8>> {
-    let c = u8::try_from(c).ok()?;
-    s.and_then(|p| {
-        CStr::from_ptr(p.as_ptr() as *const i8)
-            .to_bytes()
-            .iter()
-            .enumerate()
-            .find_map(|(o, &b)| (b == c).then(|| p.add(o)))
-    })
-}
-
-#[no_mangle]
-unsafe extern "C" fn strdup(s: Option<NonNull<i8>>) -> Option<NonNull<i8>> {
-    s.and_then(|p| {
-        let bytes = CStr::from_ptr(p.as_ptr() as *const i8).to_bytes_with_nul();
-
-        let p = malloc(bytes.len())?;
-
-        let slice = slice::from_raw_parts_mut(p.as_ptr(), bytes.len());
-        slice.copy_from_slice(bytes);
-
-        Some(p.cast())
-    })
-}
-
-#[no_mangle]
-unsafe extern "C" fn strcmp(s1: *const i8, s2: *const i8) -> i32 {
-    CStr::from_ptr(s1).cmp(CStr::from_ptr(s2)) as i32
-}
-
-#[no_mangle]
-unsafe extern "C" fn strcpy(dest: *mut i8, src: *const i8) -> *mut i8 {
-    let src = CStr::from_ptr(src).to_bytes_with_nul();
-    let dest_slice = slice::from_raw_parts_mut(dest as *mut u8, src.len());
-
-    dest_slice.copy_from_slice(src);
-
-    dest
-}
-
-#[no_mangle]
-unsafe extern "C" fn strcat(dest: *mut i8, src: *const i8) -> *mut i8 {
-    let dest_len = CStr::from_ptr(dest).to_bytes().len();
-    let src = CStr::from_ptr(src).to_bytes_with_nul();
-    let dest_slice = slice::from_raw_parts_mut(dest as *mut u8, dest_len + src.len());
-
-    dest_slice[dest_len..].copy_from_slice(src);
-
-    dest
-}
-
-#[no_mangle]
-unsafe extern "C" fn strstr(haystack: *const i8, needle: *const i8) -> *mut i8 {
-    if haystack.is_null() || needle.is_null() {
+unsafe extern "C" fn strdup(s: *const i8) -> *mut i8 {
+    if s.is_null() {
         return ptr::null_mut();
     }
 
-    let haystack_cstr = CStr::from_ptr(haystack);
-    let needle_cstr = CStr::from_ptr(needle);
+    let bytes = CStr::from_ptr(s).to_bytes_with_nul();
 
-    let haystack_bytes = haystack_cstr.to_bytes();
-    let needle_bytes = needle_cstr.to_bytes();
-
-    // Empty needle should return the beginning of haystack (per C standard)
-    if needle_bytes.is_empty() {
-        return haystack as *mut i8;
+    // Callers (e.g. ThorVG's LottieFont) release the result with C free(),
+    // so the allocation must come from tinyrlibc's malloc.
+    let p = tinyrlibc::malloc(bytes.len());
+    if p.is_null() {
+        return ptr::null_mut();
     }
 
-    // Search for needle in haystack
-    if let Some(pos) = haystack_bytes
-        .windows(needle_bytes.len())
-        .position(|window| window == needle_bytes)
-    {
-        haystack.add(pos) as *mut i8
-    } else {
-        ptr::null_mut()
-    }
+    slice::from_raw_parts_mut(p, bytes.len()).copy_from_slice(bytes);
+
+    p as *mut i8
 }
 
 #[no_mangle]
@@ -282,50 +140,6 @@ unsafe extern "C" fn bsearch(
 }
 
 #[no_mangle]
-unsafe extern "C" fn strncmp(s1: *const i8, s2: *const i8, n: usize) -> i32 {
-    let mut i = 0;
-    while i < n {
-        let c1 = unsafe { *s1.add(i) as u8 };
-        let c2 = unsafe { *s2.add(i) as u8 };
-        if c1 != c2 {
-            return c1 as i32 - c2 as i32;
-        }
-        if c1 == 0 {
-            return 0;
-        }
-        i += 1;
-    }
-    0
-}
-
-#[no_mangle]
-unsafe extern "C" fn strncasecmp(s1: *const i8, s2: *const i8, n: usize) -> i32 {
-    let mut i = 0;
-    while i < n {
-        let c1 = unsafe { *s1.add(i) as u8 }.to_ascii_lowercase();
-        let c2 = unsafe { *s2.add(i) as u8 }.to_ascii_lowercase();
-        if c1 != c2 {
-            return c1 as i32 - c2 as i32;
-        }
-        if c1 == 0 {
-            return 0;
-        }
-        i += 1;
-    }
-    0
-}
-
-#[no_mangle]
-unsafe extern "C" fn isspace(c: i32) -> i32 {
-    matches!(c as u8, b' ' | b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r') as i32
-}
-
-#[no_mangle]
-unsafe extern "C" fn isdigit(c: i32) -> i32 {
-    matches!(c as u8, b'0'..=b'9') as i32
-}
-
-#[no_mangle]
 unsafe extern "C" fn tolower(c: i32) -> i32 {
     if (c as u8).is_ascii_uppercase() {
         c + 32
@@ -345,90 +159,6 @@ unsafe extern "C" fn rand() -> i32 {
     x ^= x << 5;
     RAND_STATE.store(x, Ordering::Relaxed);
     (x & 0x7fff_ffff) as i32
-}
-
-/// `strtol(s, endptr, base)` — string to long (wasm32: long == i32).
-#[no_mangle]
-unsafe extern "C" fn strtol(s: *const i8, endptr: *mut *mut i8, base: i32) -> i32 {
-    let set_end = |p: *const i8| {
-        if !endptr.is_null() {
-            unsafe { *endptr = p as *mut i8 };
-        }
-    };
-
-    if s.is_null() {
-        set_end(s);
-        return 0;
-    }
-
-    let bytes = CStr::from_ptr(s).to_bytes();
-    let mut idx = 0;
-
-    // Skip leading whitespace
-    while idx < bytes.len()
-        && matches!(bytes[idx], b' ' | b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r')
-    {
-        idx += 1;
-    }
-
-    // Optional sign
-    let negative = if idx < bytes.len() && bytes[idx] == b'-' {
-        idx += 1;
-        true
-    } else {
-        if idx < bytes.len() && bytes[idx] == b'+' {
-            idx += 1;
-        }
-        false
-    };
-
-    // Determine radix and consume optional prefix
-    let radix: u32 = if base == 0 {
-        if idx + 1 < bytes.len() && bytes[idx] == b'0' && matches!(bytes[idx + 1], b'x' | b'X') {
-            idx += 2;
-            16
-        } else if idx < bytes.len() && bytes[idx] == b'0' {
-            8
-        } else {
-            10
-        }
-    } else {
-        if base == 16
-            && idx + 1 < bytes.len()
-            && bytes[idx] == b'0'
-            && matches!(bytes[idx + 1], b'x' | b'X')
-        {
-            idx += 2;
-        }
-        base as u32
-    };
-
-    let start = idx;
-    let mut result: i64 = 0;
-    while idx < bytes.len() {
-        let digit = match bytes[idx] {
-            b'0'..=b'9' => bytes[idx] - b'0',
-            b'a'..=b'z' => bytes[idx] - b'a' + 10,
-            b'A'..=b'Z' => bytes[idx] - b'A' + 10,
-            _ => break,
-        } as u32;
-        if digit >= radix {
-            break;
-        }
-        result = result * radix as i64 + digit as i64;
-        idx += 1;
-    }
-
-    set_end(if idx == start {
-        s
-    } else {
-        unsafe { s.add(idx) }
-    });
-    if negative {
-        -(result as i32)
-    } else {
-        result as i32
-    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
Replaces ~300 lines of hand-written libc stubs in `src/wasm/stubs.rs` with the maintained [tinyrlibc](https://github.com/rust-embedded-community/tinyrlibc) crate (wasm32-unknown-unknown target dep only): allocator, string/ctype functions, `atoi`/`strtol`.

What stays hand-written (no crate covers these): C++ ABI symbols (`__cxa_*`, sized `operator delete`, libc++ `__next_prime`/`mutex`), math stubs, `strdup`/`tolower`/`bsearch`, setjmp/longjmp, and `rand` (kept local so `random()` expression sequences stay identical). `nostd-printf` stays for `snprintf` — tinyrlibc's snprintf is C code that can't build without a sysroot on this target.

`strdup` and both `operator delete` stubs now route through tinyrlibc's `malloc`/`free` so allocations stay within one allocator (ThorVG's `operator new` is the C `malloc` symbol).

Also fixes a latent bug: the old `atoi` returned 0 for strings with trailing non-digits, so ThorVG's internal version (`_buildVersionInfo` parsing "1.0.1") has been 0 in wasm builds.

Verified: `make wasm` links clean; symbol-level smoke test in Node (allocator round-trips incl. strdup→free, hex strtol, atoi cases); web-example.html renders and animates correctly; native tests and clippy unaffected.