### PR TITLE
chore: replace zip crate with a vendored dotlottie zip reader

### DIFF
--- a/dotlottie-rs/Cargo.toml
+++ b/dotlottie-rs/Cargo.toml
@@ -32,7 +32,7 @@ tvg-otf = []
 tvg-threads = []
 tvg-simd = []
 tracking_allocator = []
-dotlottie = ["dep:zip"]
+dotlottie = ["dep:miniz_oxide"]
 state-machines = ["dotlottie"]
 theming = ["dotlottie"]
 wasm-bindgen-api = ["dep:console_error_panic_hook"] # OOP JS wrapper via wasm-bindgen
@@ -45,7 +45,7 @@ audio = ["dotlottie", "dep:rodio", "dep:ndk-context", "web-sys/HtmlAudioElement"
 rustc-hash = "2.1.1"
 thiserror = "2"
 oorandom = "11"
-zip = { version = "2.4.2", default-features = false, features = ["deflate"], optional = true }
+miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"], optional = true }
 bitflags = { version = "2.6", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/dotlottie-rs/src/dotlottie/archive.rs
+++ b/dotlottie-rs/src/dotlottie/archive.rs
@@ -1,0 +1,477 @@
+//! Minimal read-only ZIP reader for the dotLottie container: central
+//! directory walk + `miniz_oxide` inflate, stored/deflate methods only.
+//! ZIP64, encryption, and multi-disk archives are rejected. CRC32 is not
+//! validated: corrupt entries fail downstream at JSON/image/audio decode.
+
+use std::borrow::Cow;
+use std::ops::Range;
+
+const EOCD_SIG: u32 = 0x0605_4b50;
+const CDIR_SIG: u32 = 0x0201_4b50;
+const LOCAL_SIG: u32 = 0x0403_4b50;
+
+const EOCD_MIN: usize = 22;
+const MAX_COMMENT: usize = 0xFFFF;
+
+const METHOD_STORED: u16 = 0;
+const METHOD_DEFLATE: u16 = 8;
+
+const MAX_ENTRIES: usize = 4096;
+const MAX_ENTRY_SIZE: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ArchiveError {
+    Invalid,
+    TooLarge,
+    Unsupported,
+    NotFound,
+    Inflate,
+}
+
+#[derive(Debug)]
+pub(crate) struct Archive {
+    data: Vec<u8>,
+    entries: Vec<Entry>,
+}
+
+#[derive(Debug)]
+struct Entry {
+    name: Range<usize>,
+    method: u16,
+    data: Range<usize>,
+    uncompressed_size: usize,
+}
+
+fn u16_at(data: &[u8], at: usize) -> Option<u16> {
+    let b = data.get(at..at.checked_add(2)?)?;
+    Some(u16::from_le_bytes([b[0], b[1]]))
+}
+
+fn u32_at(data: &[u8], at: usize) -> Option<u32> {
+    let b = data.get(at..at.checked_add(4)?)?;
+    Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+/// Bounds-checked `start..start + len`; `checked_add` guards usize wrap on
+/// 32-bit targets with crafted header values.
+fn range_at(data: &[u8], start: usize, len: usize) -> Option<Range<usize>> {
+    let end = start.checked_add(len)?;
+    data.get(start..end)?;
+    Some(start..end)
+}
+
+impl Archive {
+    pub fn new(data: Vec<u8>) -> Result<Self, ArchiveError> {
+        let eocd = Self::find_eocd(&data).ok_or(ArchiveError::Invalid)?;
+        let disk_number = u16_at(&data, eocd + 4).ok_or(ArchiveError::Invalid)?;
+        let cdir_disk = u16_at(&data, eocd + 6).ok_or(ArchiveError::Invalid)?;
+        if disk_number != 0 || cdir_disk != 0 {
+            return Err(ArchiveError::Unsupported);
+        }
+        let entry_count = u16_at(&data, eocd + 10).ok_or(ArchiveError::Invalid)? as usize;
+        let cdir_offset = u32_at(&data, eocd + 16).ok_or(ArchiveError::Invalid)? as usize;
+        if entry_count == 0xFFFF || cdir_offset == 0xFFFF_FFFF {
+            return Err(ArchiveError::Unsupported); // ZIP64
+        }
+        if entry_count > MAX_ENTRIES {
+            return Err(ArchiveError::TooLarge);
+        }
+
+        let mut entries = Vec::with_capacity(entry_count);
+        let mut at = cdir_offset;
+        for _ in 0..entry_count {
+            if u32_at(&data, at) != Some(CDIR_SIG) {
+                return Err(ArchiveError::Invalid);
+            }
+            let flags = u16_at(&data, at + 8).ok_or(ArchiveError::Invalid)?;
+            let method = u16_at(&data, at + 10).ok_or(ArchiveError::Invalid)?;
+            let compressed_size = u32_at(&data, at + 20).ok_or(ArchiveError::Invalid)? as usize;
+            let uncompressed_size = u32_at(&data, at + 24).ok_or(ArchiveError::Invalid)? as usize;
+            let name_len = u16_at(&data, at + 28).ok_or(ArchiveError::Invalid)? as usize;
+            let extra_len = u16_at(&data, at + 30).ok_or(ArchiveError::Invalid)? as usize;
+            let comment_len = u16_at(&data, at + 32).ok_or(ArchiveError::Invalid)? as usize;
+            let local_offset = u32_at(&data, at + 42).ok_or(ArchiveError::Invalid)? as usize;
+            if compressed_size == 0xFFFF_FFFF
+                || uncompressed_size == 0xFFFF_FFFF
+                || local_offset == 0xFFFF_FFFF
+            {
+                return Err(ArchiveError::Unsupported); // ZIP64
+            }
+            let name = range_at(&data, at + 46, name_len).ok_or(ArchiveError::Invalid)?;
+            at = name
+                .end
+                .checked_add(extra_len)
+                .and_then(|v| v.checked_add(comment_len))
+                .ok_or(ArchiveError::Invalid)?;
+
+            let name_bytes = &data[name.clone()];
+            // Directory and non-UTF-8 names are unreferenceable from manifest.json.
+            if name_bytes.ends_with(b"/") || std::str::from_utf8(name_bytes).is_err() {
+                continue;
+            }
+            if flags & 0x1 != 0 {
+                return Err(ArchiveError::Unsupported); // encrypted
+            }
+            if method != METHOD_STORED && method != METHOD_DEFLATE {
+                return Err(ArchiveError::Unsupported);
+            }
+            if uncompressed_size > MAX_ENTRY_SIZE {
+                return Err(ArchiveError::TooLarge);
+            }
+
+            // Name/extra lengths may differ from the central directory's copy;
+            // the payload offset must come from the local header.
+            if u32_at(&data, local_offset) != Some(LOCAL_SIG) {
+                return Err(ArchiveError::Invalid);
+            }
+            let local_name_len =
+                u16_at(&data, local_offset + 26).ok_or(ArchiveError::Invalid)? as usize;
+            let local_extra_len =
+                u16_at(&data, local_offset + 28).ok_or(ArchiveError::Invalid)? as usize;
+            let payload_start = local_offset
+                .checked_add(30 + local_name_len)
+                .and_then(|v| v.checked_add(local_extra_len))
+                .ok_or(ArchiveError::Invalid)?;
+            let payload =
+                range_at(&data, payload_start, compressed_size).ok_or(ArchiveError::Invalid)?;
+
+            entries.push(Entry {
+                name,
+                method,
+                data: payload,
+                uncompressed_size,
+            });
+        }
+
+        Ok(Archive { data, entries })
+    }
+
+    fn find_eocd(data: &[u8]) -> Option<usize> {
+        let start = data.len().checked_sub(EOCD_MIN)?;
+        let floor = start.saturating_sub(MAX_COMMENT);
+        (floor..=start)
+            .rev()
+            .find(|&at| u32_at(data, at) == Some(EOCD_SIG))
+    }
+
+    /// Stored entries borrow from the archive buffer; deflated entries
+    /// inflate into a fresh buffer capped at the declared size.
+    pub fn by_name(&self, name: &str) -> Result<Cow<'_, [u8]>, ArchiveError> {
+        let entry = self
+            .entries
+            .iter()
+            .find(|e| &self.data[e.name.clone()] == name.as_bytes())
+            .ok_or(ArchiveError::NotFound)?;
+        let raw = &self.data[entry.data.clone()];
+        match entry.method {
+            METHOD_STORED => Ok(Cow::Borrowed(raw)),
+            _ => miniz_oxide::inflate::decompress_to_vec_with_limit(raw, entry.uncompressed_size)
+                .map(Cow::Owned)
+                .map_err(|_| ArchiveError::Inflate),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    //! Tiny ZIP writer for tests; CRC fields are zeroed (the reader skips them).
+
+    /// Entries are `(name, content, deflate?)`.
+    pub fn build_zip(entries: &[(&str, &[u8], bool)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut central = Vec::new();
+        for (name, content, deflate) in entries {
+            let payload = if *deflate {
+                miniz_oxide::deflate::compress_to_vec(content, 6)
+            } else {
+                content.to_vec()
+            };
+            let method: u16 = if *deflate { 8 } else { 0 };
+            let offset = out.len() as u32;
+            // Local file header (30 bytes + name).
+            out.extend_from_slice(&0x0403_4b50u32.to_le_bytes());
+            out.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            out.extend_from_slice(&0u16.to_le_bytes()); // flags
+            out.extend_from_slice(&method.to_le_bytes());
+            out.extend_from_slice(&[0u8; 4]); // dos time/date
+            out.extend_from_slice(&[0u8; 4]); // crc32
+            out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            out.extend_from_slice(&(content.len() as u32).to_le_bytes());
+            out.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            out.extend_from_slice(&0u16.to_le_bytes()); // extra len
+            out.extend_from_slice(name.as_bytes());
+            out.extend_from_slice(&payload);
+            // Central directory record (46 bytes + name).
+            central.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+            central.extend_from_slice(&20u16.to_le_bytes()); // version made by
+            central.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            central.extend_from_slice(&0u16.to_le_bytes()); // flags
+            central.extend_from_slice(&method.to_le_bytes());
+            central.extend_from_slice(&[0u8; 4]); // dos time/date
+            central.extend_from_slice(&[0u8; 4]); // crc32
+            central.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            central.extend_from_slice(&(content.len() as u32).to_le_bytes());
+            central.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            // extra len, comment len, disk#, internal attrs, external attrs
+            central.extend_from_slice(&[0u8; 12]);
+            central.extend_from_slice(&offset.to_le_bytes());
+            central.extend_from_slice(name.as_bytes());
+        }
+        let cdir_offset = out.len() as u32;
+        let cdir_size = central.len() as u32;
+        out.extend_from_slice(&central);
+        // End of central directory (22 bytes).
+        out.extend_from_slice(&0x0605_4b50u32.to_le_bytes());
+        out.extend_from_slice(&[0u8; 4]); // disk numbers
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        out.extend_from_slice(&cdir_size.to_le_bytes());
+        out.extend_from_slice(&cdir_offset.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // comment len
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_util::build_zip;
+    use super::*;
+
+    #[test]
+    fn roundtrips_stored_entries() {
+        let zip = build_zip(&[
+            ("manifest.json", b"{}", false),
+            ("a/x.json", b"hello", false),
+        ]);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("manifest.json").unwrap().as_ref(), b"{}");
+        assert_eq!(archive.by_name("a/x.json").unwrap().as_ref(), b"hello");
+        assert!(matches!(
+            archive.by_name("a/x.json").unwrap(),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn roundtrips_deflated_entries() {
+        let payload = b"the quick brown fox jumps over the lazy dog".repeat(50);
+        let zip = build_zip(&[("a/big.json", &payload, true)]);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(
+            archive.by_name("a/big.json").unwrap().as_ref(),
+            &payload[..]
+        );
+    }
+
+    #[test]
+    fn roundtrips_empty_entry() {
+        let zip = build_zip(&[("empty.json", b"", false)]);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("empty.json").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn missing_name_is_not_found() {
+        let zip = build_zip(&[("manifest.json", b"{}", false)]);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(
+            archive.by_name("nope.json").unwrap_err(),
+            ArchiveError::NotFound
+        );
+    }
+
+    #[test]
+    fn reads_real_fixture() {
+        let path = format!(
+            "{}/assets/animations/dotlottie/v1/emojis.lottie",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let bytes = std::fs::read(path).expect("fixture must exist");
+        let archive = Archive::new(bytes).expect("fixture parses");
+        let manifest = archive.by_name("manifest.json").expect("manifest entry");
+        assert!(std::str::from_utf8(&manifest)
+            .unwrap()
+            .contains("animations"));
+    }
+
+    #[test]
+    fn rejects_non_zip_input() {
+        assert_eq!(
+            Archive::new(b"{\"v\":\"5.5\"}".to_vec()).unwrap_err(),
+            ArchiveError::Invalid
+        );
+        assert_eq!(Archive::new(Vec::new()).unwrap_err(), ArchiveError::Invalid);
+    }
+
+    #[test]
+    fn rejects_truncated_archive() {
+        let zip = build_zip(&[("a.json", b"data", false)]);
+        for len in [zip.len() - 1, zip.len() - 10, 5] {
+            assert!(Archive::new(zip[..len].to_vec()).is_err(), "len {len}");
+        }
+    }
+
+    #[test]
+    fn parses_with_trailing_comment() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let comment = b"trailing comment";
+        let n = zip.len();
+        zip[n - 2..].copy_from_slice(&(comment.len() as u16).to_le_bytes());
+        zip.extend_from_slice(comment);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("a.json").unwrap().as_ref(), b"data");
+    }
+
+    #[test]
+    fn rejects_zip64_entry_count_sentinel() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let eocd = zip.len() - 22;
+        zip[eocd + 10..eocd + 12].copy_from_slice(&0xFFFFu16.to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::Unsupported);
+    }
+
+    #[test]
+    fn rejects_unsupported_method() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let cd = zip
+            .windows(4)
+            .position(|w| w == 0x0201_4b50u32.to_le_bytes())
+            .unwrap();
+        zip[cd + 10..cd + 12].copy_from_slice(&12u16.to_le_bytes()); // bzip2
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::Unsupported);
+    }
+
+    #[test]
+    fn skips_directory_and_non_utf8_entries() {
+        let zip = build_zip(&[
+            ("dir/", b"", false),
+            ("\u{fffd}ok.json", b"x", false),
+            ("real.json", b"y", false),
+        ]);
+        // Corrupt the second entry's name to invalid UTF-8 in both headers.
+        let mut zip = zip;
+        let needle = "\u{fffd}".as_bytes().to_vec();
+        while let Some(i) = zip.windows(needle.len()).position(|w| w == needle) {
+            zip[i..i + needle.len()].copy_from_slice(&[0xFF, 0xFE, 0xFD]);
+        }
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("real.json").unwrap().as_ref(), b"y");
+        assert_eq!(archive.by_name("dir/").unwrap_err(), ArchiveError::NotFound);
+    }
+
+    #[test]
+    fn rejects_entry_count_over_cap() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let eocd = zip.len() - 22;
+        zip[eocd + 10..eocd + 12].copy_from_slice(&4097u16.to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::TooLarge);
+    }
+
+    #[test]
+    fn rejects_oversized_declared_entry() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let cd = zip
+            .windows(4)
+            .position(|w| w == 0x0201_4b50u32.to_le_bytes())
+            .unwrap();
+        // uncompressed_size field at CD offset +24.
+        zip[cd + 24..cd + 28].copy_from_slice(&(65 * 1024 * 1024u32).to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::TooLarge);
+    }
+
+    #[test]
+    fn inflate_output_capped_at_declared_size() {
+        let payload = b"A".repeat(10_000);
+        let mut zip = build_zip(&[("a.bin", &payload, true)]);
+        let cd = zip
+            .windows(4)
+            .position(|w| w == 0x0201_4b50u32.to_le_bytes())
+            .unwrap();
+        zip[cd + 24..cd + 28].copy_from_slice(&16u32.to_le_bytes());
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("a.bin").unwrap_err(), ArchiveError::Inflate);
+    }
+
+    #[test]
+    fn rejects_wrapping_local_offset() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let cd = zip
+            .windows(4)
+            .position(|w| w == 0x0201_4b50u32.to_le_bytes())
+            .unwrap();
+        // local_header_offset field at CD offset +42: huge but non-sentinel.
+        zip[cd + 42..cd + 46].copy_from_slice(&0xFFFF_FFF0u32.to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::Invalid);
+    }
+
+    #[test]
+    fn respects_local_header_extra_field() {
+        // Local header carries a 4-byte extra field the central directory omits.
+        let name = b"a.json";
+        let content = b"data";
+        let mut out = Vec::new();
+        out.extend_from_slice(&0x0403_4b50u32.to_le_bytes());
+        out.extend_from_slice(&20u16.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // stored
+        out.extend_from_slice(&[0u8; 8]); // time/date + crc
+        out.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        out.extend_from_slice(&4u16.to_le_bytes()); // local extra len = 4
+        out.extend_from_slice(name);
+        out.extend_from_slice(&[0xAA; 4]); // the extra field
+        out.extend_from_slice(content);
+        let cdir_offset = out.len() as u32;
+        out.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+        out.extend_from_slice(&20u16.to_le_bytes());
+        out.extend_from_slice(&20u16.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes());
+        out.extend_from_slice(&[0u8; 8]);
+        out.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        out.extend_from_slice(&[0u8; 12]); // CD extra len = 0
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(name);
+        let cdir_size = out.len() as u32 - cdir_offset;
+        out.extend_from_slice(&0x0605_4b50u32.to_le_bytes());
+        out.extend_from_slice(&[0u8; 4]);
+        out.extend_from_slice(&1u16.to_le_bytes());
+        out.extend_from_slice(&1u16.to_le_bytes());
+        out.extend_from_slice(&cdir_size.to_le_bytes());
+        out.extend_from_slice(&cdir_offset.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes());
+
+        let archive = Archive::new(out).unwrap();
+        assert_eq!(archive.by_name("a.json").unwrap().as_ref(), b"data");
+    }
+
+    #[test]
+    fn rejects_encrypted_entry() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let cd = zip
+            .windows(4)
+            .position(|w| w == 0x0201_4b50u32.to_le_bytes())
+            .unwrap();
+        // flags field at CD offset +8: set bit 0 (encrypted).
+        zip[cd + 8..cd + 10].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::Unsupported);
+    }
+
+    #[test]
+    fn rejects_multi_disk_archive() {
+        let mut zip = build_zip(&[("a.json", b"data", false)]);
+        let eocd = zip.len() - 22;
+        zip[eocd + 4..eocd + 6].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(Archive::new(zip).unwrap_err(), ArchiveError::Unsupported);
+    }
+
+    #[test]
+    fn duplicate_names_first_wins() {
+        let zip = build_zip(&[("a.json", b"first", false), ("a.json", b"second", false)]);
+        let archive = Archive::new(zip).unwrap();
+        assert_eq!(archive.by_name("a.json").unwrap().as_ref(), b"first");
+    }
+}

--- a/dotlottie-rs/src/dotlottie/mod.rs
+++ b/dotlottie-rs/src/dotlottie/mod.rs
@@ -1,19 +1,22 @@
+mod archive;
 mod errors;
 mod manifest;
 
 pub use errors::*;
 pub use manifest::*;
 
+use archive::{Archive, ArchiveError};
+
 use crate::json::Value;
 #[cfg(feature = "theming")]
 use crate::theme::Theme;
 #[cfg(feature = "audio")]
 use rustc_hash::FxHashMap;
+use std::borrow::Cow;
+#[cfg(feature = "audio")]
 use std::cell::RefCell;
-use std::io::{self, Read};
 #[cfg(feature = "audio")]
 use std::sync::Arc;
-use zip::ZipArchive;
 
 const BASE64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -29,7 +32,7 @@ pub struct DotLottieManager {
     active_animation_id: Box<str>,
     manifest: Manifest,
     version: u8,
-    archive: RefCell<ZipArchive<io::Cursor<Vec<u8>>>>,
+    archive: Archive,
     /// Audio bytes keyed by packaged path (e.g. `u/clip.mp3`).
     #[cfg(feature = "audio")]
     audio_sources: RefCell<FxHashMap<String, Arc<[u8]>>>,
@@ -37,10 +40,9 @@ pub struct DotLottieManager {
 
 impl DotLottieManager {
     pub fn new(dotlottie: &[u8]) -> Result<Self, Error> {
-        let mut archive = ZipArchive::new(io::Cursor::new(dotlottie.to_vec()))
-            .map_err(|_| Error::ArchiveOpenError)?;
+        let archive = Archive::new(dotlottie.to_vec()).map_err(|_| Error::ArchiveOpenError)?;
 
-        let manifest = Self::read_zip_file(&mut archive, "manifest.json")?;
+        let manifest = Self::read_file(&archive, "manifest.json")?;
         let manifest_str = std::str::from_utf8(&manifest).map_err(|_| Error::ReadContentError)?;
         let manifest = Manifest::from_json(manifest_str).ok_or(Error::ReadContentError)?;
 
@@ -63,7 +65,7 @@ impl DotLottieManager {
             active_animation_id: id,
             manifest,
             version,
-            archive: RefCell::new(archive),
+            archive,
             #[cfg(feature = "audio")]
             audio_sources: RefCell::new(FxHashMap::default()),
         })
@@ -75,8 +77,6 @@ impl DotLottieManager {
     }
 
     pub fn get_animation(&self, animation_id: &str) -> Result<String, Error> {
-        let mut archive = self.archive.borrow_mut();
-
         let (json_path, lot_path) = if self.version == 2 {
             (
                 format!("a/{animation_id}.json"),
@@ -89,8 +89,8 @@ impl DotLottieManager {
             )
         };
 
-        let file_data = Self::read_zip_file(&mut archive, &json_path)
-            .or_else(|_| Self::read_zip_file(&mut archive, &lot_path))?;
+        let file_data = Self::read_file(&self.archive, &json_path)
+            .or_else(|_| Self::read_file(&self.archive, &lot_path))?;
 
         let animation_data =
             std::str::from_utf8(&file_data).map_err(|_| Error::ReadContentError)?;
@@ -102,10 +102,10 @@ impl DotLottieManager {
         let mut audio_sources: FxHashMap<String, Arc<[u8]>> = FxHashMap::default();
 
         if let Some(Value::Array(assets)) = lottie_animation.get_mut("assets") {
-            Self::embed_images(&mut archive, assets, self.version);
+            Self::embed_images(&self.archive, assets, self.version);
             #[cfg(feature = "audio")]
             {
-                audio_sources = Self::collect_audio(&mut archive, assets, self.version);
+                audio_sources = Self::collect_audio(&self.archive, assets, self.version);
             }
         }
 
@@ -114,7 +114,7 @@ impl DotLottieManager {
                 .get_mut("fonts")
                 .and_then(|fonts| fonts.get_mut("list"))
             {
-                Self::embed_fonts(&mut archive, font_list);
+                Self::embed_fonts(&self.archive, font_list);
             }
         }
 
@@ -126,11 +126,7 @@ impl DotLottieManager {
         Ok(lottie_animation.to_json())
     }
 
-    fn embed_images<R: Read + io::Seek>(
-        archive: &mut ZipArchive<R>,
-        assets: &mut [Value],
-        version: u8,
-    ) {
+    fn embed_images(archive: &Archive, assets: &mut [Value], version: u8) {
         let image_prefix = if version == 2 { "i/" } else { "images/" };
         let mut asset_path = String::with_capacity(128);
 
@@ -148,21 +144,18 @@ impl DotLottieManager {
             asset_path.push_str(image_prefix);
             asset_path.push_str(p_str.trim_matches('"'));
 
-            if let Ok(mut result) = archive.by_name(&asset_path) {
-                let mut content = Vec::with_capacity(result.size() as usize);
-                if result.read_to_end(&mut content).is_ok() {
-                    let image_ext = p_str
-                        .rfind('.')
-                        .map(|i| &p_str[i + 1..])
-                        .unwrap_or(DEFAULT_EXT);
-                    let data_url = format!(
-                        "{DATA_IMAGE_PREFIX}{image_ext}{BASE64_PREFIX}{}",
-                        Self::encode_base64(&content)
-                    );
-                    asset.set("u", Value::String("".into()));
-                    asset.set("p", Value::String(data_url.into()));
-                    asset.set("e", Value::Number(1.0));
-                }
+            if let Ok(content) = archive.by_name(&asset_path) {
+                let image_ext = p_str
+                    .rfind('.')
+                    .map(|i| &p_str[i + 1..])
+                    .unwrap_or(DEFAULT_EXT);
+                let data_url = format!(
+                    "{DATA_IMAGE_PREFIX}{image_ext}{BASE64_PREFIX}{}",
+                    Self::encode_base64(&content)
+                );
+                asset.set("u", Value::String("".into()));
+                asset.set("p", Value::String(data_url.into()));
+                asset.set("e", Value::Number(1.0));
             }
         }
     }
@@ -171,8 +164,8 @@ impl DotLottieManager {
     /// (e.g. `u/clip.mp3`). Audio is not re-embedded in the JSON since ThorVG
     /// never renders it.
     #[cfg(feature = "audio")]
-    fn collect_audio<R: Read + io::Seek>(
-        archive: &mut ZipArchive<R>,
+    fn collect_audio(
+        archive: &Archive,
         assets: &[Value],
         version: u8,
     ) -> FxHashMap<String, Arc<[u8]>> {
@@ -200,18 +193,15 @@ impl DotLottieManager {
             asset_path.push_str(audio_prefix);
             asset_path.push_str(p_str);
 
-            if let Ok(mut result) = archive.by_name(&asset_path) {
-                let mut content = Vec::with_capacity(result.size() as usize);
-                if result.read_to_end(&mut content).is_ok() {
-                    out.insert(asset_path.clone(), Arc::from(content));
-                }
+            if let Ok(content) = archive.by_name(&asset_path) {
+                out.insert(asset_path.clone(), Arc::from(content.into_owned()));
             }
         }
 
         out
     }
 
-    fn embed_fonts<R: Read + io::Seek>(archive: &mut ZipArchive<R>, font_list: &mut [Value]) {
+    fn embed_fonts(archive: &Archive, font_list: &mut [Value]) {
         let mut font_path = String::with_capacity(128);
 
         for font in font_list.iter_mut() {
@@ -227,19 +217,16 @@ impl DotLottieManager {
             font_path.push_str("f/");
             font_path.push_str(path_without_prefix);
 
-            if let Ok(mut result) = archive.by_name(&font_path) {
-                let mut content = Vec::with_capacity(result.size() as usize);
-                if result.read_to_end(&mut content).is_ok() {
-                    let font_ext = path_without_prefix
-                        .rfind('.')
-                        .map(|i| &path_without_prefix[i + 1..])
-                        .unwrap_or(DEFAULT_FONT_EXT);
-                    let data_url = format!(
-                        "{DATA_FONT_PREFIX}{font_ext}{BASE64_PREFIX}{}",
-                        Self::encode_base64(&content)
-                    );
-                    font.set("fPath", Value::String(data_url.into()));
-                }
+            if let Ok(content) = archive.by_name(&font_path) {
+                let font_ext = path_without_prefix
+                    .rfind('.')
+                    .map(|i| &path_without_prefix[i + 1..])
+                    .unwrap_or(DEFAULT_FONT_EXT);
+                let data_url = format!(
+                    "{DATA_FONT_PREFIX}{font_ext}{BASE64_PREFIX}{}",
+                    Self::encode_base64(&content)
+                );
+                font.set("fPath", Value::String(data_url.into()));
             }
         }
     }
@@ -247,10 +234,9 @@ impl DotLottieManager {
     #[inline]
     #[cfg(feature = "state-machines")]
     pub fn get_state_machine(&self, state_machine_id: &str) -> Result<String, Error> {
-        let mut archive = self.archive.borrow_mut();
         let path = format!("s/{state_machine_id}.json");
-        let content = Self::read_zip_file(&mut archive, &path)?;
-        String::from_utf8(content).map_err(|_| Error::InvalidUtf8Error)
+        let content = Self::read_file(&self.archive, &path)?;
+        String::from_utf8(content.into_owned()).map_err(|_| Error::InvalidUtf8Error)
     }
 
     #[inline]
@@ -272,11 +258,7 @@ impl DotLottieManager {
         }
 
         let prefix = if self.version == 2 { "i/" } else { "images/" };
-        let mut archive = self.archive.borrow_mut();
-        let mut entry = archive.by_name(&format!("{prefix}{name}")).ok()?;
-
-        let mut content = Vec::with_capacity(entry.size() as usize);
-        entry.read_to_end(&mut content).ok()?;
+        let content = self.archive.by_name(&format!("{prefix}{name}")).ok()?;
 
         let ext = name
             .rfind('.')
@@ -292,9 +274,8 @@ impl DotLottieManager {
     #[inline]
     #[cfg(feature = "theming")]
     pub fn get_theme(&self, theme_id: &str) -> Result<Theme, Error> {
-        let mut archive = self.archive.borrow_mut();
         let path = format!("t/{theme_id}.json");
-        let content = Self::read_zip_file(&mut archive, &path)?;
+        let content = Self::read_file(&self.archive, &path)?;
         let theme_str = std::str::from_utf8(&content).map_err(|_| Error::InvalidUtf8Error)?;
         theme_str
             .parse::<Theme>()
@@ -344,17 +325,11 @@ impl DotLottieManager {
     }
 
     #[inline]
-    fn read_zip_file<R: Read + io::Seek>(
-        archive: &mut ZipArchive<R>,
-        path: &str,
-    ) -> Result<Vec<u8>, Error> {
-        let mut file = archive.by_name(path).map_err(|_| Error::FileFindError)?;
-
-        let mut buf = Vec::with_capacity(file.size() as usize);
-        file.read_to_end(&mut buf)
-            .map_err(|_| Error::ReadContentError)?;
-
-        Ok(buf)
+    fn read_file<'a>(archive: &'a Archive, path: &str) -> Result<Cow<'a, [u8]>, Error> {
+        archive.by_name(path).map_err(|e| match e {
+            ArchiveError::NotFound => Error::FileFindError,
+            _ => Error::ReadContentError,
+        })
     }
 
     #[cfg(feature = "audio")]
@@ -377,18 +352,22 @@ mod tests {
             "/assets/animations/dotlottie/v1/emojis.lottie"
         );
 
-        if let Ok(mut file) = File::open(&file_path) {
-            let mut buffer = Vec::new();
-            if file.read_to_end(&mut buffer).is_ok() {
-                let manager = DotLottieManager::new(&buffer);
-                assert!(manager.is_ok());
+        let mut buffer = Vec::new();
+        File::open(&file_path)
+            .expect("fixture must exist")
+            .read_to_end(&mut buffer)
+            .expect("fixture must be readable");
 
-                if let Ok(mgr) = manager {
-                    assert!(!mgr.active_animation_id().is_empty());
-                    assert!(!mgr.manifest().animations.is_empty());
-                }
-            }
-        }
+        let manager = DotLottieManager::new(&buffer).expect("manager creation");
+        assert!(!manager.active_animation_id().is_empty());
+        assert!(!manager.manifest().animations.is_empty());
+    }
+
+    #[test]
+    #[cfg(not(feature = "audio"))]
+    fn manager_is_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DotLottieManager>();
     }
 
     #[test]


### PR DESCRIPTION
| | main | this PR | delta |
|---|---|---|---|
| wasm size (raw) | 1,283,934 B | 1,213,421 B | **−70,513 B (−5.5%)** |
| wasm size (gzip -9) | 530,492 B | 489,194 B | **−41,298 B (−7.8%)** |
| container open, 1.37 MB `.lottie` | 48.7 µs | 43.9 µs | **−10%** |
| container open, audio `.lottie` | 6.2 µs | 4.2 µs | **−33%** |
| full entry extraction, all 16 fixtures | 28.2 ms | 26.5 ms | **−6%** |