### PR TITLE
chore: expose color space option in wasm setup_sw_target

### DIFF
--- a/dotlottie-rs/build.rs
+++ b/dotlottie-rs/build.rs
@@ -199,7 +199,7 @@ mod thorvg {
         files
     }
 
-    /// Track ThorVG changes                                                
+    /// Track ThorVG changes
     fn emit_rerun_directives(dirs: &[&str], extensions: &[&str]) {
         for dir in dirs {
             println!("cargo:rerun-if-changed={dir}");
@@ -556,6 +556,11 @@ namespace tvg
 
         // --- cc::Build setup ---
         let mut cc_build = cc::Build::new();
+
+        // Compile out assert() in optimized builds (matches meson -Db_ndebug=true).
+        if env::var("OPT_LEVEL").as_deref() != Ok("0") {
+            cc_build.define("NDEBUG", None);
+        }
         // Only override compiler when CXX is explicitly set or for non-MSVC targets.
         // For MSVC targets, let cc crate auto-detect cl.exe.
         if let Some(ref comp) = compiler {

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -6,7 +6,7 @@ use js_sys::{Array, Float32Array, Object};
 use wasm_bindgen::prelude::*;
 
 #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
-use crate::ColorSpace;
+use crate::ColorSpace as CoreColorSpace;
 use crate::{Fit, Layout, Mode as PlayerMode, Player, Rgba, Segment};
 
 // ─── Renderer mode ───────────────────────────────────────────────────────────
@@ -105,6 +105,27 @@ impl crate::WgpuTarget for WgpuSurfacePtr {
 }
 
 // ─── Exported enums ───────────────────────────────────────────────────────────
+
+/// Pixel format of the software render target; `S` variants are straight alpha.
+#[wasm_bindgen]
+#[derive(Clone, Copy, PartialEq)]
+pub enum ColorSpace {
+    ABGR8888 = 0,
+    ABGR8888S = 1,
+    ARGB8888 = 2,
+    ARGB8888S = 3,
+}
+
+impl From<ColorSpace> for CoreColorSpace {
+    fn from(cs: ColorSpace) -> Self {
+        match cs {
+            ColorSpace::ABGR8888 => CoreColorSpace::ABGR8888,
+            ColorSpace::ABGR8888S => CoreColorSpace::ABGR8888S,
+            ColorSpace::ARGB8888 => CoreColorSpace::ARGB8888,
+            ColorSpace::ARGB8888S => CoreColorSpace::ARGB8888S,
+        }
+    }
+}
 
 /// Playback direction / bounce mode.
 #[wasm_bindgen]
@@ -365,16 +386,24 @@ impl DotLottiePlayerWasm {
     }
 
     /// Set up (or resize) the software rendering target.
+    ///
+    /// `color_space` defaults to `ColorSpace::ABGR8888S`.
     #[cfg(not(any(feature = "webgl", feature = "webgpu")))]
-    pub fn setup_sw_target(&mut self, width: u32, height: u32) -> bool {
+    pub fn setup_sw_target(
+        &mut self,
+        width: u32,
+        height: u32,
+        color_space: Option<ColorSpace>,
+    ) -> bool {
         self.width = width;
         self.height = height;
         let required = (width * height) as usize;
         if self.sw_buffer.len() != required {
             self.sw_buffer.resize(required, 0);
         }
+        let cs = color_space.unwrap_or(ColorSpace::ABGR8888S);
         self.player
-            .set_sw_target(&mut self.sw_buffer, width, height, ColorSpace::ABGR8888S)
+            .set_sw_target(&mut self.sw_buffer, width, height, cs.into())
             .is_ok()
     }
 

--- a/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
+++ b/dotlottie-rs/src/wasm/wasm_bindgen_api.rs
@@ -107,6 +107,7 @@ impl crate::WgpuTarget for WgpuSurfacePtr {
 // ─── Exported enums ───────────────────────────────────────────────────────────
 
 /// Pixel format of the software render target; `S` variants are straight alpha.
+#[cfg(not(any(feature = "webgl", feature = "webgpu")))]
 #[wasm_bindgen]
 #[derive(Clone, Copy, PartialEq)]
 pub enum ColorSpace {
@@ -116,6 +117,7 @@ pub enum ColorSpace {
     ARGB8888S = 3,
 }
 
+#[cfg(not(any(feature = "webgl", feature = "webgpu")))]
 impl From<ColorSpace> for CoreColorSpace {
     fn from(cs: ColorSpace) -> Self {
         match cs {

--- a/web-example.html
+++ b/web-example.html
@@ -361,6 +361,7 @@
 
       let player         = null;
       let Status = null;
+      let ColorSpace = null; // sw-only enum exported by the wasm module
       let raf            = null;
       let activeRenderer = 'sw';
       let scrubbing      = false;  
@@ -506,6 +507,7 @@
             await mod.default({ module_or_path: "./release/wasm/dotlottie_rs_bg.wasm" });
             newPlayer = new mod.DotLottiePlayerWasm();
             Status = mod.Status;
+            ColorSpace = mod.ColorSpace;
             // Grab the 2D context after the canvas is fresh.
             ctx2d = canvas.getContext('2d');
 
@@ -542,7 +544,10 @@
             newPlayer.set_webgpu_surface(gpuCtx);
           }
 
-          const setupOk = rendererType === 'sw'    ? newPlayer.setup_sw_target(W, H)
+          // ABGR8888S = straight alpha, the layout putImageData expects.
+          // Use ColorSpace.ABGR8888 (premultiplied) when blitting via a
+          // GPU texture instead — it skips the per-frame unpremultiply pass.
+          const setupOk = rendererType === 'sw'    ? newPlayer.setup_sw_target(W, H, ColorSpace.ABGR8888S)
                         : rendererType === 'webgl' ? newPlayer.setup_gl_target(W, H)
                         :                            newPlayer.setup_wg_target(W, H);
           if (!setupOk) {
@@ -657,7 +662,7 @@
           canvas.style.width  = cssW + 'px';
           canvas.style.height = cssH + 'px';
 
-          if (activeRenderer === 'sw')         player.setup_sw_target(pixW, pixH);
+          if (activeRenderer === 'sw')         player.setup_sw_target(pixW, pixH, ColorSpace.ABGR8888S);
           else if (activeRenderer === 'webgl') player.setup_gl_target(pixW, pixH);
           else                                 player.setup_wg_target(pixW, pixH);
 


### PR DESCRIPTION
- `setup_sw_target` now takes an optional `ColorSpace` (defaults to `ABGR8888S`, unchanged behavior). Passing `ABGR8888` gives a premultiplied buffer and skips the per-frame unpremultiply pass.
- Define `NDEBUG` for optimized native builds, matching meson's `-Db_ndebug=true`, so ThorVG/JerryScript `assert()`s compile out.